### PR TITLE
ci(release): mint homebrew-tap token from the org App

### DIFF
--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -63,9 +63,18 @@ jobs:
             --notes "aarch64-darwin release" \
             "$TARBALL"
 
+      - name: Mint a scoped tap token
+        id: tap-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: lambdasistemi
+          repositories: homebrew-tap
+
       - name: Update homebrew tap
         env:
-          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+          TAP_TOKEN: ${{ steps.tap-token.outputs.token }}
         run: |
           VERSION=$(cat /tmp/version.txt)
           TAG="v${VERSION}"


### PR DESCRIPTION
Replaces the `TAP_TOKEN` PAT with a per-run token minted by the org `lambdasistemi-ci` App (`vars.CI_APP_ID` + org `secrets.CI_APP_PRIVATE_KEY`), scoped to `homebrew-tap`. Same pattern proven live on cardano-mpfs-offchain v0.2.1. Part of the org-wide PAT→App migration.