### PR TITLE
fix: launch claude with --dangerously-skip-permissions

### DIFF
--- a/src/AgentDaemon/Api.hs
+++ b/src/AgentDaemon/Api.hs
@@ -196,7 +196,7 @@ handleLaunch baseDir mgr req respond = do
                         Right () ->
                             Tmux.sendKeys
                                 tmuxName'
-                                ( "claude "
+                                ( "claude --dangerously-skip-permissions "
                                     <> claudePrompt
                                         repo
                                         issue


### PR DESCRIPTION
## Summary

- Headless agent sessions need `--dangerously-skip-permissions` since there is no user to approve tool calls interactively

Closes #8