### PR TITLE
ci: make Nix checks and CI authoritative

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - nixos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,41 +16,117 @@ jobs:
     runs-on: nixos
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build all derivations
-        run: >-
-          nix build --quiet
-          .#default
-          .#devShells.x86_64-linux.default.inputDerivation
+      - name: Run flake checks
+        run: nix flake check --no-eval-cache
+      - name: Realize development shell
+        run: nix build --quiet .#devShells.x86_64-linux.default.inputDerivation
 
-  build:
+  haskell:
+    name: Haskell build and tests
     needs: build-gate
     runs-on: nixos
     steps:
       - uses: actions/checkout@v6
-
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build Haskell
+        run: nix run --quiet .#haskell-build
+      - name: Test Haskell
+        run: nix run --quiet .#haskell-tests
 
-      - name: Build
-        run: nix build --quiet
+  formatting:
+    name: Formatting
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v17
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Check formatting
+        run: nix run --quiet .#formatting
+
+  hlint:
+    name: HLint
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v17
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Run HLint
+        run: nix run --quiet .#hlint
+
+  cabal-package:
+    name: Cabal package validation
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v17
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Validate Cabal package
+        run: nix run --quiet .#cabal-package
+
+  ui:
+    name: PureScript UI
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v17
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Verify PureScript UI
+        run: nix run --quiet .#ui
+
+  workflow-lint:
+    name: Workflow lint
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v17
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Lint workflows
+        run: nix run --quiet .#workflow-lint
+
+  dev-shell:
+    name: Dev shell build
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v17
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build from the development shell
+        run: nix develop --quiet -c cabal build all -O0
 
   build-darwin:
-    name: Build (aarch64-darwin)
+    name: Darwin build
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
-
       - uses: cachix/install-nix-action@v30
         with:
           extra_nix_config: |
             extra-substituters = https://paolino.cachix.org
             extra-trusted-public-keys = paolino.cachix.org-1:ecmgO3CXdgSWA2cHlm4srknd/cLFMLmK3i3NrzeDFaE=
-
       - name: Build
         run: nix build -L

--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -33,7 +33,7 @@ jobs:
 
           otool -L /tmp/bundle/bin/agent-daemon \
             | grep -v /usr/lib | grep -v /System | grep -v ":" \
-            | awk '{print $1}' | while read lib; do
+            | awk '{print $1}' | while read -r lib; do
               libname=$(basename "$lib")
               cp "$lib" /tmp/bundle/lib/
               install_name_tool -change "$lib" "@executable_path/../libexec/lib/$libname" /tmp/bundle/bin/agent-daemon
@@ -46,8 +46,8 @@ jobs:
       - name: Create tarball
         run: |
           VERSION=$(nix eval .#default.version --raw 2>/dev/null || echo "0.1.0")
-          tar czf /tmp/agent-daemon-${VERSION}-aarch64-darwin.tar.gz -C /tmp/bundle .
-          shasum -a 256 /tmp/agent-daemon-${VERSION}-aarch64-darwin.tar.gz
+          tar czf "/tmp/agent-daemon-${VERSION}-aarch64-darwin.tar.gz" -C /tmp/bundle .
+          shasum -a 256 "/tmp/agent-daemon-${VERSION}-aarch64-darwin.tar.gz"
           echo "$VERSION" > /tmp/version.txt
 
       - name: Create release
@@ -84,7 +84,7 @@ jobs:
 
           printf 'class AgentDaemon < Formula\n  desc "WebSocket daemon for managing tmux workspaces"\n  homepage "https://github.com/lambdasistemi/tmux-ws"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/agent-daemon"\n    (libexec/"lib").install Dir["lib/*"]\n  end\nend\n' "$URL" "$SHA" "$VERSION" > /tmp/agent-daemon.rb
 
-          git clone https://x-access-token:${TAP_TOKEN}@github.com/lambdasistemi/homebrew-tap.git /tmp/tap
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/lambdasistemi/homebrew-tap.git" /tmp/tap
           mkdir -p /tmp/tap/Formula
           cp /tmp/agent-daemon.rb /tmp/tap/Formula/agent-daemon.rb
           cd /tmp/tap
@@ -103,4 +103,4 @@ jobs:
           echo "==> Which:"
           which agent-daemon
           echo "==> Libs:"
-          otool -L $(which agent-daemon)
+          otool -L "$(command -v agent-daemon)"

--- a/agent-daemon.cabal
+++ b/agent-daemon.cabal
@@ -21,6 +21,11 @@ homepage:        https://github.com/lambdasistemi/tmux-ws
 bug-reports:     https://github.com/lambdasistemi/tmux-ws/issues
 extra-doc-files: README.md
 
+flag development-warnings
+  description: Enable warnings as errors for development and CI builds
+  manual:      True
+  default:     False
+
 library
   exposed-modules:
     AgentDaemon
@@ -59,8 +64,11 @@ library
   hs-source-dirs:     src
   default-language:   GHC2021
   ghc-options:
-    -Wall -Werror -Wunused-imports -Wunused-packages
-    -Wmissing-export-lists -Wname-shadowing -Wredundant-constraints
+    -Wall -Wunused-imports -Wunused-packages -Wmissing-export-lists
+    -Wname-shadowing -Wredundant-constraints
+
+  if flag(development-warnings)
+    ghc-options: -Werror
 
   default-extensions:
     DataKinds
@@ -77,9 +85,12 @@ executable agent-daemon
   hs-source-dirs:     app
   default-language:   GHC2021
   ghc-options:
-    -Wall -Werror -Wunused-imports -Wunused-packages
-    -Wmissing-export-lists -Wname-shadowing -Wredundant-constraints
-    -threaded -rtsopts -with-rtsopts=-N
+    -Wall -Wunused-imports -Wunused-packages -Wmissing-export-lists
+    -Wname-shadowing -Wredundant-constraints -threaded -rtsopts
+    -with-rtsopts=-N
+
+  if flag(development-warnings)
+    ghc-options: -Werror
 
   build-depends:
     , agent-daemon
@@ -103,9 +114,12 @@ test-suite e2e-tests
   hs-source-dirs:     test
   default-language:   GHC2021
   ghc-options:
-    -Wall -Werror -Wunused-imports -Wunused-packages
-    -Wmissing-export-lists -Wname-shadowing -Wredundant-constraints
-    -threaded -rtsopts -with-rtsopts=-N
+    -Wall -Wunused-imports -Wunused-packages -Wmissing-export-lists
+    -Wname-shadowing -Wredundant-constraints -threaded -rtsopts
+    -with-rtsopts=-N
+
+  if flag(development-warnings)
+    ghc-options: -Werror
 
   build-depends:
     , aeson           >=2.1  && <2.3

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
-  outputs =
-    inputs@{ self, nixpkgs, flake-utils, haskellNix, dev-assets-mkdocs
+  outputs = inputs@{ self, nixpkgs, flake-utils, haskellNix, dev-assets-mkdocs
     , purescript-overlay, mkSpagoDerivation, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-darwin" ] (system:
       let
@@ -28,6 +27,14 @@
           inherit system;
         };
         project = import ./nix/project.nix { inherit pkgs; };
+        checksWithApps = import ./nix/checks.nix {
+          inherit pkgs;
+          inherit (project) components;
+          uiBuild = project.packages.uiBuild;
+          uiNodeModules = project.packages.uiNodeModules;
+          uiBundle = project.packages.static;
+          src = ./.;
+        };
         mkdocsShell = dev-assets-mkdocs.devShells.${system}.default;
         mkdocsPackages = dev-assets-mkdocs.packages.${system};
         docs = pkgs.stdenv.mkDerivation {
@@ -48,6 +55,11 @@
         packages = project.packages // {
           default = project.packages.main;
           inherit docs site;
+        };
+        checks = builtins.removeAttrs checksWithApps [ "apps" ];
+        apps = import ./nix/apps.nix {
+          inherit pkgs;
+          checks = checksWithApps;
         };
         devShells.default = project.devShells.default.overrideAttrs (old: {
           nativeBuildInputs = (old.nativeBuildInputs or [ ])

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+git diff --check
+nix develop --quiet -c just ci

--- a/gate.sh
+++ b/gate.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-cd "$(git rev-parse --show-toplevel)"
-
-git diff --check
-nix develop --quiet -c just ci

--- a/justfile
+++ b/justfile
@@ -34,14 +34,14 @@ build:
     cabal build all -O0
 
 # Full CI pipeline
-CI:
+ci:
     #!/usr/bin/env bash
     set -euo pipefail
-    just build
-    just ui-build
-    fourmolu -m check src app
-    hlint src app
-    just ui-lint
+    nix flake check --no-eval-cache
+    cabal build all -O0
+
+# Compatibility alias for the project constitution
+CI: ci
 
 # Run the daemon
 serve *args:

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -1,0 +1,5 @@
+{ pkgs, checks }:
+builtins.mapAttrs (_: app: {
+  type = "app";
+  program = pkgs.lib.getExe app;
+}) checks.apps

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,4 +1,4 @@
-{ pkgs, src, components, uiBuild, uiBundle, uiNodeModules }:
+{ pkgs, src, components, uiBuild, uiBundle, uiNodeModules, }:
 let
   scripts = {
     haskell-build = {
@@ -61,9 +61,131 @@ let
     };
 
     workflow-lint = {
-      runtimeInputs = [ pkgs.actionlint pkgs.shellcheck ];
+      runtimeInputs = [ pkgs.actionlint pkgs.shellcheck pkgs.yq-go ];
       text = ''
         actionlint -config-file .github/actionlint.yaml .github/workflows/*.yml
+
+        workflow=.github/workflows/ci.yml
+
+        assert_eq() {
+          local actual="$1"
+          local expected="$2"
+          local label="$3"
+
+          if [[ "$actual" != "$expected" ]]; then
+            printf 'workflow contract: %s: expected %q, got %q\n' \
+              "$label" "$expected" "$actual" >&2
+            return 1
+          fi
+        }
+
+        assert_command() {
+          local job="$1"
+          local command="$2"
+          local count
+
+          count="$(
+            JOB="$job" COMMAND="$command" yq -r \
+              '[.jobs[env(JOB)].steps[] | select(.run == env(COMMAND))] | length' \
+              "$workflow"
+          )"
+          assert_eq "$count" 1 "$job runs $command"
+        }
+
+        assert_eq \
+          "$(yq -r '.jobs | keys | sort | join(",")' "$workflow")" \
+          'build-darwin,build-gate,cabal-package,dev-shell,formatting,haskell,hlint,ui,workflow-lint' \
+          'exact job IDs'
+
+        while IFS='|' read -r job name runner; do
+          assert_eq \
+            "$(JOB="$job" yq -r '.jobs[env(JOB)].name // ""' "$workflow")" \
+            "$name" "$job name"
+          assert_eq \
+            "$(JOB="$job" yq -r '.jobs[env(JOB)]["runs-on"] // ""' "$workflow")" \
+            "$runner" "$job runner"
+          assert_eq \
+            "$(JOB="$job" yq -r \
+              '[.jobs[env(JOB)].steps[] | select((.uses // "") | test("^actions/checkout@"))] | length' \
+              "$workflow")" \
+            1 "$job checkout action count"
+          assert_eq \
+            "$(JOB="$job" yq -r \
+              '.jobs[env(JOB)].steps[] | select((.uses // "") | test("^actions/checkout@")) | .uses' \
+              "$workflow")" \
+            'actions/checkout@v6' "$job checkout action version"
+
+          if [[ "$runner" == nixos ]]; then
+            assert_eq \
+              "$(JOB="$job" yq -r \
+                '[.jobs[env(JOB)].steps[] | select((.uses // "") | test("^cachix/cachix-action@"))] | length' \
+                "$workflow")" \
+              1 "$job Cachix action count"
+            assert_eq \
+              "$(JOB="$job" yq -r \
+                '.jobs[env(JOB)].steps[] | select((.uses // "") | test("^cachix/cachix-action@")) | .uses' \
+                "$workflow")" \
+              'cachix/cachix-action@v17' "$job Cachix action version"
+          fi
+
+          if [[ "$job" != build-gate && "$runner" == nixos ]]; then
+            assert_eq \
+              "$(JOB="$job" yq -r '.jobs[env(JOB)].needs // ""' "$workflow")" \
+              'build-gate' "$job dependency"
+          fi
+        done <<'JOBS'
+        build-gate|Build Gate|nixos
+        haskell|Haskell build and tests|nixos
+        formatting|Formatting|nixos
+        hlint|HLint|nixos
+        cabal-package|Cabal package validation|nixos
+        ui|PureScript UI|nixos
+        workflow-lint|Workflow lint|nixos
+        dev-shell|Dev shell build|nixos
+        build-darwin|Darwin build|macos-14
+        JOBS
+
+        assert_eq \
+          "$(yq -r '.on | keys | sort | join(",")' "$workflow")" \
+          'pull_request,push' 'workflow triggers'
+        assert_eq \
+          "$(yq -r '.on.push | keys | sort | join(",")' "$workflow")" \
+          'branches' 'push trigger keys'
+        assert_eq \
+          "$(yq -r '.on.push.branches | join(",")' "$workflow")" \
+          'main' 'push branches'
+        assert_eq \
+          "$(yq -r '.on.pull_request | keys | sort | join(",")' "$workflow")" \
+          'branches' 'pull request trigger keys'
+        assert_eq \
+          "$(yq -r '.on.pull_request.branches | join(",")' "$workflow")" \
+          'main' 'pull request branches'
+        assert_eq \
+          "$(yq -r '[.jobs[] | select(has("if"))] | length' "$workflow")" \
+          0 'job-level condition count'
+        assert_eq \
+          "$(yq -r '[.jobs[] | select(has("strategy"))] | length' "$workflow")" \
+          0 'job strategy count'
+        expected_concurrency='$'"{{ github.workflow }}-"'$'"{{ github.ref }}"
+        assert_eq \
+          "$(yq -r '.concurrency.group // ""' "$workflow")" \
+          "$expected_concurrency" 'concurrency group'
+        assert_eq \
+          "$(yq -r '.concurrency["cancel-in-progress"] // false' "$workflow")" \
+          true 'concurrency cancellation'
+
+        assert_command build-gate 'nix flake check --no-eval-cache'
+        assert_command build-gate \
+          'nix build --quiet .#devShells.x86_64-linux.default.inputDerivation'
+        assert_command haskell 'nix run --quiet .#haskell-build'
+        assert_command haskell 'nix run --quiet .#haskell-tests'
+        assert_command formatting 'nix run --quiet .#formatting'
+        assert_command hlint 'nix run --quiet .#hlint'
+        assert_command cabal-package 'nix run --quiet .#cabal-package'
+        assert_command ui 'nix run --quiet .#ui'
+        assert_command workflow-lint 'nix run --quiet .#workflow-lint'
+        assert_command dev-shell \
+          'nix develop --quiet -c cabal build all -O0'
       '';
     };
   };

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,0 +1,99 @@
+{ pkgs, src, components, uiBuild, uiBundle, uiNodeModules }:
+let
+  scripts = {
+    haskell-build = {
+      runtimeInputs = [ components.exes.agent-daemon ];
+      text = ''
+        test -e ${components.library}
+        test -x ${components.exes.agent-daemon}/bin/agent-daemon
+        agent-daemon --help >/dev/null
+      '';
+    };
+
+    haskell-tests = {
+      runtimeInputs = [ components.tests.e2e-tests pkgs.git pkgs.tmux ];
+      text = ''
+        export GIT_CONFIG_COUNT=1
+        export GIT_CONFIG_KEY_0=init.defaultBranch
+        export GIT_CONFIG_VALUE_0=main
+        e2e-tests
+      '';
+    };
+
+    formatting = {
+      runtimeInputs = [
+        pkgs.diffutils
+        pkgs.findutils
+        pkgs.haskellPackages.cabal-fmt
+        pkgs.haskellPackages.fourmolu
+        pkgs.nixfmt-classic
+      ];
+      text = ''
+        diff -u agent-daemon.cabal <(cabal-fmt agent-daemon.cabal)
+        find src app -type f -name '*.hs' -exec fourmolu -m check {} +
+        nixfmt --check flake.nix nix/*.nix
+      '';
+    };
+
+    hlint = {
+      runtimeInputs = [ pkgs.findutils pkgs.haskellPackages.hlint ];
+      text = ''
+        find src app -type f -name '*.hs' -exec hlint {} +
+      '';
+    };
+
+    cabal-package = {
+      runtimeInputs = [ pkgs.cabal-install ];
+      text = ''
+        cabal check
+      '';
+    };
+
+    ui = {
+      runtimeInputs = [ pkgs.purs-tidy-bin.purs-tidy-0_10_0 ];
+      text = ''
+        test -d ${uiNodeModules}/node_modules
+        test -e ${uiBuild}
+        test -s ${uiBundle}/index.html
+        test -s ${uiBundle}/index.js
+        purs-tidy check 'ui/src/**/*.purs'
+      '';
+    };
+
+    workflow-lint = {
+      runtimeInputs = [ pkgs.actionlint pkgs.shellcheck ];
+      text = ''
+        actionlint -config-file .github/actionlint.yaml .github/workflows/*.yml
+      '';
+    };
+  };
+
+  mkApp = name:
+    { runtimeInputs, text }:
+    pkgs.writeShellApplication { inherit name runtimeInputs text; };
+
+  mkCheck = name: spec:
+    let app = mkApp name spec;
+    in pkgs.runCommand name {
+      nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux
+        [ pkgs.glibcLocales ];
+      LANG = "C.UTF-8";
+      LC_ALL = "C.UTF-8";
+    } ''
+      set -euo pipefail
+      cd ${src}
+      ${pkgs.lib.getExe app}
+      touch "$out"
+    '';
+
+  apps = builtins.mapAttrs mkApp scripts;
+in {
+  haskell-build = mkCheck "haskell-build" scripts.haskell-build;
+  haskell-tests = mkCheck "haskell-tests" scripts.haskell-tests;
+  formatting = mkCheck "formatting" scripts.formatting;
+  hlint = mkCheck "hlint" scripts.hlint;
+  cabal-package = mkCheck "cabal-package" scripts.cabal-package;
+  ui = mkCheck "ui" scripts.ui;
+  workflow-lint = mkCheck "workflow-lint" scripts.workflow-lint;
+  inherit apps;
+}

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -11,11 +11,22 @@ let
     };
 
     haskell-tests = {
-      runtimeInputs = [ components.tests.e2e-tests pkgs.git pkgs.tmux ];
+      runtimeInputs = [
+        components.tests.e2e-tests
+        pkgs.bashInteractive
+        pkgs.coreutils
+        pkgs.git
+        pkgs.tmux
+      ];
       text = ''
         export GIT_CONFIG_COUNT=1
         export GIT_CONFIG_KEY_0=init.defaultBranch
         export GIT_CONFIG_VALUE_0=main
+        TMUX_TMPDIR="$(mktemp -d)"
+        export TMUX_TMPDIR
+        trap 'rm -rf "$TMUX_TMPDIR"' EXIT
+        SHELL="${pkgs.bashInteractive}/bin/bash"
+        export SHELL
         e2e-tests
       '';
     };

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,6 +1,6 @@
 { pkgs }:
 let
-  project = pkgs.haskell-nix.cabalProject' {
+  planProject = pkgs.haskell-nix.cabalProject' {
     src = pkgs.haskell-nix.cleanSourceHaskell {
       src = ./..;
       name = "agent-daemon";
@@ -29,6 +29,32 @@ let
         nodejs_22
       ];
     };
+  };
+  indexStateHashes = import pkgs.haskell-nix.indexStateHashesPath;
+  suitableIndexStates =
+    builtins.filter (state: state > planProject.index-state-max)
+    (builtins.attrNames indexStateHashes);
+  cachedIndexState = if suitableIndexStates == [ ] then
+    planProject.index-state-max
+  else
+    pkgs.lib.head suitableIndexStates;
+  indexSha256 = indexStateHashes.${cachedIndexState} or (throw
+    "Unknown Hackage index state ${cachedIndexState}");
+  dotCabal = pkgs.haskell-nix.dotCabal {
+    index-state = cachedIndexState;
+    sha256 = indexSha256;
+    nix-tools = pkgs.haskell-nix.nix-tools-unchecked;
+  };
+  project = planProject.appendModule {
+    shell.shellHook = pkgs.lib.mkAfter ''
+      cabalCacheRoot="''${XDG_CACHE_HOME:-''${HOME:?HOME must be set}/.cache}"
+      export CABAL_DIR="$cabalCacheRoot/agent-daemon/cabal-${cachedIndexState}"
+      if [[ ! -e "$CABAL_DIR/config" ]]; then
+        mkdir -p "$CABAL_DIR"
+        cp -RL ${dotCabal}/. "$CABAL_DIR/"
+        chmod -R u+w "$CABAL_DIR"
+      fi
+    '';
   };
   uiNodeModules = pkgs.importNpmLock.buildNodeModules {
     npmRoot = ./../ui;

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -6,6 +6,7 @@ let
       name = "agent-daemon";
     };
     compiler-nix-name = "ghc984";
+    modules = [{ packages.agent-daemon.flags.development-warnings = true; }];
     shell = { ... }: {
       tools = {
         cabal = { };
@@ -33,18 +34,28 @@ let
     npmRoot = ./../ui;
     nodejs = pkgs.nodejs_22;
   };
+  uiBuild = pkgs.mkSpagoDerivation {
+    pname = "agent-daemon-ui-build";
+    version = "0.1.0";
+    src = ./../ui;
+    spagoYaml = ./../ui/spago.yaml;
+    spagoLock = ./../ui/spago.lock;
+    nativeBuildInputs = [ pkgs.purs pkgs.spago-unstable ];
+    buildPhase = ''
+      spago build --offline
+    '';
+    installPhase = ''
+      touch $out
+    '';
+  };
   static = pkgs.mkSpagoDerivation {
     pname = "agent-daemon-static";
     version = "0.1.0";
     src = ./../ui;
     spagoYaml = ./../ui/spago.yaml;
     spagoLock = ./../ui/spago.lock;
-    nativeBuildInputs = [
-      pkgs.purs
-      pkgs.spago-unstable
-      pkgs.esbuild
-      pkgs.nodejs_22
-    ];
+    nativeBuildInputs =
+      [ pkgs.purs pkgs.spago-unstable pkgs.esbuild pkgs.nodejs_22 ];
     buildPhase = ''
       ln -s ${uiNodeModules}/node_modules node_modules
       mkdir -p dist/fonts
@@ -67,9 +78,10 @@ let
     '';
   };
 in {
+  components = project.hsPkgs.agent-daemon.components;
   packages = {
     main = project.hsPkgs.agent-daemon.components.exes.agent-daemon;
-    inherit static;
+    inherit static uiBuild uiNodeModules;
   };
   devShells.default = project.shell;
 }

--- a/specs/077-authoritative-nix-ci/checklists/requirements.md
+++ b/specs/077-authoritative-nix-ci/checklists/requirements.md
@@ -1,7 +1,7 @@
 # Specification Quality Checklist: Authoritative Nix and CI Quality Contract
 
-**Purpose**: Validate specification completeness and quality before planning  
-**Created**: 2026-07-10  
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2026-07-10
 **Feature**: [spec.md](../spec.md)
 
 ## Content Quality

--- a/specs/077-authoritative-nix-ci/checklists/requirements.md
+++ b/specs/077-authoritative-nix-ci/checklists/requirements.md
@@ -1,0 +1,33 @@
+# Specification Quality Checklist: Authoritative Nix and CI Quality Contract
+
+**Purpose**: Validate specification completeness and quality before planning  
+**Created**: 2026-07-10  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] User value and maintainer/reviewer outcomes are explicit.
+- [x] All mandatory sections are complete.
+- [x] Technical command and job names appear only where they are public acceptance surfaces for this automation ticket.
+
+## Requirement Completeness
+
+- [x] No `[NEEDS CLARIFICATION]` markers remain.
+- [x] Requirements are testable and unambiguous.
+- [x] Success criteria are measurable.
+- [x] All acceptance scenarios are defined.
+- [x] Edge cases are identified.
+- [x] Scope is clearly bounded.
+- [x] Dependencies and assumptions are identified.
+
+## Feature Readiness
+
+- [x] Every functional requirement has a corresponding acceptance scenario or measurable outcome.
+- [x] User scenarios cover contributor, reviewer, and maintainer flows.
+- [x] The feature has measurable completion signals for local, pull-request, and ruleset surfaces.
+- [x] No application-design details leak into this repository-quality specification.
+
+## Notes
+
+- The ticket itself defines commands, job names, runner labels, and ruleset contexts as user-visible interfaces; omitting those names would make acceptance non-verifiable.
+- The structured clarification scan found no unresolved decision requiring a parent Q-file before planning.

--- a/specs/077-authoritative-nix-ci/contracts/quality-contract.md
+++ b/specs/077-authoritative-nix-ci/contracts/quality-contract.md
@@ -1,0 +1,30 @@
+# Executable Quality Contract
+
+## Local and flake surfaces
+
+| Surface | Flake check/app | Required evidence |
+|---|---|---|
+| Haskell build | `haskell-build` | Existing library/executable builds and executable smoke succeeds |
+| Haskell tests | `haskell-tests` | 55 examples, 0 failures |
+| Formatting | `formatting` | Fourmolu, Cabal formatting, and Nix formatting checks succeed |
+| HLint | `hlint` | Zero HLint findings |
+| Cabal package | `cabal-package` | `cabal check` emits no warnings/errors |
+| PureScript UI | `ui` | Lockfile install realization, lint, build, and bundle outputs succeed |
+| Workflow lint | `workflow-lint` | All workflow actionlint/shellcheck and structural CI assertions succeed |
+| Canonical local gate | `nix develop --quiet -c just ci` | All flake checks plus real dev-shell `cabal build all -O0` succeed |
+
+## GitHub Actions contexts
+
+| Job ID | Required context | Runner | Orchestration command |
+|---|---|---|---|
+| `build-gate` | `Build Gate` | `nixos` | Realize all Linux checks/apps and dev-shell input derivation |
+| `haskell` | `Haskell build and tests` | `nixos` | Run `haskell-build` and `haskell-tests` apps |
+| `formatting` | `Formatting` | `nixos` | Run `formatting` app |
+| `hlint` | `HLint` | `nixos` | Run `hlint` app |
+| `cabal-package` | `Cabal package validation` | `nixos` | Run `cabal-package` app |
+| `ui` | `PureScript UI` | `nixos` | Run `ui` app |
+| `workflow-lint` | `Workflow lint` | `nixos` | Run `workflow-lint` app |
+| `dev-shell` | `Dev shell build` | `nixos` | `nix develop --quiet -c cabal build all -O0` |
+| `build-darwin` | `Darwin build` | `macos-14` | Retained `nix build` platform verification |
+
+The ruleset context set equals the second column exactly. Pages and manual release workflows are excluded because they are not always-present pull-request gates.

--- a/specs/077-authoritative-nix-ci/data-model.md
+++ b/specs/077-authoritative-nix-ci/data-model.md
@@ -1,0 +1,35 @@
+# Quality Contract Model
+
+This ticket changes no application data. The relevant entities are repository-quality contract records.
+
+## Quality Surface
+
+- **Name**: Stable focused identifier such as `formatting` or `ui`.
+- **App**: Strict-path executable used for focused local/CI execution.
+- **Check**: Sandboxed derivation that invokes the same app.
+- **Evidence**: Exit status plus surface-specific output, such as 55 examples and 0 failures.
+
+## CI Job
+
+- **Job ID**: Internal workflow identifier.
+- **Context name**: Stable human-visible name reported to GitHub.
+- **Runner**: `nixos` for Linux or macOS 14 for Darwin.
+- **Dependency**: Linux substantive jobs depend on `build-gate`.
+- **Command**: Focused flake app, representative dev-shell build, or retained Darwin build.
+- **Presence rule**: Unconditional on every pull request to `main`.
+
+## Ruleset Contract
+
+- **Ruleset ID**: `13867328`.
+- **Required contexts**: Exact set of nine observed CI context names.
+- **Strict policy**: Preserve the existing value unless the ticket explicitly requires otherwise.
+- **Bypass actor**: ID `5`, type `RepositoryRole`, mode `always`.
+
+## State Transitions
+
+1. Baseline quality surface is missing, wrapper-only, or failing.
+2. Focused RED evidence proves the new check can reject a representative defect.
+3. Focused GREEN and full local gate prove the restored contract.
+4. Draft PR reports all stable jobs successfully.
+5. Ruleset required contexts are replaced with the observed exact set.
+6. Final gate/audit pass and the PR moves from draft to ready.

--- a/specs/077-authoritative-nix-ci/plan.md
+++ b/specs/077-authoritative-nix-ci/plan.md
@@ -71,7 +71,7 @@ Ruleset mutation is deferred until GitHub reports the exact final job names on p
 - **Slice 2 RED**: Extend the workflow-lint surface with structural assertions for the nine job names, prescribed runners, dependency on Build Gate, and focused commands; run it against the old CI workflow and observe failure.
 - **Slice 2 GREEN**: Replace the CI orchestration, rerun the workflow-lint surface and full `./gate.sh`, then commit only after navigator approval.
 - **Slice 2a hosted RED**: Preserve the first hosted run's logs showing a clean runner with no Hackage index and six tmux-backed failures after the inherited server disappears. Reproduce the Cabal failure with fresh user state; do not change test semantics or job names.
-- **Slice 2a GREEN**: Make the haskell.nix shell use exact Nix-provided dependencies and give the test app a private tmux socket root plus a packaged interactive shell. Re-run the fresh-state Cabal build, all 55 tests, workflow contract, and full gate before navigator approval.
+- **Slice 2a GREEN**: Make the haskell.nix shell provision a writable copy of the package index pinned to its project plan and give the test app a private tmux socket root plus a packaged interactive shell. Re-run the fresh-state Cabal build, all 55 tests, workflow contract, and full gate before navigator approval.
 
 ## Bisect-Safe Slice Plan
 
@@ -91,7 +91,7 @@ Add the failing structural workflow contract, then make the workflow satisfy it 
 
 **Owned files**: `nix/project.nix`, `nix/checks.nix`.
 
-Use hosted RED evidence to remove mutable host dependencies without changing the nine-job workflow: exact haskell.nix shell dependencies make a clean Cabal invocation deterministic, while a private tmux socket root and known shell isolate the existing 55-example test app. Commit subject: `fix(ci): isolate hosted runner verification`.
+Use hosted RED evidence to remove mutable host dependencies without changing the nine-job workflow: a writable package index derived from the haskell.nix plan makes a clean Cabal invocation deterministic, while a private tmux socket root and known shell isolate the existing 55-example test app. Commit subject: `fix(ci): isolate hosted runner verification`.
 
 ### Slice 3 — Orchestrator-owned finalization
 

--- a/specs/077-authoritative-nix-ci/plan.md
+++ b/specs/077-authoritative-nix-ci/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Authoritative Nix and CI Quality Contract
+
+**Branch**: `ci/make-nix-checks-and-ci-authoritative` | **Date**: 2026-07-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/077-authoritative-nix-ci/spec.md`
+
+## Summary
+
+Refactor the flake so each verification surface has one strict-path executable used by both a real sandboxed check and a matching local app. Make lowercase `just ci` invoke the complete flake gate plus a representative build from the real development shell. Rebuild GitHub Actions as an orchestration layer over those outputs, retain the existing Darwin build, then update main ruleset `13867328` from the job names observed on pull request #81.
+
+## Technical Context
+
+**Language/Version**: Nix; Cabal 3.0 metadata; Haskell on existing GHC 9.8.4; PureScript registry 72.1.0; GitHub Actions YAML  
+**Primary Dependencies**: haskell.nix, `writeShellApplication`, `runCommand`, `mkSpagoDerivation`, actionlint, shellcheck, `just`, Cachix  
+**Storage**: N/A; repository files, Nix store outputs, and GitHub ruleset metadata only  
+**Testing**: Nix sandbox checks/apps, Cabal build/check/test, fourmolu, cabal-fmt, HLint, purs-tidy, Spago, esbuild, actionlint/shellcheck, guarded PR check snapshots  
+**Target Platform**: Linux `x86_64-linux` on self-hosted `nixos`; retained `aarch64-darwin` build on macOS 14  
+**Project Type**: Haskell daemon with a bundled PureScript SPA and Nix-first CI  
+**Performance Goals**: One cache-warming Build Gate realizes shared closures before downstream Linux jobs; no new application runtime work  
+**Constraints**: No application/test-semantics/GHC/release/docs behavior change; real sandbox execution; stable always-present job names; preserve ruleset bypass actor `5`  
+**Scale/Scope**: Seven focused flake check/app surfaces, nine PR job contexts, one ruleset update
+
+## Constitution Check
+
+*GATE: Passed before design and re-checked after slice decomposition.*
+
+- **Type-Safe API**: No endpoint or API type changes.
+- **Haskell-First**: Existing GHC remains fixed; Nix and Cabal remain authoritative. Strict warnings remain enabled through an explicit development flag.
+- **Separation of Concerns**: No domain or API source changes.
+- **WebSocket as First-Class**: The existing 55-example suite, including terminal relay coverage, remains mandatory.
+- **CORS Stays as Middleware**: No CORS behavior changes.
+- **Quality Gates**: Lowercase `just ci` becomes canonical; uppercase `just CI` remains an alias so the ratified constitution command continues to pass.
+
+No constitution violation or complexity exception is required.
+
+## Architecture
+
+### Check/app construction
+
+`nix/checks.nix` owns one script specification per focused surface. Each specification declares all runtime binaries and one script body. `mkApp` creates a strict-path `writeShellApplication`; `mkCheck` runs that exact app from the flake source inside `runCommand`, supplies a UTF-8 locale where needed, and produces `$out` only after success. `nix/apps.nix` exposes the same app objects under `apps.<system>`.
+
+The public Linux check/app names are:
+
+1. `haskell-build`
+2. `haskell-tests`
+3. `formatting`
+4. `hlint`
+5. `cabal-package`
+6. `ui`
+7. `workflow-lint`
+
+The Haskell test app executes the built `e2e-tests` component and must report all 55 examples. The UI surface realizes lockfile-derived Node modules and exercises lint/build/bundle outputs without runtime network access. The workflow surface runs repository-wide actionlint/shellcheck and, in slice 2, asserts the stable job-name/runner/orchestration contract.
+
+### Cabal warning policy
+
+`agent-daemon.cabal` declares a manual, default-off `development-warnings` flag. Existing warning options remain intact, while `-Werror` is conditional on that flag. `nix/project.nix` explicitly enables the flag for Nix development/CI surfaces. `cabal.project` changes only if a fresh `cabal check` after this correction exposes a concrete source-repository warning; the current baseline already contains the pinned stanza.
+
+### Local gate
+
+The root `justfile` provides lowercase `ci` as the canonical recipe. It runs `nix flake check --no-eval-cache` and a representative `cabal build all -O0` in the development shell entered by `gate.sh`. Uppercase `CI` delegates to lowercase `ci`. Focused existing recipes remain available for debugging.
+
+### CI and ruleset
+
+`.github/workflows/ci.yml` keeps all pull-request jobs unconditional and stable. `Build Gate` realizes the Linux flake checks/apps and development-shell input derivation to warm the shared Nix store. Dependent Linux jobs call focused `nix run .#<name>` apps, except `Dev shell build`, which must separately enter `nix develop` and run `cabal build all -O0`. `Darwin build` retains the current macOS platform exception.
+
+Ruleset mutation is deferred until GitHub reports the exact final job names on pull request #81. Its required contexts then become exactly the nine names in [contracts/quality-contract.md](./contracts/quality-contract.md), while bypass actor `5` remains unchanged.
+
+## RED → GREEN Strategy
+
+- **Slice 1 RED**: Add the executable formatting check first, introduce a temporary Cabal formatting defect, and observe the focused check exit non-zero. Record the diff and failure before restoring the file. The existing invalid dev-shell evaluation and `cabal check` failures are supporting baseline evidence, not substitutes for this deliberate negative test.
+- **Slice 1 GREEN**: Restore the Cabal file, complete all seven check/app surfaces and warning policy, then run the focused check, `cabal check`, all 55 tests, actionlint, and `./gate.sh` successfully.
+- **Slice 2 RED**: Extend the workflow-lint surface with structural assertions for the nine job names, prescribed runners, dependency on Build Gate, and focused commands; run it against the old CI workflow and observe failure.
+- **Slice 2 GREEN**: Replace the CI orchestration, rerun the workflow-lint surface and full `./gate.sh`, then commit only after navigator approval.
+
+## Bisect-Safe Slice Plan
+
+### Slice 1 — Authoritative local and flake contract
+
+**Owned files**: `flake.nix`, `nix/project.nix`, `nix/checks.nix`, `nix/apps.nix`, `justfile`, `agent-daemon.cabal`, `cabal.project`, `.github/actionlint.yaml`, `.github/workflows/darwin-release.yml`.
+
+Deliver real checks/apps, the manual development-warning flag, lowercase local gate/uppercase alias, actionlint runner configuration, and minimal Darwin lint corrections. No CI orchestration rewrite lands here. Commit subject: `ci: make Nix checks authoritative`.
+
+### Slice 2 — Stable GitHub Actions orchestration
+
+**Owned files**: `nix/checks.nix`, `.github/workflows/ci.yml`.
+
+Add the failing structural workflow contract, then make the workflow satisfy it with the Build Gate and eight stable dependent jobs. Commit subject: `ci: align GitHub Actions with flake checks`.
+
+### Slice 3 — Orchestrator-owned finalization
+
+**Owned surfaces**: pull request #81 metadata/checks, `specs/077-authoritative-nix-ci/tasks.md`, ruleset `13867328`, temporary `gate.sh`.
+
+The ticket owner independently reruns the full local gate, verifies all PR contexts and conclusions, updates the ruleset without changing bypass actor `5`, completes task accounting and PR body evidence (including parent epic #80), runs the finalization audit, drops `gate.sh`, pushes, and marks the PR ready. No worker modifies GitHub metadata or pushes.
+
+## Project Structure
+
+```text
+flake.nix
+nix/
+├── project.nix
+├── checks.nix
+└── apps.nix
+justfile
+agent-daemon.cabal
+cabal.project
+.github/
+├── actionlint.yaml
+└── workflows/
+    ├── ci.yml
+    ├── darwin-release.yml
+    └── pages.yml
+specs/077-authoritative-nix-ci/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/quality-contract.md
+├── checklists/requirements.md
+└── tasks.md
+```
+
+**Structure Decision**: Keep `flake.nix` thin; place executable check definitions and app projections in `nix/`. Confine all ticket planning artifacts to the issue-specific specs directory.
+
+## Complexity Tracking
+
+No justified violations.

--- a/specs/077-authoritative-nix-ci/plan.md
+++ b/specs/077-authoritative-nix-ci/plan.md
@@ -9,14 +9,14 @@ Refactor the flake so each verification surface has one strict-path executable u
 
 ## Technical Context
 
-**Language/Version**: Nix; Cabal 3.0 metadata; Haskell on existing GHC 9.8.4; PureScript registry 72.1.0; GitHub Actions YAML  
-**Primary Dependencies**: haskell.nix, `writeShellApplication`, `runCommand`, `mkSpagoDerivation`, actionlint, shellcheck, `just`, Cachix  
-**Storage**: N/A; repository files, Nix store outputs, and GitHub ruleset metadata only  
-**Testing**: Nix sandbox checks/apps, Cabal build/check/test, fourmolu, cabal-fmt, HLint, purs-tidy, Spago, esbuild, actionlint/shellcheck, guarded PR check snapshots  
-**Target Platform**: Linux `x86_64-linux` on self-hosted `nixos`; retained `aarch64-darwin` build on macOS 14  
-**Project Type**: Haskell daemon with a bundled PureScript SPA and Nix-first CI  
-**Performance Goals**: One cache-warming Build Gate realizes shared closures before downstream Linux jobs; no new application runtime work  
-**Constraints**: No application/test-semantics/GHC/release/docs behavior change; real sandbox execution; stable always-present job names; preserve ruleset bypass actor `5`  
+**Language/Version**: Nix; Cabal 3.0 metadata; Haskell on existing GHC 9.8.4; PureScript registry 72.1.0; GitHub Actions YAML
+**Primary Dependencies**: haskell.nix, `writeShellApplication`, `runCommand`, `mkSpagoDerivation`, actionlint, shellcheck, `just`, Cachix
+**Storage**: N/A; repository files, Nix store outputs, and GitHub ruleset metadata only
+**Testing**: Nix sandbox checks/apps, Cabal build/check/test, fourmolu, cabal-fmt, HLint, purs-tidy, Spago, esbuild, actionlint/shellcheck, guarded PR check snapshots
+**Target Platform**: Linux `x86_64-linux` on self-hosted `nixos`; retained `aarch64-darwin` build on macOS 14
+**Project Type**: Haskell daemon with a bundled PureScript SPA and Nix-first CI
+**Performance Goals**: One cache-warming Build Gate realizes shared closures before downstream Linux jobs; no new application runtime work
+**Constraints**: No application/test-semantics/GHC/release/docs behavior change; real sandbox execution; stable always-present job names; preserve ruleset bypass actor `5`
 **Scale/Scope**: Seven focused flake check/app surfaces, nine PR job contexts, one ruleset update
 
 ## Constitution Check

--- a/specs/077-authoritative-nix-ci/plan.md
+++ b/specs/077-authoritative-nix-ci/plan.md
@@ -70,6 +70,8 @@ Ruleset mutation is deferred until GitHub reports the exact final job names on p
 - **Slice 1 GREEN**: Restore the Cabal file, complete all seven check/app surfaces and warning policy, then run the focused check, `cabal check`, all 55 tests, actionlint, and `./gate.sh` successfully.
 - **Slice 2 RED**: Extend the workflow-lint surface with structural assertions for the nine job names, prescribed runners, dependency on Build Gate, and focused commands; run it against the old CI workflow and observe failure.
 - **Slice 2 GREEN**: Replace the CI orchestration, rerun the workflow-lint surface and full `./gate.sh`, then commit only after navigator approval.
+- **Slice 2a hosted RED**: Preserve the first hosted run's logs showing a clean runner with no Hackage index and six tmux-backed failures after the inherited server disappears. Reproduce the Cabal failure with fresh user state; do not change test semantics or job names.
+- **Slice 2a GREEN**: Make the haskell.nix shell use exact Nix-provided dependencies and give the test app a private tmux socket root plus a packaged interactive shell. Re-run the fresh-state Cabal build, all 55 tests, workflow contract, and full gate before navigator approval.
 
 ## Bisect-Safe Slice Plan
 
@@ -85,11 +87,17 @@ Deliver real checks/apps, the manual development-warning flag, lowercase local g
 
 Add the failing structural workflow contract, then make the workflow satisfy it with the Build Gate and eight stable dependent jobs. Commit subject: `ci: align GitHub Actions with flake checks`.
 
+### Slice 2a — Hosted runner isolation correction
+
+**Owned files**: `nix/project.nix`, `nix/checks.nix`.
+
+Use hosted RED evidence to remove mutable host dependencies without changing the nine-job workflow: exact haskell.nix shell dependencies make a clean Cabal invocation deterministic, while a private tmux socket root and known shell isolate the existing 55-example test app. Commit subject: `fix(ci): isolate hosted runner verification`.
+
 ### Slice 3 — Orchestrator-owned finalization
 
 **Owned surfaces**: pull request #81 metadata/checks, `specs/077-authoritative-nix-ci/tasks.md`, ruleset `13867328`, temporary `gate.sh`.
 
-The ticket owner independently reruns the full local gate, verifies all PR contexts and conclusions, updates the ruleset without changing bypass actor `5`, completes task accounting and PR body evidence (including parent epic #80), runs the finalization audit, drops `gate.sh`, pushes, and marks the PR ready. No worker modifies GitHub metadata or pushes.
+The ticket owner independently reruns the full local gate, verifies all PR contexts and conclusions after the hosted correction, updates the ruleset without changing bypass actor `5`, completes task accounting and PR body evidence (including parent epic #80), runs the finalization audit, drops `gate.sh`, pushes, and marks the PR ready. No worker modifies GitHub metadata or pushes.
 
 ## Project Structure
 

--- a/specs/077-authoritative-nix-ci/quickstart.md
+++ b/specs/077-authoritative-nix-ci/quickstart.md
@@ -1,0 +1,34 @@
+# Verification Quickstart
+
+## Focused local checks
+
+```bash
+nix run --quiet .#haskell-build
+nix run --quiet .#haskell-tests
+nix run --quiet .#formatting
+nix run --quiet .#hlint
+nix run --quiet .#cabal-package
+nix run --quiet .#ui
+nix run --quiet .#workflow-lint
+```
+
+## Complete local contract
+
+```bash
+nix flake check --no-eval-cache
+nix develop --quiet -c just ci
+```
+
+Expected Haskell evidence: `55 examples, 0 failures`.
+
+## Pull-request contract
+
+Inspect pull request #81 and verify every context in `contracts/quality-contract.md` is present and successful. Do not update the ruleset before all names have been observed.
+
+## Ruleset contract
+
+```bash
+gh api repos/lambdasistemi/tmux-ws/rulesets/13867328
+```
+
+Verify the exact required-context set and repository-role bypass actor `5` after the final update.

--- a/specs/077-authoritative-nix-ci/research.md
+++ b/specs/077-authoritative-nix-ci/research.md
@@ -1,0 +1,58 @@
+# Research: Authoritative Nix and CI Quality Contract
+
+## Decision 1: One script body, two flake projections
+
+**Decision**: Define each verification script once, build it as a strict-path app, and have a sandboxed `runCommand` check invoke that exact app.
+
+**Rationale**: Exposing a `writeShellApplication` directly as a check only builds the wrapper. Invoking the app from `runCommand` proves the command executes and catches missing runtime inputs.
+
+**Alternatives considered**: Duplicating commands in checks/apps; keeping wrapper-shaped checks and compensating in CI. Both permit local/CI drift.
+
+## Decision 2: Separate dev-shell proof
+
+**Decision**: Keep a named `Dev shell build` job that runs `nix develop --quiet -c cabal build all -O0`, in addition to packaged flake checks.
+
+**Rationale**: Packaged derivations never enter the development shell and cannot prove its package database, tool set, or environment works.
+
+**Alternatives considered**: `nix develop -c true`, which does not exercise Cabal configuration; relying only on `nix flake check`, which proves a different surface.
+
+## Decision 3: Conditional warning-as-error policy
+
+**Decision**: Put only `-Werror` behind manual flag `development-warnings`, default it off for package portability, and explicitly enable it in Nix development/CI.
+
+**Rationale**: This satisfies `cabal check` without weakening strict repository development.
+
+**Alternatives considered**: Removing `-Werror`; leaving it unconditional and ignoring `cabal check`. Both violate the acceptance contract.
+
+## Decision 4: Repository-wide workflow validation
+
+**Decision**: Configure actionlint with custom runner label `nixos`, validate every workflow, and make only shellcheck-driven behavior-neutral fixes outside `ci.yml`.
+
+**Rationale**: The baseline reports eight real findings across three workflows, while issue #78 and #79 own behavior changes to release and docs workflows.
+
+**Alternatives considered**: Lint only `ci.yml`; disable shellcheck; redesign release/docs workflows. Each either weakens the contract or crosses ownership boundaries.
+
+## Decision 5: Exact merge contexts
+
+**Decision**: Require `Build Gate`, `Haskell build and tests`, `Formatting`, `HLint`, `Cabal package validation`, `PureScript UI`, `Workflow lint`, `Dev shell build`, and `Darwin build`.
+
+**Rationale**: These jobs are unconditional on pull requests, cover each acceptance surface, retain the current platform check, and can be observed before ruleset mutation.
+
+**Alternatives considered**: Require only an aggregate `build`; omit Build Gate; include Pages or manual release contexts. Those choices either hide evidence or introduce missing/conditional contexts.
+
+## Decision 6: Preserve uppercase compatibility
+
+**Decision**: Keep `just CI` as an alias to lowercase `just ci`.
+
+**Rationale**: Issue #77 requires lowercase while the current ratified constitution still names uppercase. The alias satisfies both without entering #79 governance scope.
+
+**Alternatives considered**: Delete uppercase now; update the constitution in this ticket. Both violate an existing contract or a sibling boundary.
+
+## Baseline evidence reconciliation
+
+- Flake evaluation reproduced the invalid `haskell-project-plan-to-nix-pkgs.drv` store-path failure.
+- `cabal check` reproduced the unconditional `-Werror` rejection.
+- The Haskell suite reproduced 55 examples with 0 failures.
+- The current `cabal.project` already contains a pinned source-repository stanza; the audit's missing-stanza warning did not reproduce and does not justify an edit by itself.
+- Actionlint reproduced eight findings: three unknown `nixos` labels and five Darwin workflow shellcheck findings.
+- Ruleset `13867328` currently requires only `build` and retains repository-role bypass actor `5`.

--- a/specs/077-authoritative-nix-ci/spec.md
+++ b/specs/077-authoritative-nix-ci/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Authoritative Nix and CI Quality Contract
+
+**Feature Branch**: `ci/make-nix-checks-and-ci-authoritative`  
+**Created**: 2026-07-10  
+**Status**: Draft  
+**Input**: GitHub issue #77, child of epic #80
+
+## Clarifications
+
+### Session 2026-07-10
+
+- Q: Which layer owns executable verification? → A: The Nix flake owns executable checks and focused apps; local commands and workflows orchestrate those outputs.
+- Q: How are strict warnings reconciled with package validation? → A: Warning-as-error behavior is opt-in through a manual development-warning flag enabled by Nix development and CI surfaces.
+- Q: Which PR job names form the merge contract? → A: `Build Gate`, `Haskell build and tests`, `Formatting`, `HLint`, `Cabal package validation`, `PureScript UI`, `Workflow lint`, `Dev shell build`, and `Darwin build`.
+
+## User Scenarios & Testing
+
+### User Story 1 - Run One Complete Local Gate (Priority: P1)
+
+As a contributor, I run one lowercase `just ci` command and receive a trustworthy result for every shippable repository surface before I push.
+
+**Why this priority**: A complete local gate is the fastest feedback path and prevents GitHub Actions from becoming the first place ordinary failures are discovered.
+
+**Independent Test**: From a clean checkout, run `nix develop --quiet -c just ci`; it exits successfully, reports all 55 existing Haskell examples with zero failures, and exercises each declared quality surface.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean checkout, **When** the contributor runs the lowercase local gate, **Then** Haskell build/tests, formatting, HLint, package validation, PureScript install/lint/build/bundle, workflow lint, and a representative development-shell build all succeed.
+2. **Given** a deliberate formatting defect, **When** the representative flake check runs, **Then** it exits non-zero; after the defect is restored, the same check and full local gate exit zero.
+3. **Given** the existing Haskell suite, **When** the test surface runs, **Then** all 55 examples execute and report zero failures rather than only compiling a wrapper.
+
+---
+
+### User Story 2 - Review Stable, Always-Present CI Gates (Priority: P1)
+
+As a reviewer, I see stable, always-present pull-request checks whose names and results map directly to the local quality contract.
+
+**Why this priority**: Reviewers need unambiguous merge evidence, and ruleset contexts are safe only when the jobs are present on every pull request.
+
+**Independent Test**: Open or update the draft pull request and verify all nine named jobs appear; each substantive Linux job invokes the flake-owned surface or the separate representative development-shell build and finishes successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** any pull request to `main`, **When** CI starts, **Then** `Build Gate` warms the shared Nix store before the dependent Linux jobs run.
+2. **Given** the cache-warming job succeeds, **When** dependent jobs run, **Then** the Haskell, formatting, HLint, package, UI, workflow, and development-shell job names remain stable and always present.
+3. **Given** multi-platform verification, **When** CI runs, **Then** Linux jobs use `nixos` and `Darwin build` remains on the prescribed macOS runner.
+
+---
+
+### User Story 3 - Protect Main with the Observed CI Contract (Priority: P2)
+
+As a maintainer, I configure the main ruleset from observed pull-request job names without losing the documented admin bypass.
+
+**Why this priority**: Correct checks are not merge gates until the ruleset requires their exact, always-present contexts.
+
+**Independent Test**: After all jobs are observed on the pull request, inspect ruleset `13867328`; its required contexts equal the nine names in this specification and its only documented bypass remains repository role actor `5` in `always` mode.
+
+**Acceptance Scenarios**:
+
+1. **Given** green pull-request checks, **When** the main ruleset is updated, **Then** it requires exactly the nine observed job contexts and no conditional or manual-only workflow context.
+2. **Given** the pre-existing admin bypass, **When** the ruleset update is complete, **Then** actor `5`, type `RepositoryRole`, mode `always` is unchanged.
+
+### Edge Cases
+
+- A flake output that only builds a shell wrapper is not counted as executable verification; the check must run its underlying command in a sandbox.
+- Packaged checks do not prove the development shell works; the development-shell build remains a separate gate.
+- The `nixos` custom runner label must be declared to workflow linting without weakening validation of other runner labels.
+- Existing release and Pages workflows may receive only behavior-neutral lint corrections; their triggers and publication behavior remain unchanged.
+- CI jobs must not disappear through path filters, event conditions, matrix exclusions, or job-level conditions on pull requests.
+- The baseline audit's alleged missing source-repository stanza was not reproduced: the current `cabal.project` already contains the pinned stanza, so no edit is justified unless fresh validation exposes a concrete warning.
+- The existing uppercase `just CI` constitution command remains as a compatibility alias while lowercase `just ci` becomes the canonical contributor entrypoint.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The flake MUST expose real sandboxed checks and matching focused apps for Haskell build/tests, formatting, HLint, Cabal package validation, PureScript UI verification, and workflow linting.
+- **FR-002**: Each scripted flake check MUST invoke the same strict-path executable exposed as its matching app; building a script without executing it is insufficient.
+- **FR-003**: The Haskell test surface MUST execute all 55 existing examples and report their result.
+- **FR-004**: The Cabal package MUST move `-Werror` behind a manual, default-off development-warning flag, and the Nix development/CI configuration MUST explicitly enable that flag.
+- **FR-005**: `nix develop --quiet -c cabal check` MUST report no warnings or errors after the package change.
+- **FR-006**: Lowercase `just ci` MUST be the canonical local entrypoint and MUST cover the flake-owned checks plus `cabal build all -O0` inside the real development shell.
+- **FR-007**: Uppercase `just CI` MUST remain a compatibility alias to the lowercase entrypoint so the current constitution remains satisfied.
+- **FR-008**: Workflow linting MUST recognize the `nixos` custom runner and MUST validate every committed workflow with actionlint and shellcheck.
+- **FR-009**: Any changes outside `.github/workflows/ci.yml` MUST be minimal lint-only corrections that do not alter release or documentation behavior.
+- **FR-010**: The CI workflow MUST start with `Build Gate` and MUST expose the exact always-present job names `Haskell build and tests`, `Formatting`, `HLint`, `Cabal package validation`, `PureScript UI`, `Workflow lint`, `Dev shell build`, and `Darwin build`.
+- **FR-011**: Every Linux CI job MUST run on `nixos`; `Darwin build` MUST remain on the prescribed macOS runner.
+- **FR-012**: Substantive CI jobs MUST orchestrate flake-owned apps rather than duplicate their shell logic; `Dev shell build` MUST separately run a representative `nix develop` build.
+- **FR-013**: Ruleset `13867328` MUST require exactly the nine job contexts named in FR-010, including `Build Gate`.
+- **FR-014**: Ruleset `13867328` MUST retain bypass actor `5` with actor type `RepositoryRole` and bypass mode `always`.
+- **FR-015**: The implementation MUST include observed RED evidence from a deliberate representative defect followed by GREEN evidence from the restored full gate.
+- **FR-016**: The ticket MUST NOT change application/API/terminal/WebSocket/session/UI behavior, test semantics, GHC version, release publication, documentation behavior, or historical tags/releases.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: `nix flake check --no-eval-cache` exits `0` and executes every declared flake check.
+- **SC-002**: `nix develop --quiet -c just ci` exits `0` from a clean worktree after exercising every local contract surface.
+- **SC-003**: The Haskell test output reports exactly 55 examples and 0 failures.
+- **SC-004**: `nix develop --quiet -c cabal check` exits `0` with no warnings or errors.
+- **SC-005**: Repository-wide actionlint/shellcheck validation exits `0` with zero findings across every committed workflow.
+- **SC-006**: Pull request #81 shows all nine named jobs and each concludes successfully.
+- **SC-007**: Ruleset `13867328` contains exactly nine required contexts matching the observed PR job names and retains exactly the documented admin-role bypass.
+- **SC-008**: A deliberate representative defect causes its focused check to exit non-zero before restoration; the restored focused check and final full gate both exit `0`.
+
+## Assumptions
+
+- The existing branch and worktree remain based on the current `origin/main`; no duplicate worktree is needed.
+- Current GHC 9.8.4 and all application/test sources remain unchanged.
+- The pinned source-repository package in `cabal.project` remains valid unless fresh package validation provides contrary evidence.
+- Self-hosted `nixos` runners share a Nix store, so the Build Gate remains useful as a cache warmer even though checks are independently executable.
+- Main ruleset mutation occurs only after GitHub has reported the final always-present job names on pull request #81.

--- a/specs/077-authoritative-nix-ci/spec.md
+++ b/specs/077-authoritative-nix-ci/spec.md
@@ -1,8 +1,8 @@
 # Feature Specification: Authoritative Nix and CI Quality Contract
 
-**Feature Branch**: `ci/make-nix-checks-and-ci-authoritative`  
-**Created**: 2026-07-10  
-**Status**: Draft  
+**Feature Branch**: `ci/make-nix-checks-and-ci-authoritative`
+**Created**: 2026-07-10
+**Status**: Draft
 **Input**: GitHub issue #77, child of epic #80
 
 ## Clarifications

--- a/specs/077-authoritative-nix-ci/tasks.md
+++ b/specs/077-authoritative-nix-ci/tasks.md
@@ -49,6 +49,27 @@
 
 ---
 
+## Slice 2a: Hosted Runner Isolation Correction
+
+**Goal**: Preserve the exact CI orchestration while removing the two host-state leaks exposed by the first hosted run: Cabal's empty user package index and tmux's inherited runner socket/shell state.
+
+**Independent Test**: With fresh XDG/Cabal state, `nix develop --quiet -c cabal build all -O0` succeeds from Nix-provided exact dependencies; the Haskell app uses a private tmux socket root and known interactive shell and reports 55 examples with 0 failures; the focused workflow contract and full gate remain green.
+
+**Owned files**: `nix/project.nix`, `nix/checks.nix`, ignored `WIP.md`.
+
+**Forbidden scope**: Application, test, or UI source; workflow job names/commands/runners; Cabal metadata; other Nix files; other workflows; specs, `gate.sh`, PR metadata, and ruleset state.
+
+- [ ] T011 [US1] Record the hosted RED evidence from PR #81: six tmux-backed examples fail after the inherited tmux server disappears, and a clean runner cannot resolve `servant-server` without a user Hackage index.
+- [ ] T012 [US1] Configure the haskell.nix development shell with exact Nix-provided dependencies so the required Cabal build does not depend on mutable user package-index state.
+- [ ] T013 [US1] Run the Haskell test app with a fresh private `TMUX_TMPDIR` and an explicit packaged interactive shell so concurrent/headless runners cannot share or immediately lose its tmux server.
+- [ ] T014 [US1] Record fresh-state Cabal build success, 55 examples with 0 failures, focused workflow-contract success, full `./gate.sh` exit `0`, and navigator verification before commit.
+
+**Commit**: `fix(ci): isolate hosted runner verification`
+
+**Trailer**: `Tasks: T011, T012, T013, T014`
+
+---
+
 ## Slice 3: Ticket-Orchestrator Finalization
 
 **Goal**: Independently prove local and hosted results, bind the observed contexts into the main ruleset, and complete ticket metadata before the standard gate-drop lifecycle.
@@ -57,13 +78,13 @@
 
 **Owner**: Ticket orchestrator; do not dispatch these metadata/external-state tasks to an implementation pair.
 
-- [ ] T011 [US2] Rerun `./gate.sh`, inspect pull request #81 check conclusions, and record exact local/hosted evidence in the pull request body and `specs/077-authoritative-nix-ci/tasks.md`.
-- [ ] T012 [US3] Replace ruleset `13867328` required contexts with the nine observed PR job names while preserving bypass actor `5`, then verify the returned ruleset JSON.
-- [ ] T013 [US3] Update pull request #81 body to link parent epic #80, enumerate delivered local/GitHub surfaces, and complete final task accounting in `specs/077-authoritative-nix-ci/tasks.md`.
+- [ ] T015 [US2] Rerun `./gate.sh`, inspect pull request #81 check conclusions, and record exact local/hosted evidence in the pull request body and `specs/077-authoritative-nix-ci/tasks.md`.
+- [ ] T016 [US3] Replace ruleset `13867328` required contexts with the nine observed PR job names while preserving bypass actor `5`, then verify the returned ruleset JSON.
+- [ ] T017 [US3] Update pull request #81 body to link parent epic #80, enumerate delivered local/GitHub surfaces, and complete final task accounting in `specs/077-authoritative-nix-ci/tasks.md`.
 
 **Commit**: `chore: finalize issue 77 quality contract`
 
-**Trailer**: `Tasks: T011, T012, T013`
+**Trailer**: `Tasks: T015, T016, T017`
 
 After all tasks are checked, run the finalization audit, drop `gate.sh` in the lifecycle sentinel commit, push, wait for all checks to return green at the drop commit, and only then mark pull request #81 ready. Do not merge.
 
@@ -71,9 +92,10 @@ After all tasks are checked, run the finalization audit, drop `gate.sh` in the l
 
 1. Slice 1 is the serial foundation; it makes the local gate executable.
 2. Slice 2 depends on Slice 1's flake app names and workflow-lint surface.
-3. Slice 3 depends on Slice 2 being pushed and GitHub reporting the final job names.
-4. Ruleset mutation follows observed green jobs, never speculative names.
-5. Gate drop and mark-ready follow completed task accounting and the finalization audit.
+3. Slice 2a is a forward correction driven by hosted RED evidence and depends on Slice 2's exact orchestration remaining unchanged.
+4. Slice 3 depends on Slice 2a being pushed and GitHub reporting the final job names green.
+5. Ruleset mutation follows observed green jobs, never speculative names.
+6. Gate drop and mark-ready follow completed task accounting and the finalization audit.
 
 ## Parallel Opportunities
 

--- a/specs/077-authoritative-nix-ci/tasks.md
+++ b/specs/077-authoritative-nix-ci/tasks.md
@@ -1,0 +1,89 @@
+# Tasks: Authoritative Nix and CI Quality Contract
+
+**Input**: Design documents from `specs/077-authoritative-nix-ci/`
+**Prerequisites**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md), [quality contract](./contracts/quality-contract.md)
+
+**Execution model**: Slices 1 and 2 are each executed by the paired bottom-row driver and navigator. Slice 3 is explicitly ticket-orchestrator-owned. Each implementation slice is one bisect-safe commit; the driver never pushes.
+
+## Slice 1: Authoritative Local and Flake Contract
+
+**Goal**: Make every local quality surface a real sandboxed flake check with a matching app, repair Cabal portability without weakening development warnings, and make lowercase `just ci` the complete gate.
+
+**Independent Test**: A deliberate Cabal formatting defect makes `nix run --quiet .#formatting` fail; after restoration, `./gate.sh` exits `0`, Cabal validation is warning-free, all seven focused apps pass, and Haskell reports 55 examples with 0 failures.
+
+**Owned files**: `flake.nix`, `nix/project.nix`, `nix/checks.nix`, `nix/apps.nix`, `justfile`, `agent-daemon.cabal`, `cabal.project`, `.github/actionlint.yaml`, `.github/workflows/darwin-release.yml`.
+
+**Forbidden scope**: Application, test, or UI source; `.github/workflows/ci.yml`; Pages/release behavior; GHC/input upgrades; specs, `gate.sh`, PR metadata, and ruleset state.
+
+- [ ] T001 [US1] Move `-Werror` behind manual default-off `development-warnings` in `agent-daemon.cabal`, enable it explicitly in `nix/project.nix`, and edit `cabal.project` only if fresh validation exposes a concrete warning.
+- [ ] T002 [US1] Create strict-path app specifications and real sandboxed checks in `nix/checks.nix`, project matching apps through `nix/apps.nix`, and wire both from `flake.nix`.
+- [ ] T003 [US1] Add canonical lowercase `ci` and uppercase compatibility alias `CI` in `justfile` so the full flake gate plus real dev-shell build are covered.
+- [ ] T004 [P] [US2] Declare custom runner `nixos` in `.github/actionlint.yaml` and make only behavior-neutral shellcheck corrections in `.github/workflows/darwin-release.yml`.
+- [ ] T005 [US1] Record deliberate RED then restored GREEN formatting-check evidence in ignored `WIP.md` and paired runtime handoffs without leaving the representative defect in `agent-daemon.cabal`.
+- [ ] T006 [US1] Record warning-free Cabal validation, seven focused app/check results, 55 examples with 0 failures, repository-wide workflow lint, and final `./gate.sh` exit `0` in ignored `WIP.md` before commit.
+
+**Commit**: `ci: make Nix checks authoritative`
+
+**Trailer**: `Tasks: T001, T002, T003, T004, T005, T006`
+
+---
+
+## Slice 2: Stable GitHub Actions Orchestration
+
+**Goal**: Make the pull-request workflow expose the exact always-present quality contexts and orchestrate the flake-owned apps after a cache-warming Build Gate.
+
+**Independent Test**: Structural assertions added to the workflow-lint surface fail against the old workflow, then pass after `.github/workflows/ci.yml` exposes all nine names, prescribed runners, Build Gate dependencies, and focused commands; the full gate remains green.
+
+**Owned files**: `nix/checks.nix`, `.github/workflows/ci.yml`.
+
+**Forbidden scope**: All application/test/UI sources; Cabal metadata; other workflows; specs, `gate.sh`, PR metadata, and ruleset state.
+
+- [ ] T007 [US2] Add structural CI contract assertions to the `workflow-lint` surface in `nix/checks.nix` and record RED against the old `.github/workflows/ci.yml` before changing it.
+- [ ] T008 [US2] Replace `.github/workflows/ci.yml` with unconditional `Build Gate`, Haskell, formatting, HLint, Cabal package, PureScript UI, workflow lint, dev-shell, and Darwin jobs using the exact contract names.
+- [ ] T009 [US2] Make Linux jobs in `.github/workflows/ci.yml` run on `nixos`, depend on `build-gate`, and orchestrate focused flake apps while preserving the separate real `nix develop` build and macOS Darwin exception.
+- [ ] T010 [US2] Record GREEN structural workflow proof, actionlint/shellcheck exit `0`, full `./gate.sh` exit `0`, and navigator verification in ignored `WIP.md` and paired runtime status before commit.
+
+**Commit**: `ci: align GitHub Actions with flake checks`
+
+**Trailer**: `Tasks: T007, T008, T009, T010`
+
+---
+
+## Slice 3: Ticket-Orchestrator Finalization
+
+**Goal**: Independently prove local and hosted results, bind the observed contexts into the main ruleset, and complete ticket metadata before the standard gate-drop lifecycle.
+
+**Independent Test**: Fresh local gate exits `0`; pull request #81 reports all nine jobs successful; ruleset `13867328` reports exactly those contexts and unchanged bypass actor `5`.
+
+**Owner**: Ticket orchestrator; do not dispatch these metadata/external-state tasks to an implementation pair.
+
+- [ ] T011 [US2] Rerun `./gate.sh`, inspect pull request #81 check conclusions, and record exact local/hosted evidence in the pull request body and `specs/077-authoritative-nix-ci/tasks.md`.
+- [ ] T012 [US3] Replace ruleset `13867328` required contexts with the nine observed PR job names while preserving bypass actor `5`, then verify the returned ruleset JSON.
+- [ ] T013 [US3] Update pull request #81 body to link parent epic #80, enumerate delivered local/GitHub surfaces, and complete final task accounting in `specs/077-authoritative-nix-ci/tasks.md`.
+
+**Commit**: `chore: finalize issue 77 quality contract`
+
+**Trailer**: `Tasks: T011, T012, T013`
+
+After all tasks are checked, run the finalization audit, drop `gate.sh` in the lifecycle sentinel commit, push, wait for all checks to return green at the drop commit, and only then mark pull request #81 ready. Do not merge.
+
+## Dependencies & Execution Order
+
+1. Slice 1 is the serial foundation; it makes the local gate executable.
+2. Slice 2 depends on Slice 1's flake app names and workflow-lint surface.
+3. Slice 3 depends on Slice 2 being pushed and GitHub reporting the final job names.
+4. Ruleset mutation follows observed green jobs, never speculative names.
+5. Gate drop and mark-ready follow completed task accounting and the finalization audit.
+
+## Parallel Opportunities
+
+- T004 touches disjoint workflow-lint configuration files but remains under the same paired Slice 1 review/commit.
+- Slices are intentionally serial because they share the quality contract and branch history.
+- External GitHub check observation can overlap only with non-mutating PR-body preparation; the ruleset update waits for final names.
+
+## Implementation Strategy
+
+1. Establish executable local proof before changing hosted orchestration.
+2. Use focused RED → GREEN evidence for both the check engine and workflow contract.
+3. Freeze and push each navigator-verified slice only after the ticket owner independently reviews the diff and reruns `./gate.sh`.
+4. Treat the ruleset as a final external projection of already-observed CI state.

--- a/specs/077-authoritative-nix-ci/tasks.md
+++ b/specs/077-authoritative-nix-ci/tasks.md
@@ -53,16 +53,16 @@
 
 **Goal**: Preserve the exact CI orchestration while removing the two host-state leaks exposed by the first hosted run: Cabal's empty user package index and tmux's inherited runner socket/shell state.
 
-**Independent Test**: With fresh XDG/Cabal state, `nix develop --quiet -c cabal build all -O0` succeeds from Nix-provided exact dependencies; the Haskell app uses a private tmux socket root and known interactive shell and reports 55 examples with 0 failures; the focused workflow contract and full gate remain green.
+**Independent Test**: With fresh XDG/Cabal state, `nix develop --quiet -c cabal build all -O0` succeeds from a writable copy of the Nix-pinned package index without a pre-existing user index; the Haskell app uses a private tmux socket root and known interactive shell and reports 55 examples with 0 failures; the focused workflow contract and full gate remain green.
 
 **Owned files**: `nix/project.nix`, `nix/checks.nix`, ignored `WIP.md`.
 
 **Forbidden scope**: Application, test, or UI source; workflow job names/commands/runners; Cabal metadata; other Nix files; other workflows; specs, `gate.sh`, PR metadata, and ruleset state.
 
-- [ ] T011 [US1] Record the hosted RED evidence from PR #81: six tmux-backed examples fail after the inherited tmux server disappears, and a clean runner cannot resolve `servant-server` without a user Hackage index.
-- [ ] T012 [US1] Configure the haskell.nix development shell with exact Nix-provided dependencies so the required Cabal build does not depend on mutable user package-index state.
-- [ ] T013 [US1] Run the Haskell test app with a fresh private `TMUX_TMPDIR` and an explicit packaged interactive shell so concurrent/headless runners cannot share or immediately lose its tmux server.
-- [ ] T014 [US1] Record fresh-state Cabal build success, 55 examples with 0 failures, focused workflow-contract success, full `./gate.sh` exit `0`, and navigator verification before commit.
+- [X] T011 [US1] Record the hosted RED evidence from PR #81: six tmux-backed examples fail after the inherited tmux server disappears, and a clean runner cannot resolve `servant-server` without a user Hackage index.
+- [X] T012 [US1] Configure the haskell.nix development shell with a writable copy of its plan-matched Nix-pinned package index so the required Cabal build does not depend on mutable pre-existing user index state.
+- [X] T013 [US1] Run the Haskell test app with a fresh private `TMUX_TMPDIR` and an explicit packaged interactive shell so concurrent/headless runners cannot share or immediately lose its tmux server.
+- [X] T014 [US1] Record fresh-state Cabal build success, 55 examples with 0 failures, focused workflow-contract success, full `./gate.sh` exit `0`, and navigator verification before commit.
 
 **Commit**: `fix(ci): isolate hosted runner verification`
 

--- a/specs/077-authoritative-nix-ci/tasks.md
+++ b/specs/077-authoritative-nix-ci/tasks.md
@@ -78,9 +78,16 @@
 
 **Owner**: Ticket orchestrator; do not dispatch these metadata/external-state tasks to an implementation pair.
 
-- [ ] T015 [US2] Rerun `./gate.sh`, inspect pull request #81 check conclusions, and record exact local/hosted evidence in the pull request body and `specs/077-authoritative-nix-ci/tasks.md`.
-- [ ] T016 [US3] Replace ruleset `13867328` required contexts with the nine observed PR job names while preserving bypass actor `5`, then verify the returned ruleset JSON.
-- [ ] T017 [US3] Update pull request #81 body to link parent epic #80, enumerate delivered local/GitHub surfaces, and complete final task accounting in `specs/077-authoritative-nix-ci/tasks.md`.
+- [X] T015 [US2] Rerun `./gate.sh`, inspect pull request #81 check conclusions, and record exact local/hosted evidence in the pull request body and `specs/077-authoritative-nix-ci/tasks.md`.
+- [X] T016 [US3] Replace ruleset `13867328` required contexts with the nine observed PR job names while preserving bypass actor `5`, then verify the returned ruleset JSON.
+- [X] T017 [US3] Update pull request #81 body to link parent epic #80, enumerate delivered local/GitHub surfaces, and complete final task accounting in `specs/077-authoritative-nix-ci/tasks.md`.
+
+**Final evidence**:
+
+- Local `./gate.sh` exited `0` after the hosted run completed, evaluating all seven flake checks and completing the required dev-shell build.
+- Hosted run `29095995236` at head `306cb26e2d8c142cc0c39184cdebc46ee704ccc4` completed exactly nine successful jobs: `Build Gate`, `Haskell build and tests`, `Formatting`, `HLint`, `Cabal package validation`, `PureScript UI`, `Workflow lint`, `Dev shell build`, and `Darwin build`.
+- Fresh ruleset `13867328` JSON verification reported the exact ordered nine-context list and preserved the sole bypass actor `{actor_id: 5, actor_type: RepositoryRole, bypass_mode: always}`, the `main` ref condition, and the existing pull-request/non-fast-forward rules.
+- Pull request #81 remains draft during finalization; its delivered-state body starts with `Closes #77`, links parent epic #80, enumerates the delivered local/hosted surfaces, and records the hosted run and ruleset evidence.
 
 **Commit**: `chore: finalize issue 77 quality contract`
 

--- a/specs/077-authoritative-nix-ci/tasks.md
+++ b/specs/077-authoritative-nix-ci/tasks.md
@@ -15,12 +15,12 @@
 
 **Forbidden scope**: Application, test, or UI source; `.github/workflows/ci.yml`; Pages/release behavior; GHC/input upgrades; specs, `gate.sh`, PR metadata, and ruleset state.
 
-- [ ] T001 [US1] Move `-Werror` behind manual default-off `development-warnings` in `agent-daemon.cabal`, enable it explicitly in `nix/project.nix`, and edit `cabal.project` only if fresh validation exposes a concrete warning.
-- [ ] T002 [US1] Create strict-path app specifications and real sandboxed checks in `nix/checks.nix`, project matching apps through `nix/apps.nix`, and wire both from `flake.nix`.
-- [ ] T003 [US1] Add canonical lowercase `ci` and uppercase compatibility alias `CI` in `justfile` so the full flake gate plus real dev-shell build are covered.
-- [ ] T004 [P] [US2] Declare custom runner `nixos` in `.github/actionlint.yaml` and make only behavior-neutral shellcheck corrections in `.github/workflows/darwin-release.yml`.
-- [ ] T005 [US1] Record deliberate RED then restored GREEN formatting-check evidence in ignored `WIP.md` and paired runtime handoffs without leaving the representative defect in `agent-daemon.cabal`.
-- [ ] T006 [US1] Record warning-free Cabal validation, seven focused app/check results, 55 examples with 0 failures, repository-wide workflow lint, and final `./gate.sh` exit `0` in ignored `WIP.md` before commit.
+- [X] T001 [US1] Move `-Werror` behind manual default-off `development-warnings` in `agent-daemon.cabal`, enable it explicitly in `nix/project.nix`, and edit `cabal.project` only if fresh validation exposes a concrete warning.
+- [X] T002 [US1] Create strict-path app specifications and real sandboxed checks in `nix/checks.nix`, project matching apps through `nix/apps.nix`, and wire both from `flake.nix`.
+- [X] T003 [US1] Add canonical lowercase `ci` and uppercase compatibility alias `CI` in `justfile` so the full flake gate plus real dev-shell build are covered.
+- [X] T004 [P] [US2] Declare custom runner `nixos` in `.github/actionlint.yaml` and make only behavior-neutral shellcheck corrections in `.github/workflows/darwin-release.yml`.
+- [X] T005 [US1] Record deliberate RED then restored GREEN formatting-check evidence in ignored `WIP.md` and paired runtime handoffs without leaving the representative defect in `agent-daemon.cabal`.
+- [X] T006 [US1] Record warning-free Cabal validation, seven focused app/check results, 55 examples with 0 failures, repository-wide workflow lint, and final `./gate.sh` exit `0` in ignored `WIP.md` before commit.
 
 **Commit**: `ci: make Nix checks authoritative`
 

--- a/specs/077-authoritative-nix-ci/tasks.md
+++ b/specs/077-authoritative-nix-ci/tasks.md
@@ -38,10 +38,10 @@
 
 **Forbidden scope**: All application/test/UI sources; Cabal metadata; other workflows; specs, `gate.sh`, PR metadata, and ruleset state.
 
-- [ ] T007 [US2] Add structural CI contract assertions to the `workflow-lint` surface in `nix/checks.nix` and record RED against the old `.github/workflows/ci.yml` before changing it.
-- [ ] T008 [US2] Replace `.github/workflows/ci.yml` with unconditional `Build Gate`, Haskell, formatting, HLint, Cabal package, PureScript UI, workflow lint, dev-shell, and Darwin jobs using the exact contract names.
-- [ ] T009 [US2] Make Linux jobs in `.github/workflows/ci.yml` run on `nixos`, depend on `build-gate`, and orchestrate focused flake apps while preserving the separate real `nix develop` build and macOS Darwin exception.
-- [ ] T010 [US2] Record GREEN structural workflow proof, actionlint/shellcheck exit `0`, full `./gate.sh` exit `0`, and navigator verification in ignored `WIP.md` and paired runtime status before commit.
+- [X] T007 [US2] Add structural CI contract assertions to the `workflow-lint` surface in `nix/checks.nix` and record RED against the old `.github/workflows/ci.yml` before changing it.
+- [X] T008 [US2] Replace `.github/workflows/ci.yml` with unconditional `Build Gate`, Haskell, formatting, HLint, Cabal package, PureScript UI, workflow lint, dev-shell, and Darwin jobs using the exact contract names.
+- [X] T009 [US2] Make Linux jobs in `.github/workflows/ci.yml` run on `nixos`, depend on `build-gate`, and orchestrate focused flake apps while preserving the separate real `nix develop` build and macOS Darwin exception.
+- [X] T010 [US2] Record GREEN structural workflow proof, actionlint/shellcheck exit `0`, full `./gate.sh` exit `0`, and navigator verification in ignored `WIP.md` and paired runtime status before commit.
 
 **Commit**: `ci: align GitHub Actions with flake checks`
 


### PR DESCRIPTION
Closes #77

Parent epic: #80

## Purpose

Make the Nix flake the executable source of truth for repository verification, with one lowercase local entrypoint and stable, always-present GitHub Actions jobs.

## Delivered local contract

- Seven real sandbox checks with matching focused apps: Haskell build, all 55 Haskell tests, formatting, HLint, Cabal package validation, PureScript UI, and workflow lint.
- Canonical lowercase `just ci`, with `just CI` retained as a compatibility alias.
- A real development-shell `cabal build all -O0`; fresh shells seed a writable Cabal index from the same Nix-pinned snapshot used by the haskell.nix project plan, without `cabal update` or a pre-existing user index.
- Development warnings remain strict in Nix/CI through an explicit manual flag, while `cabal check` is clean for package consumers.
- Haskell tests run with a private tmux socket root and packaged interactive shell, isolating them from headless/concurrent runner state.

## Delivered GitHub contract

The pull-request workflow exposes these unconditional contexts:

1. `Build Gate`
2. `Haskell build and tests`
3. `Formatting`
4. `HLint`
5. `Cabal package validation`
6. `PureScript UI`
7. `Workflow lint`
8. `Dev shell build`
9. `Darwin build`

Linux jobs run on `nixos`, call the flake-owned apps after `Build Gate`, and retain a separate real `nix develop` build. Darwin remains on macOS 14. Actionlint validates the repository workflows and the CI structure itself.

## Verification evidence

- Deliberate formatting RED: the focused formatting app rejected a temporary Cabal formatting defect before restoration.
- Deliberate workflow RED: the structural workflow contract rejected the former three-job workflow before the nine-job orchestration was added.
- Hosted boundary RED: the first run exposed clean-runner Cabal-index and ambient tmux leaks; both were reproduced locally before the forward fix.
- Final local `./gate.sh`: exit `0` after a clean Cabal cache/build directory.
- Fresh exact `nix develop --quiet -c cabal build all -O0`: exit `0` without a pre-existing user index.
- Hostile ambient-shell Haskell app: 55 examples, 0 failures.
- Hosted run `29095995236`: all nine contexts successful at head `306cb26`.
- Main ruleset `13867328`: requires exactly the nine observed contexts and preserves repository-role bypass actor `5`.

## Scope boundaries

No application, API, UI, GHC, release publication, documentation, or historical tag behavior changed.
