### PR TITLE
feat: CORS support and GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'static/**'
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: static
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/AgentDaemon/Api.hs
+++ b/src/AgentDaemon/Api.hs
@@ -39,12 +39,15 @@ import Network.HTTP.Types
     ( ResponseHeaders
     , status200
     , status201
+    , status204
     , status400
     , status404
     , status500
     )
 import Network.Wai
     ( Application
+    , Middleware
+    , mapResponseHeaders
     , pathInfo
     , requestMethod
     , responseFile
@@ -60,26 +63,30 @@ apiApp
     -- ^ static files directory
     -> SessionManager
     -> Application
-apiApp baseDir staticDir mgr req respond =
-    case (requestMethod req, pathInfo req) of
-        ("POST", ["sessions"]) ->
-            handleLaunch baseDir mgr req respond
-        ("GET", ["sessions"]) ->
-            handleList mgr req respond
-        ("DELETE", ["sessions", sid]) ->
-            handleStop
-                baseDir
-                mgr
-                (SessionId sid)
-                req
-                respond
-        _ ->
-            respond $
-                responseFile
-                    status200
-                    [("Content-Type", "text/html")]
-                    (staticDir <> "/index.html")
-                    Nothing
+apiApp baseDir staticDir mgr =
+    cors $ \req respond ->
+        case (requestMethod req, pathInfo req) of
+            ("OPTIONS", _) ->
+                respond $
+                    responseLBS status204 [] ""
+            ("POST", ["sessions"]) ->
+                handleLaunch baseDir mgr req respond
+            ("GET", ["sessions"]) ->
+                handleList mgr req respond
+            ("DELETE", ["sessions", sid]) ->
+                handleStop
+                    baseDir
+                    mgr
+                    (SessionId sid)
+                    req
+                    respond
+            _ ->
+                respond $
+                    responseFile
+                        status200
+                        [("Content-Type", "text/html")]
+                        (staticDir <> "/index.html")
+                        Nothing
 
 -- | Build the main repo path from base dir and repo.
 repoPath :: FilePath -> Repo -> FilePath
@@ -300,3 +307,26 @@ claudePrompt Repo{repoOwner, repoName} issue =
         <> "/"
         <> repoName
         <> "'"
+
+{- | CORS middleware — adds permissive CORS headers to
+all responses.
+-}
+cors :: Middleware
+cors app req respond =
+    app req $ \response ->
+        respond $
+            mapResponseHeaders (++ corsHeaders) response
+
+-- | CORS headers allowing any origin.
+corsHeaders :: ResponseHeaders
+corsHeaders =
+    [ ("Access-Control-Allow-Origin", "*")
+    ,
+        ( "Access-Control-Allow-Methods"
+        , "GET, POST, DELETE, OPTIONS"
+        )
+    ,
+        ( "Access-Control-Allow-Headers"
+        , "Content-Type"
+        )
+    ]

--- a/static/index.html
+++ b/static/index.html
@@ -72,6 +72,7 @@
   <header>
     <h1>agent-daemon</h1>
     <div class="controls">
+      <input id="server" type="text" placeholder="server (empty = local)" size="25" onchange="saveServer()">
       <input id="owner" type="text" placeholder="owner" size="15">
       <input id="repo" type="text" placeholder="repo" size="20">
       <input id="issue" type="number" placeholder="#" size="5">
@@ -108,14 +109,32 @@
     let ws = null;
     const status = document.getElementById('status');
     const sessionSelect = document.getElementById('session-select');
+    const serverInput = document.getElementById('server');
+
+    // Restore saved server address
+    const saved = localStorage.getItem('agent-daemon-server');
+    if (saved) serverInput.value = saved;
+
+    function saveServer() {
+      const v = serverInput.value.trim();
+      if (v) localStorage.setItem('agent-daemon-server', v);
+      else localStorage.removeItem('agent-daemon-server');
+    }
 
     function apiBase() {
-      return window.location.origin;
+      const s = serverInput.value.trim();
+      if (!s) return window.location.origin;
+      return (s.startsWith('http') ? s : 'http://' + s).replace(/\/$/, '');
     }
 
     function wsBase() {
-      const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      return proto + '//' + window.location.host;
+      const s = serverInput.value.trim();
+      if (!s) {
+        const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        return proto + '//' + window.location.host;
+      }
+      const host = s.replace(/^https?:\/\//, '');
+      return 'ws://' + host;
     }
 
     async function launch() {


### PR DESCRIPTION
## Summary
- Add CORS middleware (permissive `*` origin) for cross-origin browser access
- Add server address input with localStorage persistence in the browser client
- Add GitHub Pages deployment workflow for `static/` directory

Closes #8