### PR TITLE
feat: PTY terminal relay via posix-pty

### DIFF
--- a/agent-daemon.cabal
+++ b/agent-daemon.cabal
@@ -36,8 +36,10 @@ library
   build-depends:
     , aeson                >= 2.1   && < 2.3
     , base                 >= 4.18  && < 5
+    , bytestring           >= 0.11  && < 0.13
     , containers           >= 0.6   && < 0.8
     , http-types           >= 0.12  && < 0.13
+    , posix-pty            >= 0.2   && < 0.3
     , process              >= 1.6   && < 1.7
     , stm                  >= 2.5   && < 2.6
     , text                 >= 2.0   && < 2.2

--- a/src/AgentDaemon/Terminal.hs
+++ b/src/AgentDaemon/Terminal.hs
@@ -1,37 +1,117 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module AgentDaemon.Terminal
     ( terminalApp
     ) where
 
 {- |
 Module      : AgentDaemon.Terminal
-Description : WebSocket handler for xterm.js
+Description : WebSocket to PTY terminal bridge
 Copyright   : (c) Paolo Veronelli, 2026
 License     : MIT
 
 Bridges WebSocket connections from xterm.js to tmux
-session PTYs. Each connection attaches to a running
-tmux session and relays terminal I\/O bidirectionally.
+sessions via pseudo-terminals. Each connection spawns
+a PTY running @tmux attach@ and relays I\/O
+bidirectionally.
 -}
 
+import Control.Concurrent
+    ( forkIO
+    , killThread
+    )
+import Control.Exception (SomeException, catch)
+import Data.ByteString qualified as BS
 import Data.Text (Text)
 import Data.Text qualified as T
 import Network.WebSockets qualified as WS
+import System.Posix.Pty
+    ( Pty
+    , readPty
+    , resizePty
+    , spawnWithPty
+    , writePty
+    )
 
--- | WebSocket application that attaches to a tmux session.
---
--- Currently a stub that echoes input back. Will be replaced
--- with PTY attachment to the tmux session.
+-- | WebSocket application that attaches to a tmux
+-- session via a pseudo-terminal.
 terminalApp
     :: Text
     -- ^ tmux session name
     -> WS.ServerApp
-terminalApp _sessionName pending = do
+terminalApp sessionName pending = do
     conn <- WS.acceptRequest pending
-    WS.withPingThread conn 30 (pure ()) $ echoLoop conn
+    (pty, _pid) <-
+        spawnWithPty
+            Nothing
+            True
+            "tmux"
+            ["attach", "-t", T.unpack sessionName]
+            (80, 24)
+    WS.withPingThread conn 30 (pure ()) $ do
+        readerId <- forkIO $ ptyToWs pty conn
+        wsTopty pty conn
+            `catch` \(_ :: SomeException) -> pure ()
+        killThread readerId
 
--- | Echo loop placeholder for terminal relay.
-echoLoop :: WS.Connection -> IO ()
-echoLoop conn = do
-    msg <- WS.receiveData conn
-    WS.sendTextData conn (msg :: T.Text)
-    echoLoop conn
+-- | Forward PTY output to WebSocket.
+ptyToWs :: Pty -> WS.Connection -> IO ()
+ptyToWs pty conn = go
+  where
+    go = do
+        bytes <-
+            readPty pty
+                `catch` \(_ :: SomeException) ->
+                    pure BS.empty
+        if BS.null bytes
+            then
+                WS.sendClose
+                    conn
+                    ("PTY closed" :: Text)
+            else do
+                WS.sendBinaryData conn bytes
+                go
+
+-- | Forward WebSocket input to PTY.
+wsTopty :: Pty -> WS.Connection -> IO ()
+wsTopty pty conn = go
+  where
+    go = do
+        msg <- WS.receiveData conn
+        case parseResize msg of
+            Just (cols, rows) -> do
+                resizePty pty (cols, rows)
+                go
+            Nothing -> do
+                writePty pty msg
+                go
+
+-- | Parse a resize message from xterm.js.
+--
+-- Expected format: @\\x01COLS;ROWS@ (binary prefix
+-- byte 0x01 followed by ASCII dimensions separated
+-- by semicolon). Returns @Nothing@ for regular
+-- terminal input.
+parseResize
+    :: BS.ByteString -> Maybe (Int, Int)
+parseResize bs = do
+    (prefix, rest) <- BS.uncons bs
+    if prefix /= 1
+        then Nothing
+        else case BS.split 0x3b rest of
+            [colsBS, rowsBS] -> do
+                cols <- readDecimal colsBS
+                rows <- readDecimal rowsBS
+                Just (cols, rows)
+            _ -> Nothing
+
+-- | Parse an ASCII decimal number from a ByteString.
+readDecimal :: BS.ByteString -> Maybe Int
+readDecimal b
+    | BS.null b = Nothing
+    | BS.all isDigit b =
+        Just $ BS.foldl' step 0 b
+    | otherwise = Nothing
+  where
+    isDigit w = w >= 0x30 && w <= 0x39
+    step acc w = acc * 10 + fromIntegral (w - 0x30)


### PR DESCRIPTION
Closes #4

Replaces the echo stub in Terminal.hs with a real PTY bridge:
- Spawns `tmux attach -t <session>` in a pseudo-terminal
- Bidirectional I/O: PTY output → WebSocket, WebSocket input → PTY
- Terminal resize support (xterm.js resize protocol)
- Clean shutdown on WebSocket disconnect