### PR TITLE
docs: clarify daemon-served SPA entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![CI](https://github.com/lambdasistemi/tmux-ws/actions/workflows/ci.yml/badge.svg)](https://github.com/lambdasistemi/tmux-ws/actions/workflows/ci.yml)
 
-WebSocket daemon for managing local tmux sessions from a browser.
+`tmux-ws` is a local daemon that serves the browser SPA and the
+REST/WebSocket API from the same origin. Open the SPA from the daemon URL
+itself to manage local tmux sessions from a browser.
 
 ## Documentation
 
@@ -16,6 +18,16 @@ just build
 agent-daemon --host 127.0.0.1 --port 8080 --base-dir /code
 ```
 
+Then open the daemon URL in a browser on the same machine:
+
+```
+http://127.0.0.1:8080/
+```
+
+For another device, expose that same daemon origin through a reverse proxy such
+as Tailscale Serve and open the proxied URL directly. In both modes, the URL
+serves the SPA and API together.
+
 ## Session Recovery
 
 On startup, the daemon imports existing tmux sessions directly. Session ids are
@@ -24,9 +36,14 @@ applied.
 
 ## Browser Console
 
-Open the daemon URL in a browser to use the bundled console. It can stop tmux
-sessions, attach to the selected tmux session, disconnect, and refresh the
-session list.
+Open the daemon URL in a browser to use the bundled SPA. It can stop tmux
+sessions, attach to the selected tmux session, disconnect, switch tmux windows,
+and refresh the session list.
+
+The GitHub Pages build is useful for public inspection and documentation, but
+browser control should come from the daemon-served SPA. Public origins such as
+GitHub Pages can be blocked by browser local-network protections when they try
+to call a Tailscale or localhost daemon.
 
 Destructive session actions require exact confirmation. The REST delete endpoint
 must be called as `DELETE /sessions/:sid?confirm=:sid`; the browser client

--- a/agent-daemon.cabal
+++ b/agent-daemon.cabal
@@ -1,11 +1,14 @@
 cabal-version:   3.0
 name:            agent-daemon
 version:         0.1.1
-synopsis:        WebSocket daemon for managing Claude Code agent sessions
+synopsis:
+  Same-origin browser SPA and WebSocket daemon for tmux sessions
+
 description:
-  A Haskell WebSocket server that manages Claude Code agent
-  sessions via tmux and git worktrees. Provides terminal access
-  through xterm.js in the browser.
+  tmux-ws serves a browser SPA, REST API, and WebSocket terminal
+  relay from one local origin. It manages existing tmux sessions
+  from a browser. Use localhost on the same machine, or expose
+  the same origin through a reverse proxy such as Tailscale Serve.
 
 license:         MIT
 license-file:    LICENSE

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,7 @@ module Main
 
 -- \|
 -- Module      : Main
--- Description : Entry point for agent-daemon
+-- Description : Entry point for tmux-ws
 -- Copyright   : (c) Paolo Veronelli, 2026
 -- License     : MIT
 --
@@ -42,7 +42,7 @@ data Config = Config
     , configBaseDir :: FilePath
     -- ^ base directory for worktrees
     , configStaticDir :: FilePath
-    -- ^ static files directory
+    -- ^ SPA files directory
     }
 
 -- | Parse CLI options.
@@ -73,7 +73,7 @@ configParser =
         <*> strOption
             ( long "static-dir"
                 <> help
-                    "Directory for static web files"
+                    "Directory for the SPA files served by the daemon"
                 <> showDefault
                 <> value "static"
             )
@@ -87,9 +87,9 @@ main = do
                 (configParser <**> helper)
                 ( fullDesc
                     <> progDesc
-                        "Manage Claude Code agent sessions"
+                        "Serve the tmux-ws SPA and manage local tmux sessions"
                     <> header
-                        "agent-daemon - terminal session manager"
+                        "tmux-ws - browser SPA plus tmux session daemon"
                 )
     mgr <- newSessionManager
     recoverSessions (configBaseDir config) mgr

--- a/docs/design.md
+++ b/docs/design.md
@@ -221,8 +221,9 @@ Terminal resize is sent as a protocol message: `\x01cols;rows`.
 
 ### Static files
 
-Any path not matching the API routes serves from `--static-dir`,
-falling back to `index.html` (SPA support).
+tmux-ws serves the browser SPA from `--static-dir` on the same origin as the
+REST and WebSocket API. Any path not matching the API routes serves static
+assets first, then falls back to `index.html` for SPA routing.
 
 ### CORS
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,16 @@
-# Agent Daemon
+# tmux-ws
 
-WebSocket daemon for managing Claude Code agent sessions via tmux and git worktrees.
+`tmux-ws` is a local daemon that serves both the browser SPA and the
+REST/WebSocket API used to manage tmux sessions. The supported browser-control
+entry point is the SPA served by the daemon itself.
 
 ## What it does
 
-- Launches Claude Code sessions tied to GitHub issues
-- Creates git worktrees and tmux sessions automatically
+- Serves the tmux-ws SPA from `--static-dir`
+- Lists and recovers running tmux sessions after daemon restart
 - Provides browser-based terminal access via xterm.js and WebSockets
-- Recovers running sessions after daemon restart
-- Manages the full session lifecycle: create, attach, detach, stop
+- Switches tmux windows from touch-first browsers
+- Manages the session lifecycle: attach, detach, stop, refresh
 
 ## Quick start
 
@@ -28,7 +30,7 @@ agent-daemon --host 127.0.0.1 --port 8080 --base-dir /code
 | `--host` | `*` (all interfaces) | Address to bind to |
 | `--port` | `8080` | HTTP port |
 | `--base-dir` | `/code` | Root directory for git worktrees |
-| `--static-dir` | `static` | Directory for web UI files |
+| `--static-dir` | `static` | Directory for the SPA files served by the daemon |
 
 ## Prerequisites
 
@@ -38,12 +40,28 @@ The following must be available in `PATH`:
 - **git** — worktree operations
 - **ssh** — git authentication (agent forwarding or deploy keys)
 
-The user running the daemon needs write access to `--base-dir` and
-permission to clone/fetch the repositories it will manage.
+The user running the daemon needs permission to inspect and control the tmux
+sessions it exposes.
 
 ## Browser client
 
-A web-based terminal client is available at
-[lambdasistemi.github.io/tmux-ws](https://lambdasistemi.github.io/tmux-ws/)
+Open the daemon URL in your browser. On the same machine, use localhost:
 
-Enter your daemon's address in the server field to connect remotely (e.g. via Tailscale).
+```
+http://127.0.0.1:8080/
+```
+
+For a tablet or another machine, expose the same daemon origin through a reverse
+proxy such as Tailscale Serve and open that proxied URL directly:
+
+```
+https://<hostname>.tailnet-name.ts.net:8443/
+```
+
+In both cases, the browser loads the SPA and calls the API from the same origin.
+
+The GitHub Pages build at
+[lambdasistemi.github.io/tmux-ws](https://lambdasistemi.github.io/tmux-ws/) is
+a public static copy. It is useful for inspection, but browsers may block it
+from controlling a localhost or Tailscale daemon because that crosses from a
+public origin into a local/private network address space.

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -1,7 +1,9 @@
 # HTTPS via Tailscale
 
-The daemon speaks plain HTTP. For HTTPS (required when the dashboard
-runs on `https://`), use [Tailscale Serve](https://tailscale.com/kb/1312/serve)
+The daemon serves the SPA and API over plain HTTP. When the browser runs on the
+same machine, open `http://127.0.0.1:8080/` directly.
+
+For another device, use [Tailscale Serve](https://tailscale.com/kb/1312/serve)
 as a TLS-terminating reverse proxy. No certificates to manage — Tailscale
 handles provisioning and renewal automatically.
 
@@ -34,7 +36,7 @@ sudo tailscale serve --https 8443 http://127.0.0.1:8080
 sudo tailscale serve --bg --https 8443 http://127.0.0.1:8080
 ```
 
-### 4. Verify
+### 4. Open the SPA
 
 ```bash
 # Check serve status
@@ -44,10 +46,20 @@ tailscale serve status
 # https://<hostname>.tailnet-name.ts.net:8443 (tailnet only)
 # |-- / proxy http://127.0.0.1:8080
 
-# Test HTTPS access
+# Test HTTPS API access
 curl https://<hostname>.tailnet-name.ts.net:8443/sessions
 # → []
 ```
+
+Then open the same HTTPS origin in the browser:
+
+```
+https://<hostname>.tailnet-name.ts.net:8443/
+```
+
+That page is the tmux-ws SPA served by the daemon through Tailscale. It is the
+supported tablet control surface because the SPA and API share the same proxied
+origin.
 
 ## How it works
 
@@ -59,21 +71,31 @@ Tailscale Serve (TLS termination)
     https://<hostname>.ts.net:8443
     │
     ▼ (plain HTTP, localhost only)
-agent-daemon
+tmux-ws daemon
     http://127.0.0.1:8080
     │
     ▼
 tmux sessions + git worktrees
 ```
 
+- The browser loads the SPA from `https://<hostname>.ts.net:8443/`
+- The SPA calls REST endpoints on the same origin, such as `/sessions`
 - The browser connects to `wss://<hostname>.ts.net:8443/sessions/<id>/terminal`
 - Tailscale terminates TLS and forwards to `ws://127.0.0.1:8080/...`
 - Only machines on your tailnet can reach the service
 - Certificates are Let's Encrypt, auto-renewed by Tailscale
 
+## Public static build
+
+The GitHub Pages build is a public static copy. It is useful for inspection and
+documentation, but browsers may block it from calling a localhost or Tailscale
+daemon because that crosses from a public origin into a local/private network
+address space. For real browser control, open the Tailscale URL above.
+
 ## Dashboard configuration
 
-In the gh-dashboard, set the agent server URL to:
+If another dashboard needs to call tmux-ws directly, set the agent server URL
+to:
 
 ```
 https://<hostname>.tailnet-name.ts.net:8443

--- a/src/AgentDaemon/Server.hs
+++ b/src/AgentDaemon/Server.hs
@@ -35,12 +35,12 @@ startServer
     -> FilePath
     -- ^ base directory for worktrees
     -> FilePath
-    -- ^ static files directory
+    -- ^ SPA files directory
     -> SessionManager
     -> IO ()
 startServer host port baseDir staticDir mgr = do
     putStrLn $
-        "agent-daemon listening on "
+        "tmux-ws serving SPA and API on "
             <> host
             <> ":"
             <> show port


### PR DESCRIPTION
## Summary\n- make it explicit that tmux-ws serves the SPA and API from the daemon origin\n- document localhost as the same-machine entrypoint\n- document Tailscale as the remote/tablet same-origin option rather than the core requirement\n- update CLI/help/package wording to say SPA plus tmux session daemon\n\n## Verification\n- curl http://127.0.0.1:8082/ and /sessions\n- curl http://localhost:8082/ and /sessions\n- isolated headless Chromium checks for http://localhost:8082/ and http://127.0.0.1:8082/: title tmux-ws, /sessions 200, /windows 200, window-select POST 200\n- nix build .#docs --out-link /tmp/tmux-ws-docs-clarify --quiet\n- nix develop -c bash -lc 'fourmolu -i app src && cabal-fmt -i *.cabal && fourmolu -m check app src && cabal-fmt -c *.cabal'\n- nix develop -c cabal build all -O0\n- git diff --check