### PR TITLE
fix: use relative public app assets

### DIFF
--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>agent-daemon</title>
-  <link rel="icon" href="/favicon.svg?v=20260709-touch-selection" type="image/svg+xml">
-  <link rel="stylesheet" href="/xterm.css?v=20260709-touch-selection">
-  <link rel="stylesheet" href="/index.css?v=20260709-touch-selection">
+  <link rel="icon" href="favicon.svg?v=20260709-touch-selection" type="image/svg+xml">
+  <link rel="stylesheet" href="xterm.css?v=20260709-touch-selection">
+  <link rel="stylesheet" href="index.css?v=20260709-touch-selection">
 </head>
 <body>
-  <script src="/index.js?v=20260709-touch-selection"></script>
+  <script src="index.js?v=20260709-touch-selection"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary\n- switch the static UI shell from root-relative asset URLs to relative asset URLs\n- make the GitHub Pages project site work under /agent-daemon/\n\n## Verification\n- git diff --check\n- nix build .#site --out-link /tmp/agent-daemon-site-public-fix --quiet\n- served the built site under /agent-daemon/ locally and verified index.js, index.css, xterm.css, and favicon.svg return 200