### PR TITLE
fix: complete public app and CORS cleanup

### DIFF
--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -80,9 +80,9 @@ jobs:
           TAG="v${VERSION}"
           TARBALL="/tmp/agent-daemon-${VERSION}-aarch64-darwin.tar.gz"
           SHA=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
-          URL="https://github.com/lambdasistemi/agent-daemon/releases/download/${TAG}/agent-daemon-${VERSION}-aarch64-darwin.tar.gz"
+          URL="https://github.com/lambdasistemi/tmux-ws/releases/download/${TAG}/agent-daemon-${VERSION}-aarch64-darwin.tar.gz"
 
-          printf 'class AgentDaemon < Formula\n  desc "WebSocket daemon for managing Claude Code agent sessions"\n  homepage "https://github.com/lambdasistemi/agent-daemon"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/agent-daemon"\n    (libexec/"lib").install Dir["lib/*"]\n  end\nend\n' "$URL" "$SHA" "$VERSION" > /tmp/agent-daemon.rb
+          printf 'class AgentDaemon < Formula\n  desc "WebSocket daemon for managing tmux workspaces"\n  homepage "https://github.com/lambdasistemi/tmux-ws"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/agent-daemon"\n    (libexec/"lib").install Dir["lib/*"]\n  end\nend\n' "$URL" "$SHA" "$VERSION" > /tmp/agent-daemon.rb
 
           git clone https://x-access-token:${TAP_TOKEN}@github.com/lambdasistemi/homebrew-tap.git /tmp/tap
           mkdir -p /tmp/tap/Formula

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# agent-daemon
+# tmux-ws
 
-[![CI](https://github.com/lambdasistemi/agent-daemon/actions/workflows/ci.yml/badge.svg)](https://github.com/lambdasistemi/agent-daemon/actions/workflows/ci.yml)
+[![CI](https://github.com/lambdasistemi/tmux-ws/actions/workflows/ci.yml/badge.svg)](https://github.com/lambdasistemi/tmux-ws/actions/workflows/ci.yml)
 
 WebSocket daemon for managing local tmux sessions from a browser.
 
 ## Documentation
 
-See the [full documentation](https://lambdasistemi.github.io/agent-daemon/docs/).
+See the [full documentation](https://lambdasistemi.github.io/tmux-ws/docs/).
 
 ## Quick start
 

--- a/agent-daemon.cabal
+++ b/agent-daemon.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            agent-daemon
-version:         0.1.0
+version:         0.1.1
 synopsis:        WebSocket daemon for managing Claude Code agent sessions
 description:
   A Haskell WebSocket server that manages Claude Code agent
@@ -14,8 +14,8 @@ maintainer:      paolo.veronelli@gmail.com
 copyright:       (c) 2026 Paolo Veronelli
 category:        Development
 build-type:      Simple
-homepage:        https://github.com/lambdasistemi/agent-daemon
-bug-reports:     https://github.com/lambdasistemi/agent-daemon/issues
+homepage:        https://github.com/lambdasistemi/tmux-ws
+bug-reports:     https://github.com/lambdasistemi/tmux-ws/issues
 extra-doc-files: README.md
 
 library

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,7 +7,7 @@ The flake exposes a NixOS module:
 ```nix
 # flake.nix
 {
-  inputs.agent-daemon.url = "github:lambdasistemi/agent-daemon";
+  inputs.agent-daemon.url = "github:lambdasistemi/tmux-ws";
 
   outputs = { nixpkgs, agent-daemon, ... }: {
     nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,6 @@ permission to clone/fetch the repositories it will manage.
 ## Browser client
 
 A web-based terminal client is available at
-[lambdasistemi.github.io/agent-daemon](https://lambdasistemi.github.io/agent-daemon/)
+[lambdasistemi.github.io/tmux-ws](https://lambdasistemi.github.io/tmux-ws/)
 
 Enter your daemon's address in the server field to connect remotely (e.g. via Tailscale).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: Agent Daemon
-site_url: https://lambdasistemi.github.io/agent-daemon/docs
-repo_url: https://github.com/lambdasistemi/agent-daemon
-repo_name: lambdasistemi/agent-daemon
+site_name: tmux-ws
+site_url: https://lambdasistemi.github.io/tmux-ws/docs
+repo_url: https://github.com/lambdasistemi/tmux-ws
+repo_name: lambdasistemi/tmux-ws
 
 theme:
   name: material

--- a/src/AgentDaemon/Api.hs
+++ b/src/AgentDaemon/Api.hs
@@ -49,6 +49,7 @@ import Network.HTTP.Types
     ( ResponseHeaders
     , methodGet
     , methodHead
+    , methodOptions
     , status200
     , status404
     )
@@ -617,13 +618,15 @@ noCacheHeaders =
     ]
 
 {- | CORS middleware — adds permissive CORS headers to
-all responses.
+all responses and answers browser preflight requests.
 -}
 cors :: Middleware
 cors app req respond =
-    app req $ \response ->
-        respond $
-            mapResponseHeaders (++ corsHeaders) response
+    if requestMethod req == methodOptions
+        then respond $ responseLBS status200 corsHeaders ""
+        else app req $ \response ->
+            respond $
+                mapResponseHeaders (++ corsHeaders) response
 
 -- | CORS headers allowing any origin.
 corsHeaders :: ResponseHeaders

--- a/test/AgentDaemon/ApiSpec.hs
+++ b/test/AgentDaemon/ApiSpec.hs
@@ -42,9 +42,15 @@ import Data.Text qualified as T
 import Data.Time (getCurrentTime)
 import Network.HTTP.Client
     ( defaultManagerSettings
+    , httpLbs
+    , method
     , newManager
+    , parseRequest
+    , requestHeaders
+    , responseHeaders
+    , responseStatus
     )
-import Network.HTTP.Types (status400, status404)
+import Network.HTTP.Types (status200, status400, status404)
 import Network.Wai.Handler.Warp qualified as Warp
 import Servant.API
     ( Capture
@@ -264,6 +270,49 @@ spec = describe "REST API" $ do
                         fail $
                             "Expected 404, got: "
                                 <> show other
+
+        it "OPTIONS /sessions/:sid/windows answers CORS preflight" $
+            \port -> do
+                manager <- newManager defaultManagerSettings
+                request <-
+                    parseRequest $
+                        "http://127.0.0.1:"
+                            <> show port
+                            <> "/sessions/demo/windows"
+                response <-
+                    httpLbs
+                        request
+                            { method = "OPTIONS"
+                            , requestHeaders =
+                                [
+                                    ( "Origin"
+                                    , "https://lambdasistemi.github.io"
+                                    )
+                                ,
+                                    ( "Access-Control-Request-Method"
+                                    , "POST"
+                                    )
+                                ,
+                                    ( "Access-Control-Request-Headers"
+                                    , "content-type"
+                                    )
+                                ]
+                            }
+                        manager
+
+                responseStatus response `shouldBe` status200
+                lookup
+                    "Access-Control-Allow-Origin"
+                    (responseHeaders response)
+                    `shouldBe` Just "*"
+                lookup
+                    "Access-Control-Allow-Methods"
+                    (responseHeaders response)
+                    `shouldBe` Just "GET, POST, DELETE, OPTIONS"
+                lookup
+                    "Access-Control-Allow-Headers"
+                    (responseHeaders response)
+                    `shouldBe` Just "Content-Type"
 
     around (\action -> withPaneTestServer action) $ do
         it "DELETE /sessions/:sid requires exact confirmation" $

--- a/ui/dist/index.css
+++ b/ui/dist/index.css
@@ -3,7 +3,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/jetbrains-mono-latin-400-normal.woff2") format("woff2");
+  src: url("fonts/jetbrains-mono-latin-400-normal.woff2") format("woff2");
 }
 
 @font-face {
@@ -11,7 +11,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/noto-sans-symbols-2-symbols-400-normal.woff2") format("woff2");
+  src: url("fonts/noto-sans-symbols-2-symbols-400-normal.woff2") format("woff2");
 }
 
 :root {

--- a/ui/dist/index.css
+++ b/ui/dist/index.css
@@ -318,15 +318,37 @@ button,
   gap: 7px;
 }
 
-button svg {
-  width: 16px;
-  height: 16px;
-  flex: 0 0 auto;
+.icon-button,
+.icon-link {
+  width: 34px;
+  min-width: 34px;
 }
 
 .icon-button {
-  width: 34px;
   padding: 0;
+}
+
+.icon-link {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--button-border);
+  border-radius: 4px;
+  background: var(--button-bg);
+  color: var(--text-strong);
+  text-decoration: none;
+}
+
+.icon-link:hover {
+  background: var(--button-hover);
+}
+
+button svg,
+.icon-link svg {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
 }
 
 .setting-button {

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>agent-daemon</title>
+  <title>tmux-ws</title>
   <link rel="icon" href="favicon.svg?v=20260709-touch-selection" type="image/svg+xml">
   <link rel="stylesheet" href="xterm.css?v=20260709-touch-selection">
   <link rel="stylesheet" href="index.css?v=20260709-touch-selection">

--- a/ui/src/Main.purs
+++ b/ui/src/Main.purs
@@ -152,13 +152,15 @@ render state =
 renderHeader :: State -> H.ComponentHTML Action Slots Aff
 renderHeader state =
   HH.header_
-    [ HH.h1_ [ HH.text "agent-daemon" ]
+    [ HH.h1_ [ HH.text "tmux-ws" ]
     , HH.span
         [ HP.id "status" ]
         [ HH.text state.status ]
     , HH.div
         [ cls "top-actions" ]
-        [ iconOnlyButton "Refresh sessions" "refresh-cw" RefreshSessions Nothing
+        [ iconLink "Repository" "github" "https://github.com/lambdasistemi/tmux-ws"
+        , iconLink "Documentation" "book-open" "https://lambdasistemi.github.io/tmux-ws/docs/"
+        , iconOnlyButton "Refresh sessions" "refresh-cw" RefreshSessions Nothing
         , renderSessionSwitcher state
         , renderWindowSwitcher state
         , renderTerminalActions state
@@ -1509,6 +1511,18 @@ iconTextButton className label iconName action =
         [ cls "button-label" ]
         [ HH.text label ]
     ]
+
+iconLink :: String -> String -> String -> H.ComponentHTML Action Slots Aff
+iconLink label iconName href =
+  HH.a
+    [ cls "icon-link"
+    , HP.title label
+    , HP.attr (HH.AttrName "aria-label") label
+    , HP.attr (HH.AttrName "href") href
+    , HP.attr (HH.AttrName "target") "_blank"
+    , HP.attr (HH.AttrName "rel") "noopener noreferrer"
+    ]
+    [ icon iconName ]
 
 icon :: String -> H.ComponentHTML Action Slots Aff
 icon name =


### PR DESCRIPTION
## Summary\n- use relative public asset/font paths for GitHub Pages project hosting\n- rename visible public UI branding to tmux-ws and add repo/docs links\n- answer browser CORS preflight requests for POST endpoints like tmux window switching\n- bump the daemon package version to 0.1.1 for a fresh release\n- update repository/docs/release links for the tmux-ws repo rename\n\n## Verification\n- red: cabal test e2e-tests -O0 --test-options '--match "OPTIONS /sessions/:sid/windows answers CORS preflight"' failed with 404 before the fix\n- nix develop -c just CI\n- nix develop -c cabal test e2e-tests -O0\n- git diff --check\n- nix build .#default --out-link /tmp/agent-daemon-default-fix --quiet\n- nix build .#site --out-link /tmp/agent-daemon-site-final --quiet\n- curl OPTIONS against the built daemon returned 200 with Access-Control-Allow-* headers\n- checked the built Pages artifact for tmux-ws title, relative asset/font paths, and tmux-ws repo/docs links