### PR TITLE
Make tmux-ws touch-first on tablets and small screens

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix develop --quiet -c just CI
-nix develop --quiet -c bash -lc 'cd ui && just ci'

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix develop --quiet -c just ci
+nix run --quiet .#ui

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix develop --quiet -c just CI
+nix develop --quiet -c bash -lc 'cd ui && just ci'

--- a/gate.sh
+++ b/gate.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix develop --quiet -c just ci
-nix run --quiet .#ui

--- a/specs/075-touch-first-ui/plan.md
+++ b/specs/075-touch-first-ui/plan.md
@@ -1,0 +1,65 @@
+# Implementation Plan: Touch-first tmux workspace
+
+**Branch**: `feat/make-tmux-ws-touch-first-on-tablets-and-small-scre`  
+**Issue**: [#75](https://github.com/lambdasistemi/tmux-ws/issues/75)
+
+## Technical context
+
+- PureScript/Halogen owns the rendered shell and existing actions.
+- Plain CSS in `ui/dist/index.css` owns all visual and responsive behavior.
+- Existing Lucide icons and xterm.js remain unchanged; no dependency work is
+  needed.
+- There is no frontend test harness. Proof is the PureScript/build gate plus a
+  live daemon browser smoke at the three target viewports.
+
+## Interaction design
+
+The terminal remains the dominant center surface. The shell is divided into:
+
+1. A compact identity/context header containing the product name, a connection
+   status badge, and two resilient selectors for session and window.
+2. The terminal workspace, which consumes all remaining space.
+3. A stable action dock containing refresh, terminal controls, paste snippets,
+   and settings. On touch layouts these actions use icon-plus-label affordances
+   and safe-area padding so their purpose is not hidden behind tooltips.
+
+Repository/documentation links move into a secondary utility area that remains
+reachable but does not displace operational controls. Existing menus keep one
+open surface at a time; small-screen CSS presents them as viewport-bound sheets.
+
+## Responsive invariants
+
+- No horizontal scrolling at any supported width.
+- Session/window selectors share available width with `minmax(0, 1fr)` and
+  ellipsis for long names.
+- Coarse-pointer or narrow-screen actions are at least 44x44 CSS pixels.
+- Dock and sheets use safe-area insets; the terminal is laid out around them,
+  not underneath them.
+- Desktop retains compact sizing and hover feedback, while focus-visible and
+  active states work everywhere.
+
+## Slice 1 — Deliver the touch-first shell
+
+This is one bisect-safe vertical slice because the Halogen hierarchy and its CSS
+layout must land together to remain usable.
+
+Owned implementation files:
+
+- `ui/src/Main.purs`
+- `ui/dist/index.css`
+- `ui/dist/index.html` only if a cache-busting query must change
+
+The slice will reorganize existing render helpers into the identity/context
+header, terminal workspace, stable action dock, and secondary utilities. It
+will retain all action constructors and handlers, then add responsive,
+coarse-pointer, safe-area, focus, and sheet styling. No generated bundle is
+committed.
+
+## Proof
+
+1. Run `./gate.sh`.
+2. Serve the branch build from an isolated local daemon/static directory.
+3. At 390x844, 768x1024, and 1024x768, verify no horizontal overflow, inspect
+   all required touch targets, open every menu/sheet, and capture screenshots.
+4. At 768x1024, repeat the visual check in light theme.
+

--- a/specs/075-touch-first-ui/spec.md
+++ b/specs/075-touch-first-ui/spec.md
@@ -1,0 +1,70 @@
+# Feature Specification: Touch-first tmux workspace
+
+**Issue**: [#75](https://github.com/lambdasistemi/tmux-ws/issues/75)  
+**Priority**: P1
+
+## Paramount user story
+
+As an operator using only a touchscreen, I can navigate sessions and windows,
+control the terminal, and use paste snippets without needing a hardware
+keyboard or mouse.
+
+## User journeys
+
+### US1 — Find the active workspace
+
+On phone or tablet, the operator can immediately distinguish connection state,
+active session, and active tmux window. Long names truncate without pushing any
+control off-screen.
+
+### US2 — Operate without hardware input
+
+The operator can reach refresh, session/window switching and creation,
+terminal keys (`Esc`, `Ctrl-b`, and command mode), copy/select, live mode, paste
+snippets, and settings by touch. No core action depends on hover or a physical
+keyboard.
+
+### US3 — Work across device shapes
+
+The same interface remains usable at phone portrait (390x844), tablet portrait
+(768x1024), tablet landscape (1024x768), and desktop widths. Menus stay within
+the visible viewport and terminal space remains the dominant surface.
+
+## Functional requirements
+
+- **FR-001**: Present brand and connection state separately from the active
+  session/window context.
+- **FR-002**: Keep session and window selectors visible and reachable without
+  horizontal scrolling.
+- **FR-003**: Provide a stable touch action surface for refresh, terminal
+  controls, paste snippets, and settings.
+- **FR-004**: Give every interactive control a minimum 44x44 CSS-pixel target
+  on coarse-pointer/small-screen devices, with visible pressed, active, and
+  focus states.
+- **FR-005**: Render menus as viewport-safe popovers on wider screens and
+  touch-friendly sheets on smaller screens.
+- **FR-006**: Respect `env(safe-area-inset-*)` and never overlay core controls
+  on the terminal viewport.
+- **FR-007**: Preserve all existing actions, dark/light themes, terminal
+  behavior, and desktop operation.
+- **FR-008**: Keep repository and documentation links reachable without making
+  them compete with primary touch controls.
+
+## Success criteria
+
+- At 390x844, 768x1024, and 1024x768, `scrollWidth` does not exceed
+  `clientWidth` and every required control has a visible, tappable target.
+- Coarse-pointer controls measure at least 44x44 CSS pixels.
+- Opening session, window, terminal, paste, and settings surfaces keeps their
+  bounding boxes inside the viewport.
+- Visual smoke screenshots show legible hierarchy in dark theme at all target
+  viewports and in light theme at one tablet viewport.
+- `./gate.sh` exits 0 after the implementation.
+
+## Non-goals
+
+- Backend API or WebSocket protocol changes.
+- New runtime dependencies.
+- Replacing xterm.js or changing terminal emulation internals.
+- Changing session lifecycle semantics or paste payload semantics.
+

--- a/specs/075-touch-first-ui/tasks.md
+++ b/specs/075-touch-first-ui/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Touch-first tmux workspace
+
+**Spec**: [spec.md](spec.md)  
+**Plan**: [plan.md](plan.md)
+
+## Slice 1 — Deliver the touch-first shell
+
+- [ ] T7501 Reorganize `ui/src/Main.purs` into a clear identity/context header,
+  terminal workspace, stable action dock, and reachable secondary utilities
+  while preserving every existing action.
+- [ ] T7502 Implement responsive phone/tablet/desktop layout, safe-area handling,
+  viewport-bound sheets, and long-label containment in `ui/dist/index.css`.
+- [ ] T7503 Ensure coarse-pointer interactive targets are at least 44x44 CSS
+  pixels and add visible focus, pressed, active, and disabled states.
+- [ ] T7504 Run `./gate.sh` and record the successful result.
+- [ ] T7505 Smoke 390x844, 768x1024, and 1024x768 in a live branch build;
+  verify overflow, target sizes, touch workflows, and menu bounds.
+- [ ] T7506 Capture dark-theme screenshots at all three target viewports and a
+  light-theme tablet screenshot for review.

--- a/specs/075-touch-first-ui/tasks.md
+++ b/specs/075-touch-first-ui/tasks.md
@@ -5,15 +5,15 @@
 
 ## Slice 1 — Deliver the touch-first shell
 
-- [ ] T7501 Reorganize `ui/src/Main.purs` into a clear identity/context header,
+- [X] T7501 Reorganize `ui/src/Main.purs` into a clear identity/context header,
   terminal workspace, stable action dock, and reachable secondary utilities
   while preserving every existing action.
-- [ ] T7502 Implement responsive phone/tablet/desktop layout, safe-area handling,
+- [X] T7502 Implement responsive phone/tablet/desktop layout, safe-area handling,
   viewport-bound sheets, and long-label containment in `ui/dist/index.css`.
-- [ ] T7503 Ensure coarse-pointer interactive targets are at least 44x44 CSS
+- [X] T7503 Ensure coarse-pointer interactive targets are at least 44x44 CSS
   pixels and add visible focus, pressed, active, and disabled states.
-- [ ] T7504 Run `./gate.sh` and record the successful result.
-- [ ] T7505 Smoke 390x844, 768x1024, and 1024x768 in a live branch build;
+- [X] T7504 Run `./gate.sh` and record the successful result.
+- [X] T7505 Smoke 390x844, 768x1024, and 1024x768 in a live branch build;
   verify overflow, target sizes, touch workflows, and menu bounds.
-- [ ] T7506 Capture dark-theme screenshots at all three target viewports and a
+- [X] T7506 Capture dark-theme screenshots at all three target viewports and a
   light-theme tablet screenshot for review.

--- a/ui/dist/index.css
+++ b/ui/dist/index.css
@@ -715,3 +715,453 @@ button:disabled {
     flex-wrap: wrap;
   }
 }
+
+/* Touch-first workspace shell */
+
+:root {
+  --focus-ring: #57b7d5;
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+}
+
+.app-shell {
+  min-width: 0;
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  overflow: hidden;
+}
+
+.app-header {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(320px, 1fr) auto;
+  align-items: center;
+  gap: 10px 16px;
+  padding: calc(8px + var(--safe-top)) calc(12px + var(--safe-right)) 8px calc(12px + var(--safe-left));
+}
+
+.identity-bar,
+.context-bar,
+.utility-links {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+}
+
+.identity-bar {
+  gap: 9px;
+}
+
+.context-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 8px;
+}
+
+.utility-links {
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.utility-link {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 6px 8px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.utility-link:hover {
+  border-color: var(--button-border);
+  background: var(--surface-subtle);
+  color: var(--text-strong);
+}
+
+.utility-link svg {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+}
+
+.connection-badge {
+  min-width: 0;
+  max-width: min(260px, 28vw);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-subtle);
+  padding: 4px 8px;
+}
+
+.connection-dot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #77808f;
+}
+
+.connection-badge.online .connection-dot {
+  background: #58c88a;
+  box-shadow: 0 0 0 3px rgba(88, 200, 138, 0.12);
+}
+
+.status-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-switcher,
+.window-switcher {
+  width: 100%;
+}
+
+.session-button,
+.window-button {
+  width: 100%;
+  max-width: none;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  justify-content: stretch;
+  gap: 8px;
+  text-align: left;
+}
+
+.session-button .button-label,
+.window-button .button-label {
+  justify-content: flex-start;
+}
+
+.session-button:disabled,
+.window-button:disabled {
+  background: var(--surface-subtle);
+}
+
+.action-dock {
+  z-index: 18;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(88px, 124px));
+  justify-content: center;
+  gap: 8px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  padding: 8px calc(12px + var(--safe-right)) calc(8px + var(--safe-bottom)) calc(12px + var(--safe-left));
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.action-dock > div {
+  min-width: 0;
+  position: relative;
+}
+
+.dock-button {
+  width: 100%;
+  min-width: 0;
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 7px 10px;
+}
+
+.dock-button.active,
+.dock-button[aria-expanded="true"] {
+  border-color: var(--active-border);
+  background: var(--surface-active);
+}
+
+.dock-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.terminal-menu,
+.paste-menu,
+.settings-menu {
+  top: auto;
+  bottom: calc(100% + 8px);
+}
+
+.terminal-menu {
+  left: 50%;
+  right: auto;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  transform: translateX(-50%);
+}
+
+.terminal-menu-item {
+  justify-content: center;
+}
+
+.paste-menu,
+.settings-menu {
+  right: 0;
+}
+
+.settings-menu {
+  max-height: min(70vh, 520px);
+  overflow-y: auto;
+}
+
+.session-menu,
+.window-menu,
+.terminal-menu,
+.paste-menu,
+.settings-menu {
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+button:active:not(:disabled),
+.utility-link:active {
+  transform: translateY(1px);
+  filter: brightness(1.08);
+}
+
+.modal-backdrop {
+  padding: calc(18px + var(--safe-top)) calc(18px + var(--safe-right)) calc(18px + var(--safe-bottom)) calc(18px + var(--safe-left));
+}
+
+@media (max-width: 1080px) {
+  .app-header {
+    grid-template-columns: auto minmax(280px, 1fr);
+  }
+
+  .utility-links {
+    grid-column: 1 / -1;
+    justify-content: flex-end;
+    margin-top: -4px;
+  }
+}
+
+@media (max-width: 900px), (pointer: coarse) {
+  input,
+  textarea,
+  button {
+    min-height: 44px;
+  }
+
+  .app-header {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px 10px;
+    padding: calc(8px + var(--safe-top)) calc(8px + var(--safe-right)) 8px calc(8px + var(--safe-left));
+  }
+
+  .identity-bar {
+    overflow: hidden;
+  }
+
+  .connection-badge {
+    max-width: min(52vw, 300px);
+  }
+
+  .context-bar {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .utility-links {
+    grid-column: 2;
+    grid-row: 1;
+    margin-top: 0;
+  }
+
+  .utility-link {
+    min-width: 44px;
+    min-height: 44px;
+    justify-content: center;
+    padding: 8px;
+  }
+
+  .utility-label {
+    display: none;
+  }
+
+  .session-button,
+  .window-button {
+    min-height: 48px;
+  }
+
+  .action-dock {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+    padding: 6px calc(6px + var(--safe-right)) calc(6px + var(--safe-bottom)) calc(6px + var(--safe-left));
+  }
+
+  .dock-button {
+    min-height: 52px;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 11px;
+    line-height: 1;
+    padding: 6px 3px;
+  }
+
+  .dock-button svg {
+    width: 18px;
+    height: 18px;
+  }
+
+  .session-menu,
+  .window-menu,
+  .terminal-menu,
+  .paste-menu,
+  .settings-menu {
+    position: fixed;
+    top: auto;
+    right: calc(8px + var(--safe-right));
+    bottom: calc(70px + var(--safe-bottom));
+    left: calc(8px + var(--safe-left));
+    width: auto;
+    max-height: calc(100vh - 170px - var(--safe-top) - var(--safe-bottom));
+    max-height: calc(100dvh - 170px - var(--safe-top) - var(--safe-bottom));
+    border-radius: 14px;
+    padding: 10px;
+    transform: none;
+  }
+
+  .terminal-menu {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .session-menu-item,
+  .window-menu-item,
+  .window-menu-action,
+  .terminal-menu-item,
+  .paste-snippet-button,
+  .paste-new-button,
+  .paste-icon-button,
+  .paste-option-button,
+  .paste-editor-actions button,
+  .setting-button,
+  .settings-row button,
+  .icon-button,
+  .icon-link {
+    min-height: 44px;
+  }
+
+  .icon-button,
+  .icon-link,
+  .paste-icon-button {
+    width: 44px;
+    min-width: 44px;
+  }
+
+  .paste-menu-row {
+    grid-template-columns: minmax(0, 1fr) 44px 44px;
+  }
+
+  .paste-options,
+  .paste-editor-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .paste-editor-actions button:last-child {
+    grid-column: 1 / -1;
+  }
+
+  .settings-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .grow {
+    min-width: 0;
+  }
+
+  .font-size-control .icon-button {
+    flex: 0 0 44px;
+  }
+
+  .modal {
+    max-height: calc(100dvh - 36px - var(--safe-top) - var(--safe-bottom));
+    overflow-y: auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .app-header {
+    gap: 7px 8px;
+  }
+
+  .identity-bar {
+    gap: 7px;
+  }
+
+  .identity-bar h1 {
+    font-size: 13px;
+  }
+
+  .connection-badge {
+    max-width: calc(100vw - 190px - var(--safe-left) - var(--safe-right));
+    font-size: 11px;
+  }
+
+  .context-bar {
+    gap: 6px;
+  }
+
+  .session-button,
+  .window-button {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 5px;
+    padding: 6px 8px;
+  }
+
+  .menu-prefix {
+    display: none;
+  }
+
+  .terminal-wrap {
+    padding: 2px;
+  }
+
+  .session-menu-item {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .session-state {
+    justify-self: start;
+  }
+}
+
+@media (hover: none) {
+  button:hover,
+  .icon-link:hover,
+  .utility-link:hover {
+    background: var(--button-bg);
+  }
+
+  .dock-button.active,
+  .dock-button[aria-expanded="true"],
+  .session-menu-item.active,
+  .window-menu-item.active,
+  .terminal-menu-item.active {
+    background: var(--surface-active);
+  }
+}

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>tmux-ws</title>
-  <link rel="icon" href="favicon.svg?v=20260709-touch-selection" type="image/svg+xml">
-  <link rel="stylesheet" href="xterm.css?v=20260709-touch-selection">
-  <link rel="stylesheet" href="index.css?v=20260709-touch-selection">
+  <link rel="icon" href="favicon.svg?v=20260710-touch-first" type="image/svg+xml">
+  <link rel="stylesheet" href="xterm.css?v=20260710-touch-first">
+  <link rel="stylesheet" href="index.css?v=20260710-touch-first">
 </head>
 <body>
-  <script src="index.js?v=20260709-touch-selection"></script>
+  <script src="index.js?v=20260710-touch-first"></script>
 </body>
 </html>

--- a/ui/src/Main.purs
+++ b/ui/src/Main.purs
@@ -146,31 +146,76 @@ render state =
     [ cls "app-shell" ]
     [ renderHeader state
     , renderMain state
+    , renderActionDock state
     , renderConfirm state
     ]
 
 renderHeader :: State -> H.ComponentHTML Action Slots Aff
 renderHeader state =
-  HH.header_
-    [ HH.h1_ [ HH.text "tmux-ws" ]
-    , HH.span
-        [ HP.id "status" ]
-        [ HH.text state.status ]
-    , HH.div
-        [ cls "top-actions" ]
-        [ iconLink "Repository" "github" "https://github.com/lambdasistemi/tmux-ws"
-        , iconLink "Documentation" "book-open" "https://lambdasistemi.github.io/tmux-ws/docs/"
-        , iconOnlyButton "Refresh sessions" "refresh-cw" RefreshSessions Nothing
-        , renderSessionSwitcher state
-        , renderWindowSwitcher state
-        , renderTerminalActions state
-        , renderPasteActions state
-        , HH.div
-            [ cls "settings-shell" ]
-            [ iconOnlyButton "Settings" "settings" ToggleSettings
-                (Just (if state.settingsOpen then "true" else "false"))
-            , renderSettings state
+  HH.header
+    [ cls "app-header" ]
+    [ HH.div
+        [ cls "identity-bar" ]
+        [ HH.h1_ [ HH.text "tmux-ws" ]
+        , HH.span
+            [ HP.id "status"
+            , cls
+                ( "connection-badge "
+                    <> if state.attachedSession == "" then "offline" else "online"
+                )
             ]
+            [ HH.span
+                [ cls "connection-dot" ]
+                []
+            , HH.span
+                [ cls "status-label" ]
+                [ HH.text state.status ]
+            ]
+        ]
+    , HH.div
+        [ cls "context-bar" ]
+        [ renderSessionSwitcher state
+        , renderWindowSwitcher state
+        ]
+    , HH.nav
+        [ cls "utility-links"
+        , HP.attr (HH.AttrName "aria-label") "Project links"
+        ]
+        [ iconTextLink "Repository" "github" "https://github.com/lambdasistemi/tmux-ws"
+        , iconTextLink "Documentation" "book-open" "https://lambdasistemi.github.io/tmux-ws/docs/"
+        ]
+    ]
+
+renderActionDock :: State -> H.ComponentHTML Action Slots Aff
+renderActionDock state =
+  HH.footer
+    [ cls "action-dock"
+    , HP.attr (HH.AttrName "aria-label") "Workspace actions"
+    ]
+    [ dockButton "Refresh" "refresh-cw" RefreshSessions Nothing false false
+    , HH.div
+        [ cls "terminal-actions-shell" ]
+        [ dockButton "Terminal" "keyboard" ToggleTerminalMenu
+            (Just (if state.terminalMenuOpen then "true" else "false"))
+            (state.terminalMenuOpen || state.terminalSelectionMode)
+            (state.attachedSession == "")
+        , renderTerminalMenu state
+        ]
+    , HH.div
+        [ cls "paste-actions-shell" ]
+        [ dockButton "Paste" "clipboard-list" TogglePasteMenu
+            (Just (if state.pasteMenuOpen then "true" else "false"))
+            state.pasteMenuOpen
+            (state.attachedSession == "")
+        , renderPasteMenu state
+        ]
+    , HH.div
+        [ cls "settings-shell" ]
+        [ dockButton "Settings" "settings" ToggleSettings
+            (Just (if state.settingsOpen then "true" else "false"))
+            state.settingsOpen
+            false
+        , renderSettings state
         ]
     ]
 
@@ -240,35 +285,37 @@ renderSessionItem state session =
 
 renderWindowSwitcher :: State -> H.ComponentHTML Action Slots Aff
 renderWindowSwitcher state =
-  if state.attachedSession == "" then
-    HH.text ""
-  else
-    HH.div
-      [ cls "window-switcher" ]
-      [ HH.button
-          [ cls "window-button"
-          , HP.title "Switch tmux window"
-          , HP.attr (HH.AttrName "aria-label") "Switch tmux window"
-          , HP.attr (HH.AttrName "aria-expanded")
-              (if state.windowMenuOpen then "true" else "false")
-          , HE.onClick \_ -> ToggleWindowMenu
-          ]
-          [ HH.span
-              [ cls "menu-prefix" ]
-              [ HH.text "Window" ]
-          , HH.span
-              [ cls "button-label window-label" ]
-              [ HH.text (activeWindowLabel state) ]
-          , icon "chevron-down"
-          ]
-      , HH.div
-          [ cls
-              ( "window-menu"
-                  <> if state.windowMenuOpen then "" else " hidden"
-              )
-          ]
-          (renderWindowItems state.windows)
-      ]
+  HH.div
+    [ cls "window-switcher" ]
+    [ HH.button
+        [ cls "window-button"
+        , HP.title "Switch tmux window"
+        , HP.attr (HH.AttrName "aria-label") "Switch tmux window"
+        , HP.attr (HH.AttrName "aria-expanded")
+            (if state.windowMenuOpen then "true" else "false")
+        , HP.disabled (state.attachedSession == "")
+        , HE.onClick \_ -> ToggleWindowMenu
+        ]
+        [ HH.span
+            [ cls "menu-prefix" ]
+            [ HH.text "Window" ]
+        , HH.span
+            [ cls "button-label window-label" ]
+            [ HH.text
+                ( if state.attachedSession == "" then "No window"
+                  else activeWindowLabel state
+                )
+            ]
+        , icon "chevron-down"
+        ]
+    , HH.div
+        [ cls
+            ( "window-menu"
+                <> if state.windowMenuOpen then "" else " hidden"
+            )
+        ]
+        (renderWindowItems state.windows)
+    ]
 
 renderWindowItems
   :: Array WindowInfo
@@ -293,88 +340,78 @@ renderWindowItems windows =
       else
         map renderWindowItem windows
 
-renderTerminalActions :: State -> H.ComponentHTML Action Slots Aff
-renderTerminalActions state =
+renderTerminalMenu :: State -> H.ComponentHTML Action Slots Aff
+renderTerminalMenu state =
   if state.attachedSession == "" then
     HH.text ""
   else
     HH.div
-      [ cls "terminal-actions-shell" ]
-      [ iconOnlyButton "Terminal controls" "keyboard" ToggleTerminalMenu
-          (Just (if state.terminalMenuOpen then "true" else "false"))
-      , HH.div
-          [ cls
-              ( "terminal-menu"
-                  <> if state.terminalMenuOpen then "" else " hidden"
-              )
+      [ cls
+          ( "terminal-menu"
+              <> if state.terminalMenuOpen then "" else " hidden"
+          )
+      ]
+      [ HH.button
+          [ cls "terminal-menu-item"
+          , HE.onClick \_ -> CopyTerminalText
           ]
-          [ HH.button
-              [ cls "terminal-menu-item"
-              , HE.onClick \_ -> CopyTerminalText
-              ]
-              [ icon "copy"
-              , HH.text "Copy"
-              ]
-          , HH.button
-              [ cls
-                  ( "terminal-menu-item"
-                      <> if state.terminalSelectionMode then " active" else ""
-                  )
-              , HP.attr (HH.AttrName "aria-pressed")
-                  (if state.terminalSelectionMode then "true" else "false")
-              , HE.onClick \_ -> ToggleTerminalSelectionMode
-              ]
-              [ icon "scan-text"
-              , HH.text "Select"
-              ]
-          , HH.button
-              [ cls "terminal-menu-item"
-              , HE.onClick \_ -> SendEscape
-              ]
-              [ HH.text "Esc" ]
-          , HH.button
-              [ cls "terminal-menu-item"
-              , HE.onClick \_ -> SendCtrlB
-              ]
-              [ HH.text "Ctrl-b" ]
-          , HH.button
-              [ cls "terminal-menu-item"
-              , HE.onClick \_ -> SendCtrlBCommand
-              ]
-              [ HH.text "Ctrl-b :" ]
-          , HH.button
-              [ cls "terminal-menu-item"
-              , HE.onClick \_ -> SendLive
-              ]
-              [ icon "radio"
-              , HH.text "Live"
-              ]
+          [ icon "copy"
+          , HH.text "Copy"
+          ]
+      , HH.button
+          [ cls
+              ( "terminal-menu-item"
+                  <> if state.terminalSelectionMode then " active" else ""
+              )
+          , HP.attr (HH.AttrName "aria-pressed")
+              (if state.terminalSelectionMode then "true" else "false")
+          , HE.onClick \_ -> ToggleTerminalSelectionMode
+          ]
+          [ icon "scan-text"
+          , HH.text "Select"
+          ]
+      , HH.button
+          [ cls "terminal-menu-item"
+          , HE.onClick \_ -> SendEscape
+          ]
+          [ HH.text "Esc" ]
+      , HH.button
+          [ cls "terminal-menu-item"
+          , HE.onClick \_ -> SendCtrlB
+          ]
+          [ HH.text "Ctrl-b" ]
+      , HH.button
+          [ cls "terminal-menu-item"
+          , HE.onClick \_ -> SendCtrlBCommand
+          ]
+          [ HH.text "Ctrl-b :" ]
+      , HH.button
+          [ cls "terminal-menu-item"
+          , HE.onClick \_ -> SendLive
+          ]
+          [ icon "radio"
+          , HH.text "Live"
           ]
       ]
 
-renderPasteActions :: State -> H.ComponentHTML Action Slots Aff
-renderPasteActions state =
+renderPasteMenu :: State -> H.ComponentHTML Action Slots Aff
+renderPasteMenu state =
   if state.attachedSession == "" then
     HH.text ""
   else
     HH.div
-      [ cls "paste-actions-shell" ]
-      [ iconOnlyButton "Paste snippets" "clipboard-list" TogglePasteMenu
-          (Just (if state.pasteMenuOpen then "true" else "false"))
-      , HH.div
-          [ cls
-              ( "paste-menu"
-                  <> if state.pasteMenuOpen then "" else " hidden"
-              )
-          ]
-          ( renderPasteItems state
-              <>
-                if state.pasteEditorOpen then
-                  [ renderPasteEditor state ]
-                else
-                  [ renderPasteNewButton ]
+      [ cls
+          ( "paste-menu"
+              <> if state.pasteMenuOpen then "" else " hidden"
           )
       ]
+      ( renderPasteItems state
+          <>
+            if state.pasteEditorOpen then
+              [ renderPasteEditor state ]
+            else
+              [ renderPasteNewButton ]
+      )
 
 renderPasteItems
   :: State
@@ -1512,6 +1549,31 @@ iconTextButton className label iconName action =
         [ HH.text label ]
     ]
 
+dockButton
+  :: String
+  -> String
+  -> Action
+  -> Maybe String
+  -> Boolean
+  -> Boolean
+  -> H.ComponentHTML Action Slots Aff
+dockButton label iconName action expanded active disabled =
+  HH.button
+    ( [ cls ("dock-button" <> if active then " active" else "")
+      , HP.title label
+      , HP.disabled disabled
+      , HE.onClick \_ -> action
+      ]
+        <> case expanded of
+          Nothing -> []
+          Just value -> [ HP.attr (HH.AttrName "aria-expanded") value ]
+    )
+    [ icon iconName
+    , HH.span
+        [ cls "dock-label" ]
+        [ HH.text label ]
+    ]
+
 iconLink :: String -> String -> String -> H.ComponentHTML Action Slots Aff
 iconLink label iconName href =
   HH.a
@@ -1523,6 +1585,22 @@ iconLink label iconName href =
     , HP.attr (HH.AttrName "rel") "noopener noreferrer"
     ]
     [ icon iconName ]
+
+iconTextLink :: String -> String -> String -> H.ComponentHTML Action Slots Aff
+iconTextLink label iconName href =
+  HH.a
+    [ cls "utility-link"
+    , HP.title label
+    , HP.attr (HH.AttrName "aria-label") label
+    , HP.attr (HH.AttrName "href") href
+    , HP.attr (HH.AttrName "target") "_blank"
+    , HP.attr (HH.AttrName "rel") "noopener noreferrer"
+    ]
+    [ icon iconName
+    , HH.span
+        [ cls "utility-label" ]
+        [ HH.text label ]
+    ]
 
 icon :: String -> H.ComponentHTML Action Slots Aff
 icon name =


### PR DESCRIPTION
Closes #75

Parent epic: #80

## Why

tmux-ws is frequently operated from a tablet or phone, where there may be no
hardware keyboard or mouse. The previous single-row desktop toolbar overflowed
on narrow screens, hid controls off-screen, used small targets, and made the
active session/window difficult to scan.

This PR makes the workspace touch-first while preserving the terminal as the
dominant surface.

## What changed

### Touch-first workspace shell

- Separates product/connection identity from session and window context.
- Keeps session and window selectors visible, width-safe, and usable with long
  tmux names.
- Moves the primary operations into a stable bottom action dock: **Refresh**,
  **Terminal**, **Paste**, and **Settings**.
- Keeps repository and documentation links available as secondary utilities.

### Hardware-keyboard-free operation

The touch UI exposes the existing terminal workflows without requiring hover
or physical keys:

- Copy and touch-selection mode
- `Esc`, `Ctrl-b`, and `Ctrl-b :`
- Return to the live terminal
- Saved and draft paste snippets
- Session switching
- Window switching and creation
- Font size and theme controls

### Responsive and accessible behavior

- Minimum 44×44 CSS-pixel targets on coarse-pointer/small-screen devices
- Viewport-bound session, window, terminal, paste, and settings sheets
- Safe-area inset support
- Visible active, pressed, focus, and disabled states
- Accessible names for icon-only utility links
- No hover-only primary actions

### Authoritative CI reconciliation

- Rebased the accepted touch implementation onto foundation merge `e68b718`
  from #77.
- Preserved all four original #75 commits exactly; `git range-diff` reported
  equality for every rebased commit.
- Adopted the authoritative lowercase local CI entrypoint and focused flake UI
  gate without changing the accepted touch behavior.

## Before and after

| Before | After |
|---|---|
| One crowded desktop toolbar | Clear identity/context header plus stable action dock |
| Controls clipped beyond the phone viewport | All primary controls remain reachable |
| Small icon-only targets | Labeled touch controls at least 44×44 CSS px |
| Menus positioned for desktop | Touch sheets constrained inside the viewport |
| Session/window state competed with actions | Persistent, scannable session/window context |

## Fresh verification after rebase

| Viewport | Horizontal overflow | Undersized targets | All 5 sheets in bounds |
|---|---:|---:|---:|
| Phone portrait — 390×844 | None | 0 | Yes |
| Tablet portrait — 768×1024 | None | 0 | Yes |
| Tablet landscape — 1024×768 | None | 0 | Yes |

The isolated live smoke exercised refresh, session selection, window creation
and selection, terminal shortcuts, copy/select/live, saved and draft paste,
font controls, and dark/light themes through CDP touch events. Error-severity
browser console entries: **0**. Runtime exceptions: **0**.

Local proof at the final pre-gate-drop tree:

- `nix develop --quiet -c just ci` — all seven flake checks plus the real
  development-shell Cabal build passed
- `nix run --quiet .#ui` — focused PureScript UI gate passed
- `nix develop --quiet -c bash -lc 'cd ui && just ci'` — install, lint, build,
  and bundle passed with 0 vulnerabilities, 0 warnings, and 0 errors
- Fresh dark-theme screenshots at all three target sizes and a light-theme
  screenshot at 768×1024 were visually reviewed

## Review guide

- [Halogen shell and action grouping](https://github.com/lambdasistemi/tmux-ws/blob/06f242af08f43f83f201d54253af8dcc4cda97be/ui/src/Main.purs)
- [Responsive/touch styling](https://github.com/lambdasistemi/tmux-ws/blob/06f242af08f43f83f201d54253af8dcc4cda97be/ui/dist/index.css)
- [Accepted specification](https://github.com/lambdasistemi/tmux-ws/blob/06f242af08f43f83f201d54253af8dcc4cda97be/specs/075-touch-first-ui/spec.md)
- [Implementation plan](https://github.com/lambdasistemi/tmux-ws/blob/06f242af08f43f83f201d54253af8dcc4cda97be/specs/075-touch-first-ui/plan.md)
- [Completed task ledger](https://github.com/lambdasistemi/tmux-ws/blob/06f242af08f43f83f201d54253af8dcc4cda97be/specs/075-touch-first-ui/tasks.md)

## Out of scope

- Backend API or WebSocket changes
- Pane/window close APIs, controls, tests, or documentation (owned by #82)
- New runtime dependencies
- Replacing xterm.js
- Changing session lifecycle or paste semantics
