### PR TITLE
Close the current pane or window from the touch UI

### DIFF
--- a/agent-daemon.cabal
+++ b/agent-daemon.cabal
@@ -32,6 +32,7 @@ library
     AgentDaemon.Api
     AgentDaemon.Api.Types
     AgentDaemon.Branch
+    AgentDaemon.Close
     AgentDaemon.Git
     AgentDaemon.Recovery
     AgentDaemon.Server
@@ -107,6 +108,7 @@ test-suite e2e-tests
   other-modules:
     AgentDaemon.ApiSpec
     AgentDaemon.BranchSpec
+    AgentDaemon.CloseSpec
     AgentDaemon.GitSpec
     AgentDaemon.RecoverySpec
     AgentDaemon.TerminalSpec
@@ -132,6 +134,7 @@ test-suite e2e-tests
     , http-client     >=0.7  && <0.8
     , http-types      >=0.12 && <0.13
     , process         >=1.6  && <1.7
+    , QuickCheck      >=2.14 && <2.16
     , servant         >=0.20 && <0.21
     , servant-client  >=0.20 && <0.21
     , stm             >=2.5  && <2.6

--- a/agent-daemon.cabal
+++ b/agent-daemon.cabal
@@ -112,6 +112,7 @@ test-suite e2e-tests
     AgentDaemon.GitSpec
     AgentDaemon.RecoverySpec
     AgentDaemon.TerminalSpec
+    AgentDaemon.TmuxCloseSpec
 
   hs-source-dirs:     test
   default-language:   GHC2021

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix develop --quiet -c just ci
+nix run --quiet .#ui

--- a/gate.sh
+++ b/gate.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix develop --quiet -c just ci
-nix run --quiet .#ui

--- a/specs/082-close-current-context/plan.md
+++ b/specs/082-close-current-context/plan.md
@@ -49,14 +49,14 @@ Add JSON types, STM pending-confirmation state, the four current-only routes, ha
 
 ### Slice 4 — Touch UI, confirmations, and recovery
 
-Add PureScript/JS bindings and Halogen confirmation state/actions. Put both actions in the attached-session settings surface, show consequence-based no-typing sheets, and handle survive/end/stale outcomes. Extend CSS only for touch-safe destructive grouping and sheets. With no PureScript unit harness in this repository, RED is the pre-change missing control/API behavior; proof is compiler/lint/bundle plus live browser assertions and screenshots.
+Add PureScript/JS bindings and Halogen confirmation state/actions. Put both actions in the attached-session settings surface, show consequence-based no-typing sheets, and handle survive/end/stale outcomes. Destructive recovery abandons the server-closing terminal socket before survivor replacement or ended cleanup, while ordinary session switching and explicit disconnect still close their owned socket normally. Extend CSS only for touch-safe destructive grouping and sheets. With no PureScript unit harness in this repository, RED is the pre-change missing control/API behavior; proof is compiler/lint/bundle plus live browser assertions and screenshots.
 
 ## Owned files by slice
 
 - Slice 1: `src/AgentDaemon/Close.hs`, `test/AgentDaemon/CloseSpec.hs`, `test/Main.hs` only if discovery requires it, `agent-daemon.cabal`.
 - Slice 2: `src/AgentDaemon/Tmux.hs`, `test/AgentDaemon/TmuxCloseSpec.hs`, `agent-daemon.cabal`.
 - Slice 3: `src/AgentDaemon/Types.hs`, `src/AgentDaemon/Api/Types.hs`, `src/AgentDaemon/Api.hs`, `test/AgentDaemon/ApiSpec.hs`, plus a minimal `src/AgentDaemon/Tmux.hs` forward edit exposing only the already-computed consequence of an otherwise opaque prepared close.
-- Slice 4: `ui/src/AgentDaemon/Types.purs`, `ui/src/AgentDaemon/Api.purs`, `ui/src/AgentDaemon/Api.js`, `ui/src/Main.purs`, `ui/dist/index.css`.
+- Slice 4: `ui/src/AgentDaemon/Types.purs`, `ui/src/AgentDaemon/Api.purs`, `ui/src/AgentDaemon/Api.js`, `ui/src/AgentDaemon/FFI/Terminal.purs`, `ui/src/AgentDaemon/FFI/Terminal.js`, `ui/src/Main.purs`, `ui/dist/index.css`.
 - Orchestrator: `specs/082-close-current-context/*`, `gate.sh`, PR metadata, runtime evidence outside the repository.
 
 No slice may touch #78 release/packaging/workflow scope, #79 broad docs/governance scope, unrelated terminal/session/paste behavior, the GHC version, or the main worktree's untracked specifications.

--- a/specs/082-close-current-context/plan.md
+++ b/specs/082-close-current-context/plan.md
@@ -55,7 +55,7 @@ Add PureScript/JS bindings and Halogen confirmation state/actions. Put both acti
 
 - Slice 1: `src/AgentDaemon/Close.hs`, `test/AgentDaemon/CloseSpec.hs`, `test/Main.hs` only if discovery requires it, `agent-daemon.cabal`.
 - Slice 2: `src/AgentDaemon/Tmux.hs`, `test/AgentDaemon/TmuxCloseSpec.hs`, `agent-daemon.cabal`.
-- Slice 3: `src/AgentDaemon/Types.hs`, `src/AgentDaemon/Api/Types.hs`, `src/AgentDaemon/Api.hs`, `test/AgentDaemon/ApiSpec.hs`.
+- Slice 3: `src/AgentDaemon/Types.hs`, `src/AgentDaemon/Api/Types.hs`, `src/AgentDaemon/Api.hs`, `test/AgentDaemon/ApiSpec.hs`, plus a minimal `src/AgentDaemon/Tmux.hs` forward edit exposing only the already-computed consequence of an otherwise opaque prepared close.
 - Slice 4: `ui/src/AgentDaemon/Types.purs`, `ui/src/AgentDaemon/Api.purs`, `ui/src/AgentDaemon/Api.js`, `ui/src/Main.purs`, `ui/dist/index.css`.
 - Orchestrator: `specs/082-close-current-context/*`, `gate.sh`, PR metadata, runtime evidence outside the repository.
 

--- a/specs/082-close-current-context/plan.md
+++ b/specs/082-close-current-context/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Close the Current Pane or Window
+
+## Technical context
+
+- Backend: Haskell 2021, Servant, STM, `process`, Hspec, QuickCheck.
+- Boundary: real tmux server commands in disposable sessions.
+- Frontend: PureScript, Halogen, JavaScript fetch FFI, plain CSS.
+- Gate: Nix flake checks plus the real dev-shell build through `nix develop --quiet -c just ci`; focused UI proof through `nix run --quiet .#ui`.
+- Branch: `feat/close-current-pane-or-window`; draft PR #83.
+
+## Design decision
+
+The API is current-context-only and two-phase:
+
+- `POST /sessions/:sid/current-pane/close/preview`
+- `POST /sessions/:sid/current-pane/close` with `{ "confirmation": "<opaque>" }`
+- `POST /sessions/:sid/current-window/close/preview`
+- `POST /sessions/:sid/current-window/close` with `{ "confirmation": "<opaque>" }`
+
+Preview responses describe consequences and carry a server-minted opaque, single-use token. `SessionManager` stores only the newest pending confirmation per `(session, scope)` with its internal current-context snapshot. The execute handler consumes the token, resolves tmux currentness again, rejects mismatch with HTTP 409, and invokes a tmux-side conditional close that cannot fall through onto a different context. No client payload contains or selects a pane/window target.
+
+Success returns whether the session ended and a consequence/status value. The UI reconnects the session terminal and refreshes windows when a context survives; otherwise it refreshes sessions and shows a truthful ended/disconnected state. Failure closes the confirmation sheet, reports the actionable error, and refreshes current truth without attempting another close.
+
+## Discussion → proof → docs reconciliation
+
+The accepted state machine and invariants I1–I7 are recorded in `spec.md`. The operator waived Lean because adding the repository's first formal toolchain would expand scope. The proof replacement is deliberately layered:
+
+1. Pure Haskell topology transitions mirror the documented state machine.
+2. QuickCheck properties quantify preservation, exact removal, termination, stale identity, and replay rejection over valid generated states.
+3. Hspec/Servant integration proves route shape, token lifecycle, status mapping, and session registry behavior.
+4. Disposable tmux sessions prove actual current-pane/current-window resolution, conditional race rejection, survivor selection, and last-context termination.
+5. Browser smoke proves touch interaction and recovery at the three accepted viewports.
+
+Any discovery that invalidates I1–I7 requires updating `spec.md`, this plan, `tasks.md`, the pure model, and mapped properties before continuing.
+
+## Slices
+
+### Slice 1 — Pure close-current model and properties
+
+Add `AgentDaemon.Close` with the valid topology, close scopes, snapshots, consequences, preparation/validation, pure transitions, and invariant predicates. Add generated QuickCheck properties for I1–I7. Register the module/tests in Cabal. This is independently usable as the backend's decision core.
+
+### Slice 2 — Atomic tmux close primitives and live boundary
+
+Add current-context snapshot queries and conditional close-current-pane/window primitives to `AgentDaemon.Tmux`. Tests create disposable multi-window/multi-pane sessions and demonstrate the successful, last-context, and deliberately raced paths against a real tmux server. The primitive receives an internal expected snapshot, never a client target, and refuses to close if currentness changed.
+
+### Slice 3 — Servant preview/execute API
+
+Add JSON types, STM pending-confirmation state, the four current-only routes, handlers, conflict errors, single-use behavior, and API integration tests. Route/request inspection proves there is no arbitrary target field. The handler uses the pure model and Slice 2 boundary functions.
+
+### Slice 4 — Touch UI, confirmations, and recovery
+
+Add PureScript/JS bindings and Halogen confirmation state/actions. Put both actions in the attached-session settings surface, show consequence-based no-typing sheets, and handle survive/end/stale outcomes. Extend CSS only for touch-safe destructive grouping and sheets. With no PureScript unit harness in this repository, RED is the pre-change missing control/API behavior; proof is compiler/lint/bundle plus live browser assertions and screenshots.
+
+## Owned files by slice
+
+- Slice 1: `src/AgentDaemon/Close.hs`, `test/AgentDaemon/CloseSpec.hs`, `test/Main.hs` only if discovery requires it, `agent-daemon.cabal`.
+- Slice 2: `src/AgentDaemon/Tmux.hs`, `test/AgentDaemon/TmuxCloseSpec.hs`, `agent-daemon.cabal`.
+- Slice 3: `src/AgentDaemon/Types.hs`, `src/AgentDaemon/Api/Types.hs`, `src/AgentDaemon/Api.hs`, `test/AgentDaemon/ApiSpec.hs`.
+- Slice 4: `ui/src/AgentDaemon/Types.purs`, `ui/src/AgentDaemon/Api.purs`, `ui/src/AgentDaemon/Api.js`, `ui/src/Main.purs`, `ui/dist/index.css`.
+- Orchestrator: `specs/082-close-current-context/*`, `gate.sh`, PR metadata, runtime evidence outside the repository.
+
+No slice may touch #78 release/packaging/workflow scope, #79 broad docs/governance scope, unrelated terminal/session/paste behavior, the GHC version, or the main worktree's untracked specifications.
+
+## Verification strategy
+
+- Slice focused Haskell proof: `nix run --quiet .#haskell-tests` and `./gate.sh`.
+- Slice focused UI proof: `nix run --quiet .#ui`, `nix develop --quiet -c bash -lc 'cd ui && just ci'` when available, then `./gate.sh`.
+- Live boundary: named disposable tmux specs for pane, last-pane/window, window, last-window/session, and raced currentness.
+- Browser: isolated live daemon/session, touch/CDP interaction at 390×844, 768×1024, and 1024×768; assert no overflow, every destructive control ≥44×44 CSS px, sheets in bounds, Cancel non-destructive, survive reconnect, end disconnect, stale refresh, console errors 0, runtime exceptions 0; save screenshots/transcript outside the repo and link evidence in PR #83.
+- Final local: fresh `./gate.sh`, fresh `nix develop --quiet -c just ci`, focused tests/UI, diff/status/task/message audit.
+- Hosted: exact required PR checks by name and conclusion.
+
+## Formalization waiver
+
+Per parent answer `A-001-lean-scope.md`, #82 intentionally adds no Lean files or toolchain. The state-machine/QuickCheck/live-boundary stack above is the operator-approved replacement and must be recorded in the final PR description.

--- a/specs/082-close-current-context/spec.md
+++ b/specs/082-close-current-context/spec.md
@@ -1,0 +1,86 @@
+# Feature Specification: Close the Current Pane or Window
+
+**Issue:** #82  
+**Parent:** #80  
+**Dependency:** #75, merged through PR #76 at `177679658ed21dc30cf59f5895195d2a73831ccb`  
+**Priority:** P1  
+**Command recovery:** yes — **Close this pane** and **Close this window**
+
+## P1 user story
+
+As a touch-only operator, I close the pane or window I am currently viewing and observe tmux-ws attach to the surviving context without naming or selecting a target.
+
+## Accepted product semantics
+
+There are exactly two actions:
+
+1. **Close this pane** affects only the active pane in the window currently being viewed.
+2. **Close this window** affects only the window currently being viewed and all panes inside it.
+
+The operator never sees, chooses, or types a pane name, window name, index, tmux ID, or target. There is no pane list, arbitrary target picker, or close action for a non-current context. The server resolves currentness at execution time, and the client cannot turn either route into an arbitrary-target operation.
+
+## State-machine model
+
+A live session is a non-empty ordered collection of windows. Every live window is a non-empty ordered collection of panes. Exactly one window is current, and exactly one pane in that window is current.
+
+A close interaction has two phases:
+
+1. `prepare(scope, state)` asks the server for a consequence preview. The server resolves the current context and records a single-use opaque confirmation bound to the session, scope, current window, current pane where applicable, and topology counts.
+2. `execute(token, freshState)` resolves currentness again. It proceeds only when the token is the latest unused confirmation for the same session/scope and the freshly resolved current context equals the recorded context. Otherwise it returns `stale-current-context` and makes no state change.
+
+The pure transitions are:
+
+- `closeCurrentPane` with more than one pane removes exactly the current pane; the same window survives and tmux chooses its next current pane.
+- `closeCurrentPane` on the last pane with more than one window removes exactly that window; tmux chooses a surviving current window and pane.
+- `closeCurrentPane` on the last pane of the last window ends the session.
+- `closeCurrentWindow` with more than one window removes exactly the current window and every pane in it; tmux chooses a surviving current window and pane.
+- `closeCurrentWindow` on the last window ends the session.
+- A stale, unknown, reused, wrong-session, or wrong-scope token is the identity transition: nothing closes.
+
+### Stable invariants
+
+- **I1 — Current-only effect:** a successful transition removes only the context that was current both at preparation and execution.
+- **I2 — No client-selected target:** execution input contains only a server-minted opaque token; no route accepts a pane/window identifier, name, or index as the close target.
+- **I3 — Stale identity:** when the fresh current context differs from the prepared context, every window and pane remains present.
+- **I4 — Survivor well-formedness:** a surviving session has at least one window; every surviving window has at least one pane; exactly one surviving window and pane are current.
+- **I5 — Exact cardinality:** pane-close removes one pane, except that removing a last pane removes its now-empty window; window-close removes one window and all of its panes; no other cardinality changes.
+- **I6 — Truthful termination:** the session ends exactly when the action removes the last window (directly, or by removing its last pane).
+- **I7 — Single use:** a confirmation is consumed by its first execution attempt, successful or stale, and cannot be replayed.
+
+Each invariant is implemented as a pure Haskell transition/predicate and mapped to QuickCheck preservation properties. Real disposable-tmux tests prove that the subprocess layer agrees with the model at the live boundary.
+
+## Functional requirements
+
+- **FR-001:** The touch UI exposes exactly **Close this pane** and **Close this window** for the attached session.
+- **FR-002:** Opening either action requests a server-authored consequence preview and requires no typing.
+- **FR-003:** Confirmation presents large **Cancel** and destructive action buttons and identifies consequences, never tmux identifiers.
+- **FR-004:** Pane confirmation warns when the pane is the window's last pane and when that also ends the session.
+- **FR-005:** Window confirmation warns when it is the session's last window.
+- **FR-006:** Close API routes accept no client-selected target. The server resolves currentness immediately before the close.
+- **FR-007:** Changed currentness, invalid/reused confirmation, or tmux failure fails closed with an actionable response and a truthful UI refresh.
+- **FR-008:** After success the terminal reconnects to the surviving context selected by tmux. If none survives, the UI reports a session-ended/disconnected state.
+- **FR-009:** Haskell properties cover invariants I1–I7.
+- **FR-010:** API and disposable-tmux integration cover both actions, multi-context survival, last-pane/window termination, token replay, and raced-current rejection.
+- **FR-011:** Browser smoke exercises reachability, both confirmation sheets, Cancel, success recovery, and failure refresh at 390×844, 768×1024, and 1024×768.
+
+## Success criteria
+
+- **SC-001:** Neither close request body nor route contains a pane/window target field.
+- **SC-002:** All pure state-machine properties pass with generated valid topologies and actions.
+- **SC-003:** A deliberately raced disposable-tmux request returns conflict and retains every pre-race context.
+- **SC-004:** Successful disposable-tmux closes affect only the prepared current context and report the surviving/ended state truthfully.
+- **SC-005:** At all three viewports, destructive controls are reachable by touch, confirmation controls are at least 44×44 CSS pixels, and no horizontal overflow or out-of-bounds sheet appears.
+- **SC-006:** `nix develop --quiet -c just ci`, `nix run --quiet .#ui`, the ticket gate, and all authoritative hosted checks pass.
+
+## Non-goals
+
+- Closing a non-current pane or window.
+- Pane/window target pickers or exposing identifiers.
+- Renaming panes or windows.
+- Redesigning whole-session stop semantics.
+- Keyboard-only shortcuts as the primary interaction.
+- Release, packaging, workflow, broad documentation, GHC upgrade, or production publication work.
+
+## Formalization waiver
+
+The repository has no Lean project or Lean toolchain. The operator explicitly chose option 2 in `A-001-lean-scope.md`: do not add Lean for #82. This is a deliberate proof-mechanism waiver, not an omitted design step. The rigorous replacement is precise state-machine prose, pure Haskell transitions, QuickCheck preservation properties, API integration, disposable live-tmux proof, and browser proof. All product semantics and other delivery requirements remain unchanged.

--- a/specs/082-close-current-context/tasks.md
+++ b/specs/082-close-current-context/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Close the Current Pane or Window
+
+Every behavior slice is one bisect-safe commit. The driver observes RED, the navigator approves RED before GREEN, and the navigator verifies GREEN before commit. Commit bodies carry the exact listed `Tasks:` IDs.
+
+## Slice 1 — Pure model and preservation properties
+
+- [ ] T001 Define the valid close-current topology, scopes, snapshots, consequences, and pure prepare/execute transitions for invariants I1–I7.
+- [ ] T002 Add generated QuickCheck properties proving current-only effect, stale identity, survivor validity, exact cardinality, truthful termination, and single-use rejection.
+- [ ] T003 Register the module/spec and pass focused Haskell tests plus `./gate.sh`.
+
+Commit: `feat: model close-current transitions`  
+Trailer: `Tasks: T001, T002, T003`
+
+## Slice 2 — Tmux live-boundary primitives
+
+- [ ] T004 Add internal current-context snapshot queries and conditional current-pane/current-window close primitives that fail closed on mismatch.
+- [ ] T005 Prove both actions, survivor selection, last-pane/window/session behavior, and deliberate races with disposable tmux sessions.
+- [ ] T006 Pass focused live Haskell tests and `./gate.sh` without exposing a client target surface.
+
+Commit: `feat: close current tmux contexts safely`  
+Trailer: `Tasks: T004, T005, T006`
+
+## Slice 3 — Current-only Servant API
+
+- [ ] T007 Add opaque single-use confirmation types and STM state, consequence preview, execute results, and HTTP 409 stale errors.
+- [ ] T008 Add the four preview/execute routes and handlers with no pane/window target input.
+- [ ] T009 Add API integration tests for consequence classification, success, termination, invalid/reused tokens, and raced-current fail-closed refresh truth.
+- [ ] T010 Pass focused API/live Haskell tests and `./gate.sh`.
+
+Commit: `feat: expose close-current API actions`  
+Trailer: `Tasks: T007, T008, T009, T010`
+
+## Slice 4 — Touch confirmations and recovery
+
+- [ ] T011 Add PureScript/JS API bindings and response types for pane/window preview and execution.
+- [ ] T012 Add exactly two attached-session actions with consequence-based, no-typing Cancel/destructive confirmation sheets and accessible labels.
+- [ ] T013 Reconnect/refresh a surviving context, show truthful session-ended state, and fail closed with actionable stale status and refresh.
+- [ ] T014 Add only the CSS needed for ≥44×44 touch controls, bounded sheets, destructive hierarchy, and all accepted viewports.
+- [ ] T015 Pass UI compile/lint/bundle proof and `./gate.sh`; document the no-unit-harness RED exception.
+
+Commit: `feat: add touch close-current actions`  
+Trailer: `Tasks: T011, T012, T013, T014, T015`
+
+## Final verification and handoff — orchestrator owned
+
+- [ ] T016 Independently run focused Haskell/API/state-machine and disposable live-tmux proof, then fresh full local CI.
+- [ ] T017 Run touch browser smoke and capture reviewed evidence at 390×844, 768×1024, and 1024×768 with zero console/runtime errors.
+- [ ] T018 Audit the operator-approved Lean waiver, accepted semantics, task/commit accounting, PR assignment/label/links/body, and exact hosted checks.
+- [ ] T019 Pass finalization audit, remove `gate.sh` only in the final sentinel commit, push, and hand the draft PR back without merging.
+
+## Proof-mechanism waiver
+
+The operator explicitly waived adding Lean for #82 in `A-001-lean-scope.md`. This task ledger intentionally substitutes precise prose, pure Haskell/QuickCheck, Servant/API integration, disposable tmux boundary tests, and three-viewport browser proof. This changes only the proof mechanism; every product, TDD, pair-review, gate, and evidence requirement remains binding.

--- a/specs/082-close-current-context/tasks.md
+++ b/specs/082-close-current-context/tasks.md
@@ -4,9 +4,9 @@ Every behavior slice is one bisect-safe commit. The driver observes RED, the nav
 
 ## Slice 1 — Pure model and preservation properties
 
-- [ ] T001 Define the valid close-current topology, scopes, snapshots, consequences, and pure prepare/execute transitions for invariants I1–I7.
-- [ ] T002 Add generated QuickCheck properties proving current-only effect, stale identity, survivor validity, exact cardinality, truthful termination, and single-use rejection.
-- [ ] T003 Register the module/spec and pass focused Haskell tests plus `./gate.sh`.
+- [X] T001 Define the valid close-current topology, scopes, snapshots, consequences, and pure prepare/execute transitions for invariants I1–I7.
+- [X] T002 Add generated QuickCheck properties proving current-only effect, stale identity, survivor validity, exact cardinality, truthful termination, and single-use rejection.
+- [X] T003 Register the module/spec and pass focused Haskell tests plus `./gate.sh`.
 
 Commit: `feat: model close-current transitions`  
 Trailer: `Tasks: T001, T002, T003`

--- a/specs/082-close-current-context/tasks.md
+++ b/specs/082-close-current-context/tasks.md
@@ -13,9 +13,9 @@ Trailer: `Tasks: T001, T002, T003`
 
 ## Slice 2 — Tmux live-boundary primitives
 
-- [ ] T004 Add internal current-context snapshot queries and conditional current-pane/current-window close primitives that fail closed on mismatch.
-- [ ] T005 Prove both actions, survivor selection, last-pane/window/session behavior, and deliberate races with disposable tmux sessions.
-- [ ] T006 Pass focused live Haskell tests and `./gate.sh` without exposing a client target surface.
+- [x] T004 Add internal current-context snapshot queries and conditional current-pane/current-window close primitives that fail closed on mismatch.
+- [x] T005 Prove both actions, survivor selection, last-pane/window/session behavior, and deliberate races with disposable tmux sessions.
+- [x] T006 Pass focused live Haskell tests and `./gate.sh` without exposing a client target surface.
 
 Commit: `feat: close current tmux contexts safely`  
 Trailer: `Tasks: T004, T005, T006`

--- a/specs/082-close-current-context/tasks.md
+++ b/specs/082-close-current-context/tasks.md
@@ -32,11 +32,11 @@ Trailer: `Tasks: T007, T008, T009, T010`
 
 ## Slice 4 — Touch confirmations and recovery
 
-- [ ] T011 Add PureScript/JS API bindings and response types for pane/window preview and execution.
-- [ ] T012 Add exactly two attached-session actions with consequence-based, no-typing Cancel/destructive confirmation sheets and accessible labels.
-- [ ] T013 Reconnect/refresh a surviving context, show truthful session-ended state, and fail closed with actionable stale status and refresh.
-- [ ] T014 Add only the CSS needed for ≥44×44 touch controls, bounded sheets, destructive hierarchy, and all accepted viewports.
-- [ ] T015 Pass UI compile/lint/bundle proof and `./gate.sh`; document the no-unit-harness RED exception.
+- [x] T011 Add PureScript/JS API bindings and response types for pane/window preview and execution.
+- [x] T012 Add exactly two attached-session actions with consequence-based, no-typing Cancel/destructive confirmation sheets and accessible labels.
+- [x] T013 Reconnect/refresh a surviving context, show truthful session-ended state, and fail closed with actionable stale status and refresh.
+- [x] T014 Add only the CSS needed for ≥44×44 touch controls, bounded sheets, destructive hierarchy, and all accepted viewports.
+- [x] T015 Pass UI compile/lint/bundle proof and `./gate.sh`; document the no-unit-harness RED exception.
 
 Commit: `feat: add touch close-current actions`  
 Trailer: `Tasks: T011, T012, T013, T014, T015`

--- a/specs/082-close-current-context/tasks.md
+++ b/specs/082-close-current-context/tasks.md
@@ -22,10 +22,10 @@ Trailer: `Tasks: T004, T005, T006`
 
 ## Slice 3 — Current-only Servant API
 
-- [ ] T007 Add opaque single-use confirmation types and STM state, consequence preview, execute results, and HTTP 409 stale errors.
-- [ ] T008 Add the four preview/execute routes and handlers with no pane/window target input.
-- [ ] T009 Add API integration tests for consequence classification, success, termination, invalid/reused tokens, and raced-current fail-closed refresh truth.
-- [ ] T010 Pass focused API/live Haskell tests and `./gate.sh`.
+- [x] T007 Add opaque single-use confirmation types and STM state, consequence preview, execute results, and HTTP 409 stale errors.
+- [x] T008 Add the four preview/execute routes and handlers with no pane/window target input.
+- [x] T009 Add API integration tests for consequence classification, success, termination, invalid/reused tokens, and raced-current fail-closed refresh truth.
+- [x] T010 Pass focused API/live Haskell tests and `./gate.sh`.
 
 Commit: `feat: expose close-current API actions`  
 Trailer: `Tasks: T007, T008, T009, T010`

--- a/specs/082-close-current-context/tasks.md
+++ b/specs/082-close-current-context/tasks.md
@@ -43,10 +43,10 @@ Trailer: `Tasks: T011, T012, T013, T014, T015`
 
 ## Final verification and handoff — orchestrator owned
 
-- [ ] T016 Independently run focused Haskell/API/state-machine and disposable live-tmux proof, then fresh full local CI.
-- [ ] T017 Run touch browser smoke and capture reviewed evidence at 390×844, 768×1024, and 1024×768 with zero console/runtime errors.
-- [ ] T018 Audit the operator-approved Lean waiver, accepted semantics, task/commit accounting, PR assignment/label/links/body, and exact hosted checks.
-- [ ] T019 Pass finalization audit, remove `gate.sh` only in the final sentinel commit, push, and hand the draft PR back without merging.
+- [x] T016 Independently run focused Haskell/API/state-machine and disposable live-tmux proof, then fresh full local CI.
+- [x] T017 Run touch browser smoke and capture reviewed evidence at 390×844, 768×1024, and 1024×768 with zero console/runtime errors.
+- [x] T018 Audit the operator-approved Lean waiver, accepted semantics, task/commit accounting, PR assignment/label/links/body, and exact hosted checks.
+- [x] T019 Pass finalization audit, remove `gate.sh` only in the final sentinel commit, push, and hand the draft PR back without merging.
 
 ## Proof-mechanism waiver
 

--- a/src/AgentDaemon/Api.hs
+++ b/src/AgentDaemon/Api.hs
@@ -1,5 +1,9 @@
 module AgentDaemon.Api
     ( apiApp
+    , apiAppWithCloseBoundary
+    , CloseBoundary (..)
+    , CloseActionFailure (..)
+    , CloseActionResult (..)
     ) where
 
 -- \|
@@ -13,14 +17,22 @@ module AgentDaemon.Api
 
 import AgentDaemon.Api.Types (agentApi)
 import AgentDaemon.Branch qualified as Branch
+import AgentDaemon.Close (CloseScope (..))
 import AgentDaemon.Recovery qualified as Recovery
 import AgentDaemon.Tmux qualified as Tmux
 import AgentDaemon.Types
     ( BranchInfo (..)
+    , CloseActionFailure (..)
+    , CloseActionResult (..)
+    , CloseConfirmationRequest (..)
+    , CloseContextScope (..)
+    , CloseExecution (..)
+    , ClosePreview (..)
     , LayoutRequest (..)
     , PaneId (..)
     , PaneInfo (..)
     , PaneSplitRequest (..)
+    , PendingClose (..)
     , Repo (..)
     , ScrollRequest (..)
     , Session (..)
@@ -31,14 +43,17 @@ import AgentDaemon.Types
     , WorktreeInfo (..)
     )
 import Control.Concurrent.STM
-    ( atomically
+    ( STM
+    , atomically
     , readTVar
     , readTVarIO
     , writeTVar
     )
+import Control.Monad (when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson qualified as Aeson
 import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
 import Data.List (intercalate, isSuffixOf)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes)
@@ -50,7 +65,9 @@ import Network.HTTP.Types
     , methodGet
     , methodHead
     , methodOptions
+    , methodPost
     , status200
+    , status400
     , status404
     )
 import Network.Wai
@@ -58,15 +75,18 @@ import Network.Wai
     , Middleware
     , mapResponseHeaders
     , pathInfo
+    , queryString
     , requestMethod
     , responseFile
     , responseLBS
+    , strictRequestBody
     )
 import Servant
     ( Handler
     , ServerError (..)
     , err400
     , err404
+    , err409
     , err500
     , serve
     , throwError
@@ -86,25 +106,247 @@ apiApp
     -- ^ static files directory
     -> SessionManager
     -> Application
-apiApp baseDir staticDir mgr =
+apiApp = apiAppWithCloseBoundary (CloseBoundary id)
+
+{- | Injectable current-close execution boundary.
+
+Tests can observe or fail a captured execution closure without adding
+test-only state to 'SessionManager'.
+-}
+newtype CloseBoundary = CloseBoundary
+    { invokeCloseBoundary
+        :: IO (Either CloseActionFailure CloseActionResult)
+        -> IO (Either CloseActionFailure CloseActionResult)
+    }
+
+-- | WAI application with an injectable close execution boundary.
+apiAppWithCloseBoundary
+    :: CloseBoundary
+    -> FilePath
+    -> FilePath
+    -> SessionManager
+    -> Application
+apiAppWithCloseBoundary closeBoundary baseDir staticDir mgr =
     cors $
-        serve
-            agentApi
-            ( handleList baseDir mgr
-                :<|> handleStop mgr
-                :<|> handleListPanes mgr
-                :<|> handleSplitPane mgr
-                :<|> handleSelectLayout mgr
-                :<|> handleListWindows mgr
-                :<|> handleNewWindow mgr
-                :<|> handleSelectWindow mgr
-                :<|> handleScrollSession mgr
-                :<|> handleLiveSession mgr
-                :<|> handleListWorktrees baseDir
-                :<|> handleListBranches baseDir
-                :<|> handleDeleteBranch baseDir
-                :<|> staticFallback staticDir
-            )
+        rejectClosePreviewTargets $
+            serve
+                agentApi
+                ( handleList baseDir mgr
+                    :<|> handleStop mgr
+                    :<|> handleClosePreview mgr CurrentPaneScope
+                    :<|> handleCloseExecute closeBoundary mgr CurrentPaneScope
+                    :<|> handleClosePreview mgr CurrentWindowScope
+                    :<|> handleCloseExecute closeBoundary mgr CurrentWindowScope
+                    :<|> handleListPanes mgr
+                    :<|> handleSplitPane mgr
+                    :<|> handleSelectLayout mgr
+                    :<|> handleListWindows mgr
+                    :<|> handleNewWindow mgr
+                    :<|> handleSelectWindow mgr
+                    :<|> handleScrollSession mgr
+                    :<|> handleLiveSession mgr
+                    :<|> handleListWorktrees baseDir
+                    :<|> handleListBranches baseDir
+                    :<|> handleDeleteBranch baseDir
+                    :<|> staticFallback staticDir
+                )
+
+-- | Reject request bodies and query-selected targets on preview routes.
+rejectClosePreviewTargets :: Middleware
+rejectClosePreviewTargets app request respond
+    | isClosePreview request = do
+        body <- strictRequestBody request
+        if null (queryString request) && LBS.null body
+            then app request respond
+            else
+                respond $
+                    responseLBS
+                        status400
+                        [("Content-Type", "application/json")]
+                        "{\"error\":\"close preview accepts no body or target\"}"
+    | otherwise = app request respond
+  where
+    isClosePreview req =
+        requestMethod req == methodPost
+            && case pathInfo req of
+                ["sessions", _, scope, "close", "preview"] ->
+                    scope == "current-pane" || scope == "current-window"
+                _ -> False
+
+-- | Prepare and store the newest current-context close for one key.
+handleClosePreview
+    :: SessionManager
+    -> CloseContextScope
+    -> Text
+    -> Handler ClosePreview
+handleClosePreview mgr scope sidText =
+    withSession mgr sidText $ \session -> do
+        preparedResult <-
+            liftIO $
+                Tmux.prepareCurrentClose
+                    (sessionTmuxName session)
+                    (tmuxScope scope)
+        case preparedResult of
+            Left failure -> throwCloseActionFailure $ mapTmuxFailure failure
+            Right prepared -> do
+                let consequence = Tmux.preparedCloseConsequence prepared
+                    sid = sessionId session
+                    action =
+                        mapTmuxExecution
+                            <$> Tmux.executeCurrentClose
+                                (sessionTmuxName session)
+                                prepared
+                token <-
+                    liftIO $
+                        atomically $ do
+                            source <- readTVar $ closeTokenSource mgr
+                            let next = source + 1
+                                minted = renderCloseToken next
+                                pending =
+                                    PendingClose
+                                        { pendingCloseToken = minted
+                                        , pendingCloseConsequence = consequence
+                                        , pendingCloseAction = action
+                                        }
+                            writeTVar (closeTokenSource mgr) next
+                            current <- readTVar $ pendingCloses mgr
+                            writeTVar (pendingCloses mgr) $
+                                Map.insert (sid, scope) pending current
+                            pure minted
+                pure
+                    ClosePreview
+                        { closePreviewConsequence = consequence
+                        , closePreviewConfirmation = token
+                        }
+
+-- | Atomically consume and execute one recognized confirmation.
+handleCloseExecute
+    :: CloseBoundary
+    -> SessionManager
+    -> CloseContextScope
+    -> Text
+    -> CloseConfirmationRequest
+    -> Handler CloseExecution
+handleCloseExecute boundary mgr scope sidText CloseConfirmationRequest{confirmation} = do
+    consumed <-
+        liftIO $
+            atomically $
+                consumePendingClose mgr confirmation (SessionId sidText, scope)
+    case consumed of
+        Nothing -> throwError staleCurrentContext
+        Just (False, _) -> throwError staleCurrentContext
+        Just (True, PendingClose{pendingCloseAction}) -> do
+            result <- liftIO $ invokeCloseBoundary boundary pendingCloseAction
+            case result of
+                Left failure -> throwCloseActionFailure failure
+                Right
+                    CloseActionResult{closeActionConsequence, closeActionSessionEnded} -> do
+                        when closeActionSessionEnded $
+                            liftIO $
+                                atomically $ do
+                                    current <- readTVar $ sessions mgr
+                                    writeTVar (sessions mgr) $
+                                        Map.delete (SessionId sidText) current
+                        pure
+                            CloseExecution
+                                { closeExecutionConsequence = closeActionConsequence
+                                , closeExecutionSessionEnded = closeActionSessionEnded
+                                }
+
+consumePendingClose
+    :: SessionManager
+    -> Text
+    -> (SessionId, CloseContextScope)
+    -> STM (Maybe (Bool, PendingClose))
+consumePendingClose mgr token requestedKey = do
+    current <- readTVar $ pendingCloses mgr
+    case findPending $ Map.toList current of
+        Nothing -> pure Nothing
+        Just (storedKey, pending) -> do
+            writeTVar (pendingCloses mgr) $ Map.delete storedKey current
+            pure $ Just (storedKey == requestedKey, pending)
+  where
+    findPending [] = Nothing
+    findPending (entry@(_, pending) : entries)
+        | pendingCloseToken pending == token = Just entry
+        | otherwise = findPending entries
+
+tmuxScope :: CloseContextScope -> CloseScope
+tmuxScope CurrentPaneScope = CloseCurrentPane
+tmuxScope CurrentWindowScope = CloseCurrentWindow
+
+mapTmuxExecution
+    :: Either Tmux.TmuxCloseFailure Tmux.TmuxCloseResult
+    -> Either CloseActionFailure CloseActionResult
+mapTmuxExecution = \case
+    Left failure -> Left $ mapTmuxFailure failure
+    Right
+        Tmux.TmuxCloseResult{tmuxCloseConsequence, tmuxCloseSessionEnded} ->
+            Right
+                CloseActionResult
+                    { closeActionConsequence = tmuxCloseConsequence
+                    , closeActionSessionEnded = tmuxCloseSessionEnded
+                    }
+
+mapTmuxFailure :: Tmux.TmuxCloseFailure -> CloseActionFailure
+mapTmuxFailure = \case
+    Tmux.TmuxCloseStaleCurrentContext -> CloseActionStaleCurrentContext
+    Tmux.TmuxCloseUnavailable message -> CloseActionUnavailable message
+    Tmux.TmuxCloseProcessFailure message -> CloseActionProcessFailure message
+    Tmux.TmuxCloseParseFailure message -> CloseActionParseFailure message
+
+throwCloseActionFailure :: CloseActionFailure -> Handler a
+throwCloseActionFailure CloseActionStaleCurrentContext =
+    throwError staleCurrentContext
+throwCloseActionFailure failure =
+    throwError
+        err500
+            { errBody =
+                Aeson.encode $
+                    Aeson.object
+                        [ "error" Aeson..= failureCode failure
+                        , "status" Aeson..= ("tmux-failure" :: Text)
+                        , "message" Aeson..= failureMessage failure
+                        ]
+            , errHeaders = jsonHeaders
+            }
+
+failureCode :: CloseActionFailure -> Text
+failureCode CloseActionStaleCurrentContext = "stale-current-context"
+failureCode CloseActionUnavailable{} = "tmux-unavailable"
+failureCode CloseActionProcessFailure{} = "tmux-process-failure"
+failureCode CloseActionParseFailure{} = "tmux-parse-failure"
+
+failureMessage :: CloseActionFailure -> Text
+failureMessage CloseActionStaleCurrentContext =
+    "The current tmux context changed; request a new preview."
+failureMessage (CloseActionUnavailable message) = message
+failureMessage (CloseActionProcessFailure message) = message
+failureMessage (CloseActionParseFailure message) = message
+
+renderCloseToken :: Integer -> Text
+renderCloseToken identity = "confirmation-" <> encodeLetters identity
+
+encodeLetters :: Integer -> Text
+encodeLetters identity = T.pack $ reverse $ go identity
+  where
+    go value
+        | value <= 0 = []
+        | otherwise =
+            let (quotient, remainder) = (value - 1) `divMod` 26
+            in  toEnum (fromEnum 'a' + fromIntegral remainder) : go quotient
+
+staleCurrentContext :: ServerError
+staleCurrentContext =
+    err409
+        { errBody =
+            Aeson.encode $
+                Aeson.object
+                    [ "error" Aeson..= ("stale-current-context" :: Text)
+                    , "status" Aeson..= ("stale-current-context" :: Text)
+                    ]
+        , errHeaders = jsonHeaders
+        }
 
 -- | Static file fallback — serves real assets first, then index.html for SPA.
 staticFallback :: FilePath -> Tagged Handler Application

--- a/src/AgentDaemon/Api/Types.hs
+++ b/src/AgentDaemon/Api/Types.hs
@@ -15,6 +15,9 @@ module AgentDaemon.Api.Types
 
 import AgentDaemon.Types
     ( BranchInfo (..)
+    , CloseConfirmationRequest
+    , CloseExecution
+    , ClosePreview
     , LayoutRequest (..)
     , PaneInfo (..)
     , PaneSplitRequest (..)
@@ -48,6 +51,30 @@ type AgentApi =
             :> Capture "sid" Text
             :> QueryParam "confirm" Text
             :> Delete '[JSON] Value
+        :<|> "sessions"
+            :> Capture "sid" Text
+            :> "current-pane"
+            :> "close"
+            :> "preview"
+            :> Post '[JSON] ClosePreview
+        :<|> "sessions"
+            :> Capture "sid" Text
+            :> "current-pane"
+            :> "close"
+            :> ReqBody '[JSON] CloseConfirmationRequest
+            :> Post '[JSON] CloseExecution
+        :<|> "sessions"
+            :> Capture "sid" Text
+            :> "current-window"
+            :> "close"
+            :> "preview"
+            :> Post '[JSON] ClosePreview
+        :<|> "sessions"
+            :> Capture "sid" Text
+            :> "current-window"
+            :> "close"
+            :> ReqBody '[JSON] CloseConfirmationRequest
+            :> Post '[JSON] CloseExecution
         :<|> "sessions"
             :> Capture "sid" Text
             :> "panes"

--- a/src/AgentDaemon/Close.hs
+++ b/src/AgentDaemon/Close.hs
@@ -1,0 +1,263 @@
+{- |
+Module      : AgentDaemon.Close
+Description : Pure close-current state-machine model
+Copyright   : (c) 2026 Paolo Veronelli
+License     : MIT
+
+Models preparation and single-use execution of current-pane and
+current-window closes independently of tmux and the API layer.
+-}
+module AgentDaemon.Close
+    ( SessionId (..)
+    , WindowId (..)
+    , PaneId (..)
+    , CloseScope (..)
+    , CloseWindow (..)
+    , CloseTopology (..)
+    , CurrentContext (..)
+    , CloseConsequence (..)
+    , CloseFailure (..)
+    , PreparedClose
+    , CloseOutcome (..)
+    , prepareClose
+    , executeClose
+    , isConsumed
+    , isValidTopology
+    )
+where
+
+import Data.List (find, nub)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+
+-- | Stable identity of a live session.
+newtype SessionId = SessionId Int
+    deriving stock (Eq, Ord, Show)
+
+-- | Stable identity of a live window.
+newtype WindowId = WindowId Int
+    deriving stock (Eq, Ord, Show)
+
+-- | Stable identity of a live pane.
+newtype PaneId = PaneId Int
+    deriving stock (Eq, Ord, Show)
+
+-- | Current context affected by a close.
+data CloseScope
+    = CloseCurrentPane
+    | CloseCurrentWindow
+    deriving stock (Eq, Show)
+
+-- | One valid live window and its current pane.
+data CloseWindow = CloseWindow
+    { closeWindowId :: WindowId
+    , closeWindowPanes :: NonEmpty PaneId
+    , closeWindowCurrentPane :: PaneId
+    }
+    deriving stock (Eq, Show)
+
+-- | A non-empty live session topology and its current window.
+data CloseTopology = CloseTopology
+    { topologySession :: SessionId
+    , topologyWindows :: NonEmpty CloseWindow
+    , topologyCurrentWindow :: WindowId
+    }
+    deriving stock (Eq, Show)
+
+-- | Prepared identity and cardinality snapshot.
+data CurrentContext = CurrentContext
+    { contextSession :: SessionId
+    , contextScope :: CloseScope
+    , contextWindow :: WindowId
+    , contextPane :: Maybe PaneId
+    , contextWindowCount :: Int
+    , contextPaneCount :: Int
+    , contextCurrentWindowPaneCount :: Int
+    }
+    deriving stock (Eq, Show)
+
+-- | Truthful consequence previewed and returned by execution.
+data CloseConsequence
+    = PaneRemoved
+    | PaneAndWindowRemoved
+    | WindowRemoved
+    | SessionEnded
+    deriving stock (Eq, Show)
+
+-- | Failure that leaves the supplied topology unchanged.
+data CloseFailure
+    = InvalidTopology
+    | StaleCurrentContext
+    | ConfirmationConsumed
+    deriving stock (Eq, Show)
+
+-- | Single-use prepared confirmation state.
+data PreparedClose
+    = Available CurrentContext CloseConsequence
+    | Consumed CurrentContext CloseConsequence
+    deriving stock (Eq, Show)
+
+-- | Successful consequence and optional surviving topology.
+data CloseOutcome = CloseOutcome
+    { outcomeConsequence :: CloseConsequence
+    , outcomeTopology :: Maybe CloseTopology
+    }
+    deriving stock (Eq, Show)
+
+-- | Prepare a confirmation for a valid topology.
+prepareClose
+    :: CloseScope
+    -> CloseTopology
+    -> Either CloseFailure PreparedClose
+prepareClose scope topology
+    | isValidTopology topology =
+        Right $
+            Available
+                (snapshot scope topology)
+                (consequenceFor scope topology)
+    | otherwise = Left InvalidTopology
+
+-- | Consume a confirmation and execute it against fresh topology.
+executeClose
+    :: PreparedClose
+    -> CloseTopology
+    -> (PreparedClose, Either CloseFailure CloseOutcome)
+executeClose consumed@Consumed{} _ =
+    (consumed, Left ConfirmationConsumed)
+executeClose available@(Available context consequence) topology
+    | not $ isValidTopology topology =
+        (consume available, Left InvalidTopology)
+    | snapshot (contextScope context) topology /= context =
+        (consume available, Left StaleCurrentContext)
+    | otherwise =
+        ( consume available
+        , Right $ applyClose (contextScope context) consequence topology
+        )
+
+-- | Whether a confirmation has already had an execution attempt.
+isConsumed :: PreparedClose -> Bool
+isConsumed Available{} = False
+isConsumed Consumed{} = True
+
+-- | Check all live-topology identity and currentness invariants.
+isValidTopology :: CloseTopology -> Bool
+isValidTopology CloseTopology{topologyWindows, topologyCurrentWindow} =
+    unique windowIdentities
+        && unique paneIdentities
+        && topologyCurrentWindow `elem` windowIdentities
+        && all currentPaneExists windows
+  where
+    windows = NE.toList topologyWindows
+    windowIdentities = closeWindowId <$> windows
+    paneIdentities = concatMap (NE.toList . closeWindowPanes) windows
+    currentPaneExists CloseWindow{closeWindowPanes, closeWindowCurrentPane} =
+        closeWindowCurrentPane `elem` closeWindowPanes
+
+snapshot :: CloseScope -> CloseTopology -> CurrentContext
+snapshot scope topology@CloseTopology{topologySession, topologyCurrentWindow} =
+    CurrentContext
+        { contextSession = topologySession
+        , contextScope = scope
+        , contextWindow = topologyCurrentWindow
+        , contextPane = paneForScope scope topology
+        , contextWindowCount = NE.length $ topologyWindows topology
+        , contextPaneCount =
+            sum $ NE.length . closeWindowPanes <$> topologyWindows topology
+        , contextCurrentWindowPaneCount =
+            maybe 0 (NE.length . closeWindowPanes) $ currentWindowFor topology
+        }
+
+paneForScope :: CloseScope -> CloseTopology -> Maybe PaneId
+paneForScope CloseCurrentWindow _ = Nothing
+paneForScope CloseCurrentPane CloseTopology{topologyWindows, topologyCurrentWindow} =
+    closeWindowCurrentPane
+        <$> find
+            ((== topologyCurrentWindow) . closeWindowId)
+            (NE.toList topologyWindows)
+
+consume :: PreparedClose -> PreparedClose
+consume (Available context consequence) = Consumed context consequence
+consume consumed@Consumed{} = consumed
+
+unique :: (Eq a) => [a] -> Bool
+unique values = length values == length (nub values)
+
+consequenceFor :: CloseScope -> CloseTopology -> CloseConsequence
+consequenceFor CloseCurrentWindow CloseTopology{topologyWindows}
+    | NE.length topologyWindows == 1 = SessionEnded
+    | otherwise = WindowRemoved
+consequenceFor CloseCurrentPane topology@CloseTopology{topologyWindows} =
+    case currentWindowFor topology of
+        Just window
+            | NE.length (closeWindowPanes window) > 1 -> PaneRemoved
+            | NE.length topologyWindows > 1 -> PaneAndWindowRemoved
+        _ -> SessionEnded
+
+applyClose
+    :: CloseScope
+    -> CloseConsequence
+    -> CloseTopology
+    -> CloseOutcome
+applyClose CloseCurrentPane consequence topology =
+    closePane consequence topology
+applyClose CloseCurrentWindow consequence topology =
+    closeWindow consequence topology
+
+closePane :: CloseConsequence -> CloseTopology -> CloseOutcome
+closePane consequence topology =
+    case currentWindowFor topology of
+        Nothing -> CloseOutcome SessionEnded Nothing
+        Just window ->
+            case remainingPanes window of
+                Just panes ->
+                    CloseOutcome consequence . Just $
+                        topology
+                            { topologyWindows =
+                                replaceCurrentWindow
+                                    topology
+                                    window
+                                        { closeWindowPanes = panes
+                                        , closeWindowCurrentPane = NE.head panes
+                                        }
+                            }
+                Nothing -> closeWindow consequence topology
+
+closeWindow :: CloseConsequence -> CloseTopology -> CloseOutcome
+closeWindow consequence topology =
+    case remainingWindows topology of
+        Nothing -> CloseOutcome SessionEnded Nothing
+        Just windows ->
+            CloseOutcome consequence . Just $
+                topology
+                    { topologyWindows = windows
+                    , topologyCurrentWindow = closeWindowId $ NE.head windows
+                    }
+
+currentWindowFor :: CloseTopology -> Maybe CloseWindow
+currentWindowFor CloseTopology{topologyWindows, topologyCurrentWindow} =
+    find
+        ((== topologyCurrentWindow) . closeWindowId)
+        (NE.toList topologyWindows)
+
+remainingPanes :: CloseWindow -> Maybe (NonEmpty PaneId)
+remainingPanes CloseWindow{closeWindowPanes, closeWindowCurrentPane} =
+    NE.nonEmpty $
+        filter (/= closeWindowCurrentPane) $
+            NE.toList closeWindowPanes
+
+remainingWindows :: CloseTopology -> Maybe (NonEmpty CloseWindow)
+remainingWindows CloseTopology{topologyWindows, topologyCurrentWindow} =
+    NE.nonEmpty $
+        filter ((/= topologyCurrentWindow) . closeWindowId) $
+            NE.toList topologyWindows
+
+replaceCurrentWindow
+    :: CloseTopology
+    -> CloseWindow
+    -> NonEmpty CloseWindow
+replaceCurrentWindow CloseTopology{topologyWindows, topologyCurrentWindow} replacement =
+    replace <$> topologyWindows
+  where
+    replace window
+        | closeWindowId window == topologyCurrentWindow = replacement
+        | otherwise = window

--- a/src/AgentDaemon/Tmux.hs
+++ b/src/AgentDaemon/Tmux.hs
@@ -3,6 +3,7 @@ module AgentDaemon.Tmux
     , TmuxCloseFailure (..)
     , TmuxCloseResult (..)
     , prepareCurrentClose
+    , preparedCloseConsequence
     , executeCurrentClose
     , createSession
     , killSession
@@ -72,6 +73,11 @@ data PreparedTmuxClose
         Int
         Int
         CloseConsequence
+
+-- | Reveal only the already-computed consequence of an opaque close.
+preparedCloseConsequence :: PreparedTmuxClose -> CloseConsequence
+preparedCloseConsequence (PreparedTmuxClose _ _ _ _ _ _ _ _ consequence) =
+    consequence
 
 -- | Failure at the live tmux close boundary.
 data TmuxCloseFailure

--- a/src/AgentDaemon/Tmux.hs
+++ b/src/AgentDaemon/Tmux.hs
@@ -1,5 +1,10 @@
 module AgentDaemon.Tmux
-    ( createSession
+    ( PreparedTmuxClose
+    , TmuxCloseFailure (..)
+    , TmuxCloseResult (..)
+    , prepareCurrentClose
+    , executeCurrentClose
+    , createSession
     , killSession
     , listSessions
     , listPanes
@@ -24,6 +29,18 @@ module AgentDaemon.Tmux
 -- inside a named tmux session that persists across terminal
 -- disconnects.
 
+import AgentDaemon.Close
+    ( CloseConsequence (..)
+    , CloseFailure (..)
+    , CloseOutcome (..)
+    , CloseScope (..)
+    , CloseTopology (..)
+    , CloseWindow (..)
+    , PreparedClose
+    , executeClose
+    , prepareClose
+    )
+import AgentDaemon.Close qualified as Close
 import AgentDaemon.Types
     ( PaneId (..)
     , PaneInfo (..)
@@ -31,6 +48,8 @@ import AgentDaemon.Types
     , WindowInfo (..)
     )
 import Control.Exception (IOException, try)
+import Data.List (groupBy, nub)
+import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
 import Data.Text qualified as T
 import System.Exit (ExitCode (..))
@@ -40,6 +59,406 @@ import System.Process
     , readProcessWithExitCode
     )
 import Text.Read (readMaybe)
+
+-- | Opaque, internally targeted close prepared from live tmux state.
+data PreparedTmuxClose
+    = PreparedTmuxClose
+        Text
+        CloseScope
+        PreparedClose
+        Text
+        Text
+        (Maybe Text)
+        Int
+        Int
+        CloseConsequence
+
+-- | Failure at the live tmux close boundary.
+data TmuxCloseFailure
+    = TmuxCloseStaleCurrentContext
+    | TmuxCloseUnavailable Text
+    | TmuxCloseProcessFailure Text
+    | TmuxCloseParseFailure Text
+    deriving stock (Eq, Show)
+
+-- | Truthful result of executing a prepared close.
+data TmuxCloseResult = TmuxCloseResult
+    { tmuxCloseConsequence :: CloseConsequence
+    , tmuxCloseSessionEnded :: Bool
+    }
+    deriving stock (Eq, Show)
+
+{- | Prepare a current-only close from one live topology snapshot.
+
+The returned value is opaque so callers cannot forge a later target.
+-}
+prepareCurrentClose
+    :: Text
+    -> CloseScope
+    -> IO (Either TmuxCloseFailure PreparedTmuxClose)
+prepareCurrentClose sessionName scope = do
+    topologyResult <- queryCloseTopology sessionName
+    pure $ do
+        topology <- topologyResult
+        prepared <-
+            either
+                (const $ Left $ TmuxCloseParseFailure "invalid tmux topology")
+                Right
+                (prepareClose scope topology)
+        consequence <-
+            case snd $ executeClose prepared topology of
+                Right CloseOutcome{outcomeConsequence} -> Right outcomeConsequence
+                Left _ -> Left $ TmuxCloseParseFailure "invalid prepared topology"
+        let currentWindow = topologyCurrentWindow topology
+            currentPane = currentPaneFor currentWindow topology
+            windowCount = NE.length $ topologyWindows topology
+            paneCount = currentWindowPaneCount currentWindow topology
+        Right $
+            PreparedTmuxClose
+                sessionName
+                scope
+                prepared
+                (renderSessionId $ topologySession topology)
+                (renderWindowId currentWindow)
+                (renderPaneId <$> currentPane)
+                windowCount
+                paneCount
+                consequence
+
+{- | Execute an opaque prepared close.
+
+Fresh tmux state must match the prepared model before a single atomic
+tmux conditional is allowed to close the internally recorded target.
+-}
+executeCurrentClose
+    :: Text
+    -> PreparedTmuxClose
+    -> IO (Either TmuxCloseFailure TmuxCloseResult)
+executeCurrentClose
+    sessionName
+    prepared
+        | sessionName /= preparedName prepared =
+            pure $ Left TmuxCloseStaleCurrentContext
+        | otherwise = do
+            freshResult <- queryCloseTopology sessionName
+            case freshResult of
+                Left failure -> pure $ Left failure
+                Right fresh ->
+                    case validatePrepared prepared fresh of
+                        Left failure -> pure $ Left failure
+                        Right () -> runPreparedClose prepared
+
+preparedName :: PreparedTmuxClose -> Text
+preparedName (PreparedTmuxClose name _ _ _ _ _ _ _ _) = name
+
+validatePrepared
+    :: PreparedTmuxClose
+    -> CloseTopology
+    -> Either TmuxCloseFailure ()
+validatePrepared (PreparedTmuxClose _ _ model _ _ _ _ _ _) fresh =
+    case snd $ executeClose model fresh of
+        Left StaleCurrentContext -> Left TmuxCloseStaleCurrentContext
+        Left ConfirmationConsumed -> Left TmuxCloseStaleCurrentContext
+        Left InvalidTopology ->
+            Left $ TmuxCloseParseFailure "invalid fresh tmux topology"
+        Right _ -> Right ()
+
+runPreparedClose
+    :: PreparedTmuxClose
+    -> IO (Either TmuxCloseFailure TmuxCloseResult)
+runPreparedClose
+    ( PreparedTmuxClose
+            _
+            scope
+            _
+            sessionId
+            windowId
+            paneId
+            windowCount
+            paneCount
+            consequence
+        ) = do
+        result <-
+            try $
+                readProcessWithExitCode
+                    "tmux"
+                    [ "if-shell"
+                    , "-F"
+                    , "-t"
+                    , T.unpack sessionId
+                    , T.unpack $
+                        closeCondition
+                            scope
+                            sessionId
+                            windowId
+                            paneId
+                            windowCount
+                            paneCount
+                    , T.unpack $ closeCommand scope windowId paneId
+                    , "run-shell 'exit 71'"
+                    ]
+                    ""
+        pure $ case result of
+            Left exception ->
+                Left $
+                    TmuxCloseProcessFailure $
+                        "tmux if-shell failed: "
+                            <> T.pack (show (exception :: IOException))
+            Right (ExitFailure 71, _, _) ->
+                Left TmuxCloseStaleCurrentContext
+            Right (ExitFailure code, _, stderr) ->
+                Left $
+                    TmuxCloseProcessFailure $
+                        "tmux if-shell failed ("
+                            <> T.pack (show code)
+                            <> "): "
+                            <> T.strip (T.pack stderr)
+            Right (ExitSuccess, _, _) ->
+                Right
+                    TmuxCloseResult
+                        { tmuxCloseConsequence = consequence
+                        , tmuxCloseSessionEnded = consequence == SessionEnded
+                        }
+
+closeCondition
+    :: CloseScope
+    -> Text
+    -> Text
+    -> Maybe Text
+    -> Int
+    -> Int
+    -> Text
+closeCondition scope sessionId windowId paneId windowCount paneCount =
+    formatAnd $
+        [ formatEquals "#{session_id}" sessionId
+        , formatEquals "#{window_id}" windowId
+        , formatEquals "#{window_active}" "1"
+        , formatEquals "#{session_windows}" $ T.pack $ show windowCount
+        ]
+            <> paneConditions
+  where
+    paneConditions =
+        case (scope, paneId) of
+            (CloseCurrentPane, Just stablePaneId) ->
+                [ formatEquals "#{pane_id}" stablePaneId
+                , formatEquals "#{pane_active}" "1"
+                , formatEquals "#{window_panes}" $ T.pack $ show paneCount
+                ]
+            _ -> []
+
+formatEquals :: Text -> Text -> Text
+formatEquals actual expected =
+    "#{==:" <> actual <> "," <> expected <> "}"
+
+formatAnd :: [Text] -> Text
+formatAnd [] = "1"
+formatAnd [condition] = condition
+formatAnd (condition : conditions) =
+    "#{&&:" <> condition <> "," <> formatAnd conditions <> "}"
+
+closeCommand :: CloseScope -> Text -> Maybe Text -> Text
+closeCommand CloseCurrentPane _ (Just paneId) = "kill-pane -t " <> paneId
+closeCommand CloseCurrentPane _ Nothing = "run-shell 'exit 71'"
+closeCommand CloseCurrentWindow windowId _ = "kill-window -t " <> windowId
+
+currentPaneFor
+    :: Close.WindowId -> CloseTopology -> Maybe Close.PaneId
+currentPaneFor windowId CloseTopology{topologyWindows} =
+    closeWindowCurrentPane
+        <$> listHead
+            (filter ((== windowId) . closeWindowId) $ NE.toList topologyWindows)
+
+currentWindowPaneCount :: Close.WindowId -> CloseTopology -> Int
+currentWindowPaneCount windowId CloseTopology{topologyWindows} =
+    maybe 0 (NE.length . closeWindowPanes) $
+        listHead $
+            filter ((== windowId) . closeWindowId) $
+                NE.toList topologyWindows
+
+renderSessionId :: Close.SessionId -> Text
+renderSessionId (Close.SessionId identity) = "$" <> T.pack (show identity)
+
+renderWindowId :: Close.WindowId -> Text
+renderWindowId (Close.WindowId identity) = "@" <> T.pack (show identity)
+
+renderPaneId :: Close.PaneId -> Text
+renderPaneId (Close.PaneId identity) = "%" <> T.pack (show identity)
+
+data ClosePaneRow = ClosePaneRow
+    { rowSessionId :: Close.SessionId
+    , rowWindowId :: Close.WindowId
+    , rowWindowActive :: Bool
+    , rowWindowPaneCount :: Int
+    , rowPaneId :: Close.PaneId
+    , rowPaneActive :: Bool
+    }
+
+queryCloseTopology
+    :: Text -> IO (Either TmuxCloseFailure CloseTopology)
+queryCloseTopology sessionName = do
+    result <-
+        try $
+            readProcessWithExitCode
+                "tmux"
+                [ "list-panes"
+                , "-s"
+                , "-t"
+                , T.unpack sessionName
+                , "-F"
+                , T.unpack closePaneFormat
+                ]
+                ""
+    pure $ case result of
+        Left exception ->
+            Left $
+                TmuxCloseProcessFailure $
+                    "tmux list-panes failed: "
+                        <> T.pack (show (exception :: IOException))
+        Right (ExitFailure code, _, stderr)
+            | unavailableMessage stderr ->
+                Left $ TmuxCloseUnavailable $ T.strip $ T.pack stderr
+            | otherwise ->
+                Left $
+                    TmuxCloseProcessFailure $
+                        "tmux list-panes failed ("
+                            <> T.pack (show code)
+                            <> "): "
+                            <> T.strip (T.pack stderr)
+        Right (ExitSuccess, output, _) -> parseCloseTopology $ T.pack output
+
+unavailableMessage :: String -> Bool
+unavailableMessage stderr =
+    any
+        (`T.isInfixOf` message)
+        [ "can't find session"
+        , "no server running"
+        , "no sessions"
+        ]
+  where
+    message = T.toLower $ T.pack stderr
+
+parseCloseTopology :: Text -> Either TmuxCloseFailure CloseTopology
+parseCloseTopology output = do
+    rows <- traverse parseClosePaneRow $ T.lines output
+    firstRow <-
+        maybe
+            (Left $ TmuxCloseParseFailure "tmux returned an empty topology")
+            Right
+            (listHead rows)
+    windows <- traverse rowsToWindow $ groupBy sameWindow rows
+    nonEmptyWindows <-
+        maybe
+            (Left $ TmuxCloseParseFailure "tmux returned no windows")
+            Right
+            (NE.nonEmpty windows)
+    currentWindow <-
+        exactlyOne "active window" id $
+            nub $
+                rowWindowId <$> filter rowWindowActive rows
+    pure
+        CloseTopology
+            { topologySession = rowSessionId firstRow
+            , topologyWindows = nonEmptyWindows
+            , topologyCurrentWindow = currentWindow
+            }
+  where
+    sameWindow left right = rowWindowId left == rowWindowId right
+
+rowsToWindow :: [ClosePaneRow] -> Either TmuxCloseFailure CloseWindow
+rowsToWindow rows = do
+    firstRow <-
+        maybe
+            (Left $ TmuxCloseParseFailure "tmux returned an empty window")
+            Right
+            (listHead rows)
+    panes <-
+        maybe
+            (Left $ TmuxCloseParseFailure "tmux returned a window without panes")
+            Right
+            (NE.nonEmpty $ rowPaneId <$> rows)
+    if rowWindowPaneCount firstRow /= length rows
+        then Left $ TmuxCloseParseFailure "tmux window pane count mismatch"
+        else do
+            currentPane <-
+                exactlyOne "active pane" rowPaneId $ filter rowPaneActive rows
+            pure
+                CloseWindow
+                    { closeWindowId = rowWindowId firstRow
+                    , closeWindowPanes = panes
+                    , closeWindowCurrentPane = currentPane
+                    }
+
+parseClosePaneRow :: Text -> Either TmuxCloseFailure ClosePaneRow
+parseClosePaneRow line =
+    case T.splitOn "\t" line of
+        [ sessionText
+            , windowText
+            , windowActiveText
+            , paneCountText
+            , paneText
+            , paneActiveText
+            ] ->
+                ClosePaneRow
+                    <$> parseStableId "$" Close.SessionId sessionText
+                    <*> parseStableId "@" Close.WindowId windowText
+                    <*> parseCloseBool "window_active" windowActiveText
+                    <*> parseCloseInt "window_panes" paneCountText
+                    <*> parseStableId "%" Close.PaneId paneText
+                    <*> parseCloseBool "pane_active" paneActiveText
+        _ ->
+            Left $
+                TmuxCloseParseFailure $
+                    "unexpected tmux close metadata: " <> line
+
+parseStableId
+    :: Text
+    -> (Int -> a)
+    -> Text
+    -> Either TmuxCloseFailure a
+parseStableId prefix constructor raw =
+    case T.stripPrefix prefix raw of
+        Nothing ->
+            Left $
+                TmuxCloseParseFailure $
+                    "invalid stable identity prefix: " <> raw
+        Just numeric -> constructor <$> parseCloseInt "stable identity" numeric
+
+parseCloseInt :: Text -> Text -> Either TmuxCloseFailure Int
+parseCloseInt field raw =
+    maybe
+        (Left $ TmuxCloseParseFailure $ "invalid " <> field <> ": " <> raw)
+        Right
+        (readMaybe $ T.unpack raw)
+
+parseCloseBool :: Text -> Text -> Either TmuxCloseFailure Bool
+parseCloseBool field = \case
+    "0" -> Right False
+    "1" -> Right True
+    raw -> Left $ TmuxCloseParseFailure $ "invalid " <> field <> ": " <> raw
+
+exactlyOne
+    :: Text
+    -> (a -> b)
+    -> [a]
+    -> Either TmuxCloseFailure b
+exactlyOne _ project [value] = Right $ project value
+exactlyOne label _ _ = Left $ TmuxCloseParseFailure $ "expected exactly one " <> label
+
+listHead :: [a] -> Maybe a
+listHead [] = Nothing
+listHead (value : _) = Just value
+
+closePaneFormat :: Text
+closePaneFormat =
+    T.intercalate
+        "\t"
+        [ "#{session_id}"
+        , "#{window_id}"
+        , "#{window_active}"
+        , "#{window_panes}"
+        , "#{pane_id}"
+        , "#{pane_active}"
+        ]
 
 {- | Create a new detached tmux session.
 

--- a/src/AgentDaemon/Types.hs
+++ b/src/AgentDaemon/Types.hs
@@ -14,6 +14,13 @@ module AgentDaemon.Types
     , PaneSplitDirection (..)
     , PaneSplitRequest (..)
     , LayoutRequest (..)
+    , CloseConfirmationRequest (..)
+    , ClosePreview (..)
+    , CloseExecution (..)
+    , CloseContextScope (..)
+    , CloseActionFailure (..)
+    , CloseActionResult (..)
+    , PendingClose (..)
     , WorktreeInfo (..)
     , BranchInfo (..)
     , SyncStatus (..)
@@ -30,6 +37,7 @@ module AgentDaemon.Types
 --
 -- Domain types for tmux-backed session management.
 
+import AgentDaemon.Close (CloseConsequence (..))
 import Control.Concurrent.STM
     ( TVar
     , atomically
@@ -46,6 +54,7 @@ import Data.Aeson
     , genericToJSON
     )
 import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KM
 import Data.Char (isAsciiUpper, toLower)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -145,15 +154,49 @@ data Session = Session
 instance ToJSON Session where
     toJSON = genericToJSON stripPrefix
 
--- | Thread-safe session registry.
-newtype SessionManager = SessionManager
+-- | Thread-safe session registry and close-confirmation state.
+data SessionManager = SessionManager
     { sessions :: TVar (Map SessionId Session)
+    , pendingCloses
+        :: TVar (Map (SessionId, CloseContextScope) PendingClose)
+    , closeTokenSource :: TVar Integer
+    }
+
+-- | API-neutral current-context scope used as a manager key.
+data CloseContextScope
+    = CurrentPaneScope
+    | CurrentWindowScope
+    deriving stock (Eq, Ord, Show)
+
+-- | API-neutral close execution failure.
+data CloseActionFailure
+    = CloseActionStaleCurrentContext
+    | CloseActionUnavailable Text
+    | CloseActionProcessFailure Text
+    | CloseActionParseFailure Text
+    deriving stock (Eq, Show)
+
+-- | API-neutral truthful close result.
+data CloseActionResult = CloseActionResult
+    { closeActionConsequence :: CloseConsequence
+    , closeActionSessionEnded :: Bool
+    }
+    deriving stock (Eq, Show)
+
+-- | Newest pending server-side close for one session and scope.
+data PendingClose = PendingClose
+    { pendingCloseToken :: Text
+    , pendingCloseConsequence :: CloseConsequence
+    , pendingCloseAction :: IO (Either CloseActionFailure CloseActionResult)
     }
 
 -- | Create an empty session manager.
 newSessionManager :: IO SessionManager
-newSessionManager =
-    SessionManager <$> newTVarIO Map.empty
+newSessionManager = do
+    sessions <- newTVarIO Map.empty
+    pendingCloses <- newTVarIO Map.empty
+    closeTokenSource <- newTVarIO 0
+    pure SessionManager{sessions, pendingCloses, closeTokenSource}
 
 -- | Metadata for a tmux pane inside a session.
 data PaneInfo = PaneInfo
@@ -260,6 +303,52 @@ newtype LayoutRequest = LayoutRequest
 
 instance FromJSON LayoutRequest where
     parseJSON = genericParseJSON stripPrefix
+
+-- | Opaque server-minted confirmation supplied to a close execution.
+newtype CloseConfirmationRequest = CloseConfirmationRequest
+    { confirmation :: Text
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance FromJSON CloseConfirmationRequest where
+    parseJSON = Aeson.withObject "CloseConfirmationRequest" $ \value ->
+        if KM.size value == 1 && KM.member "confirmation" value
+            then CloseConfirmationRequest <$> value Aeson..: "confirmation"
+            else fail "expected only the confirmation field"
+
+-- | Current-context consequence and opaque confirmation preview.
+data ClosePreview = ClosePreview
+    { closePreviewConsequence :: CloseConsequence
+    , closePreviewConfirmation :: Text
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON ClosePreview where
+    toJSON ClosePreview{closePreviewConsequence, closePreviewConfirmation} =
+        Aeson.object
+            [ "consequence" Aeson..= consequenceText closePreviewConsequence
+            , "confirmation" Aeson..= closePreviewConfirmation
+            ]
+
+-- | Truthful result of executing a current-context close.
+data CloseExecution = CloseExecution
+    { closeExecutionConsequence :: CloseConsequence
+    , closeExecutionSessionEnded :: Bool
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON CloseExecution where
+    toJSON CloseExecution{closeExecutionConsequence, closeExecutionSessionEnded} =
+        Aeson.object
+            [ "consequence" Aeson..= consequenceText closeExecutionConsequence
+            , "sessionEnded" Aeson..= closeExecutionSessionEnded
+            ]
+
+consequenceText :: CloseConsequence -> Text
+consequenceText PaneRemoved = "pane-removed"
+consequenceText PaneAndWindowRemoved = "pane-and-window-removed"
+consequenceText WindowRemoved = "window-removed"
+consequenceText SessionEnded = "session-ended"
 
 -- | A worktree directory on disk, with repo and issue metadata.
 data WorktreeInfo = WorktreeInfo

--- a/test/AgentDaemon/ApiSpec.hs
+++ b/test/AgentDaemon/ApiSpec.hs
@@ -14,16 +14,30 @@ module AgentDaemon.ApiSpec
 -- a live warp test server. Validates request/response shapes
 -- and error handling.
 
-import AgentDaemon.Api (apiApp)
+import AgentDaemon.Api
+    ( CloseActionFailure (..)
+    , CloseBoundary (..)
+    , apiApp
+    , apiAppWithCloseBoundary
+    )
 import AgentDaemon.Types
     ( Session (..)
     , SessionId (..)
+    , SessionManager
     , SessionState (..)
     , newSessionManager
     , sessions
     )
+import Control.Concurrent
+    ( MVar
+    , forkIO
+    , newEmptyMVar
+    , putMVar
+    , takeMVar
+    )
 import Control.Concurrent.STM
     ( atomically
+    , readTVarIO
     , writeTVar
     )
 import Control.Exception
@@ -31,26 +45,46 @@ import Control.Exception
     )
 import Data.Aeson
     ( Value (..)
+    , decode
     , object
     , (.=)
     )
+import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KM
+import Data.Char (isAsciiLower, isDigit)
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , atomicWriteIORef
+    , newIORef
+    , readIORef
+    )
 import Data.Map.Strict qualified as Map
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time (getCurrentTime)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Unique (hashUnique, newUnique)
 import Network.HTTP.Client
-    ( defaultManagerSettings
+    ( RequestBody (RequestBodyLBS)
+    , defaultManagerSettings
     , httpLbs
     , method
     , newManager
     , parseRequest
+    , requestBody
     , requestHeaders
     , responseHeaders
     , responseStatus
     )
-import Network.HTTP.Types (status200, status400, status404)
+import Network.HTTP.Types
+    ( status200
+    , status400
+    , status404
+    , status409
+    , status500
+    )
 import Network.Wai.Handler.Warp qualified as Warp
 import Servant.API
     ( Capture
@@ -70,6 +104,7 @@ import Servant.Client
     , Scheme (..)
     , client
     , mkClientEnv
+    , responseBody
     , responseStatusCode
     , runClientM
     )
@@ -82,12 +117,14 @@ import System.Process
     , readProcess
     , readProcessWithExitCode
     )
+import System.Timeout (timeout)
 import Test.Hspec
     ( Spec
     , around
     , describe
     , it
     , shouldBe
+    , shouldReturn
     , shouldSatisfy
     )
 
@@ -99,6 +136,30 @@ type RestApi =
             :> Capture "sid" Text
             :> QueryParam "confirm" Text
             :> Delete '[JSON] Value
+        :<|> "sessions"
+            :> Capture "sid" Text
+            :> "current-pane"
+            :> "close"
+            :> "preview"
+            :> Post '[JSON] Value
+        :<|> "sessions"
+            :> Capture "sid" Text
+            :> "current-pane"
+            :> "close"
+            :> ReqBody '[JSON] Value
+            :> Post '[JSON] Value
+        :<|> "sessions"
+            :> Capture "sid" Text
+            :> "current-window"
+            :> "close"
+            :> "preview"
+            :> Post '[JSON] Value
+        :<|> "sessions"
+            :> Capture "sid" Text
+            :> "current-window"
+            :> "close"
+            :> ReqBody '[JSON] Value
+            :> Post '[JSON] Value
         :<|> "sessions"
             :> Capture "sid" Text
             :> "panes"
@@ -139,6 +200,10 @@ type RestApi =
 -- | Servant client functions.
 listSessions :: ClientM [Value]
 deleteSession :: Text -> Maybe Text -> ClientM Value
+previewPaneClose :: Text -> ClientM Value
+executePaneClose :: Text -> Value -> ClientM Value
+previewWindowClose :: Text -> ClientM Value
+executeWindowClose :: Text -> Value -> ClientM Value
 listPanes :: Text -> ClientM [Value]
 splitPane :: Text -> Value -> ClientM Value
 _selectLayout :: Text -> Value -> ClientM Value
@@ -150,6 +215,10 @@ listBranches :: ClientM [Value]
 _deleteBranch :: Text -> Text -> ClientM Value
 ( listSessions
         :<|> deleteSession
+        :<|> previewPaneClose
+        :<|> executePaneClose
+        :<|> previewWindowClose
+        :<|> executeWindowClose
         :<|> listPanes
         :<|> splitPane
         :<|> _selectLayout
@@ -165,10 +234,6 @@ _deleteBranch :: Text -> Text -> ClientM Value
 testBaseDir :: FilePath
 testBaseDir = "/tmp/agent-daemon-test"
 
--- | Tmux session name for pane API tests.
-testPaneSession :: Text
-testPaneSession = "agent-daemon-api-pane-test"
-
 -- | Run a test against a temporary warp server.
 withTestServer :: (Int -> IO ()) -> IO ()
 withTestServer action =
@@ -181,51 +246,105 @@ withTestServer action =
             Warp.testWithApplication (pure app) action
 
 -- | Run a test server with one registered tmux session.
-withPaneTestServer :: (Int -> IO ()) -> IO ()
+data TestBoundary = TestBoundary
+    { testBoundary :: CloseBoundary
+    , testBoundaryAttempts :: IORef Int
+    , testBoundaryGate :: IORef (Maybe (MVar (), MVar ()))
+    , testBoundaryFailure :: IORef (Maybe CloseActionFailure)
+    , testSessionManager :: SessionManager
+    }
+
+newTestBoundary :: SessionManager -> IO TestBoundary
+newTestBoundary testSessionManager = do
+    testBoundaryAttempts <- newIORef 0
+    testBoundaryGate <- newIORef Nothing
+    testBoundaryFailure <- newIORef Nothing
+    let testBoundary = CloseBoundary $ \realAction -> do
+            atomicModifyIORef' testBoundaryAttempts $ \count -> (count + 1, ())
+            gate <- readIORef testBoundaryGate
+            gateResult <- case gate of
+                Nothing -> pure $ Just ()
+                Just (entered, release) ->
+                    timeout 3000000 $ do
+                        putMVar entered ()
+                        takeMVar release
+            case gateResult of
+                Nothing ->
+                    pure $
+                        Left $
+                            CloseActionProcessFailure "test boundary timed out"
+                Just () -> do
+                    injected <- readIORef testBoundaryFailure
+                    atomicWriteIORef testBoundaryFailure Nothing
+                    maybe realAction (pure . Left) injected
+    pure
+        TestBoundary
+            { testBoundary
+            , testBoundaryAttempts
+            , testBoundaryGate
+            , testBoundaryFailure
+            , testSessionManager
+            }
+
+-- | Run a test server with one registered tmux session.
+withPaneTestServer :: ((Int, Text, TestBoundary) -> IO ()) -> IO ()
 withPaneTestServer action =
-    bracket_ setup cleanup $ do
-        mgr <- newSessionManager
-        now <- getCurrentTime
-        let sid = SessionId testPaneSession
-            session =
-                Session
-                    { sessionId = sid
-                    , sessionTmuxName = testPaneSession
-                    , sessionCurrentPath = "/tmp"
-                    , sessionState = Running
-                    , sessionCreatedAt = now
-                    , sessionLastActivity = now
-                    }
-        atomically $
-            writeTVar
-                (sessions mgr)
-                (Map.singleton sid session)
-        let app = apiApp testBaseDir "static" mgr
-        Warp.testWithApplication (pure app) action
-  where
-    setup = do
-        cleanup
-        callProcess
-            "tmux"
-            [ "new-session"
-            , "-d"
-            , "-s"
-            , T.unpack testPaneSession
-            , "-n"
-            , "first"
-            , "-x"
-            , "100"
-            , "-y"
-            , "40"
-            , "-c"
-            , "/tmp"
-            ]
-    cleanup =
-        ()
-            <$ readProcessWithExitCode
-                "tmux"
-                ["kill-session", "-t", T.unpack testPaneSession]
-                ""
+    do
+        unique <- newUnique
+        epoch <- round . (* 1000000) <$> getPOSIXTime
+        let testPaneSession =
+                "agent-daemon-api-"
+                    <> T.pack (show (epoch :: Integer))
+                    <> "-"
+                    <> T.pack (show $ hashUnique unique)
+            setup =
+                callProcess
+                    "tmux"
+                    [ "new-session"
+                    , "-d"
+                    , "-s"
+                    , T.unpack testPaneSession
+                    , "-n"
+                    , "first"
+                    , "-x"
+                    , "100"
+                    , "-y"
+                    , "40"
+                    , "-c"
+                    , "/tmp"
+                    ]
+            cleanup =
+                ()
+                    <$ readProcessWithExitCode
+                        "tmux"
+                        ["kill-session", "-t", T.unpack testPaneSession]
+                        ""
+        bracket_ setup cleanup $ do
+            mgr <- newSessionManager
+            boundary <- newTestBoundary mgr
+            now <- getCurrentTime
+            let sid = SessionId testPaneSession
+                session =
+                    Session
+                        { sessionId = sid
+                        , sessionTmuxName = testPaneSession
+                        , sessionCurrentPath = "/tmp"
+                        , sessionState = Running
+                        , sessionCreatedAt = now
+                        , sessionLastActivity = now
+                        }
+            atomically $
+                writeTVar
+                    (sessions mgr)
+                    (Map.singleton sid session)
+            let app =
+                    apiAppWithCloseBoundary
+                        (testBoundary boundary)
+                        testBaseDir
+                        "static"
+                        mgr
+            Warp.testWithApplication (pure app) $ \port ->
+                action (port, testPaneSession, boundary)
 
 -- | Run a client request against a test server.
 runClient
@@ -315,8 +434,401 @@ spec = describe "REST API" $ do
                     `shouldBe` Just "Content-Type"
 
     around (\action -> withPaneTestServer action) $ do
+        it "previews and closes only the current pane" $
+            \(port, testPaneSession, _) -> do
+                callProcess
+                    "tmux"
+                    [ "split-window"
+                    , "-v"
+                    , "-t"
+                    , T.unpack testPaneSession
+                    , "-c"
+                    , "/tmp"
+                    ]
+                before <- tmuxIdentities "list-panes" testPaneSession
+                active <- tmuxActive "pane" testPaneSession
+                preview <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                secrets <- tmuxTokenSecrets testPaneSession
+                tokenText preview
+                    `shouldSatisfy` opaqueToken testPaneSession secrets
+                preview `shouldSatisfy` hasExactPreviewSchema
+                field "consequence" preview `shouldBe` Just (String "pane-removed")
+                result <-
+                    requireRight
+                        =<< runClient
+                            port
+                            (executePaneClose testPaneSession $ confirmationBody preview)
+                field "consequence" result `shouldBe` Just (String "pane-removed")
+                field "sessionEnded" result `shouldBe` Just (Bool False)
+                after <- tmuxIdentities "list-panes" testPaneSession
+                after `shouldBe` filter (/= active) before
+                sessionsResult <- requireRight =<< runClient port listSessions
+                sessionsResult `shouldSatisfy` any (hasSessionId testPaneSession)
+                result `shouldSatisfy` hasExactExecutionSchema
+
+        it
+            "classifies a last pane as removing its window but preserves another window"
+            $ \(port, testPaneSession, _) -> do
+                callProcess
+                    "tmux"
+                    ["new-window", "-t", T.unpack testPaneSession, "-n", "survivor"]
+                callProcess
+                    "tmux"
+                    ["select-window", "-t", T.unpack testPaneSession <> ":first"]
+                before <- tmuxIdentities "list-windows" testPaneSession
+                active <- tmuxActive "window" testPaneSession
+                preview <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                field "consequence" preview
+                    `shouldBe` Just (String "pane-and-window-removed")
+                result <-
+                    requireRight
+                        =<< runClient
+                            port
+                            (executePaneClose testPaneSession $ confirmationBody preview)
+                field "sessionEnded" result `shouldBe` Just (Bool False)
+                field "consequence" result
+                    `shouldBe` Just (String "pane-and-window-removed")
+                after <- tmuxIdentities "list-windows" testPaneSession
+                after `shouldBe` filter (/= active) before
+                sessionsResult <- requireRight =<< runClient port listSessions
+                sessionsResult `shouldSatisfy` any (hasSessionId testPaneSession)
+                result `shouldSatisfy` hasExactExecutionSchema
+
+        it "truthfully ends and unregisters the last pane of the last window" $
+            \(port, testPaneSession, _) -> do
+                preview <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                field "consequence" preview `shouldBe` Just (String "session-ended")
+                result <-
+                    requireRight
+                        =<< runClient
+                            port
+                            (executePaneClose testPaneSession $ confirmationBody preview)
+                field "sessionEnded" result `shouldBe` Just (Bool True)
+                field "consequence" result
+                    `shouldBe` Just (String "session-ended")
+                sessionsResult <- requireRight =<< runClient port listSessions
+                sessionsResult
+                    `shouldSatisfy` all (not . hasSessionId testPaneSession)
+                result `shouldSatisfy` containsNoTmuxIdentity
+                result `shouldSatisfy` hasExactExecutionSchema
+
+        it
+            "closes only the current window and reports last-window session end"
+            $ \(port, testPaneSession, _) -> do
+                callProcess
+                    "tmux"
+                    ["new-window", "-t", T.unpack testPaneSession, "-n", "current"]
+                before <- tmuxIdentities "list-windows" testPaneSession
+                active <- tmuxActive "window" testPaneSession
+                preview <-
+                    requireRight =<< runClient port (previewWindowClose testPaneSession)
+                secrets <- tmuxTokenSecrets testPaneSession
+                tokenText preview
+                    `shouldSatisfy` opaqueToken testPaneSession secrets
+                field "consequence" preview `shouldBe` Just (String "window-removed")
+                result <-
+                    requireRight
+                        =<< runClient
+                            port
+                            (executeWindowClose testPaneSession $ confirmationBody preview)
+                field "sessionEnded" result `shouldBe` Just (Bool False)
+                after <- tmuxIdentities "list-windows" testPaneSession
+                after `shouldBe` filter (/= active) before
+                survivorRegistry <- requireRight =<< runClient port listSessions
+                survivorRegistry `shouldSatisfy` any (hasSessionId testPaneSession)
+                result `shouldSatisfy` hasExactExecutionSchema
+                lastPreview <-
+                    requireRight =<< runClient port (previewWindowClose testPaneSession)
+                ended <-
+                    requireRight
+                        =<< runClient
+                            port
+                            (executeWindowClose testPaneSession $ confirmationBody lastPreview)
+                field "sessionEnded" ended `shouldBe` Just (Bool True)
+                field "consequence" ended
+                    `shouldBe` Just (String "session-ended")
+                endedRegistry <- requireRight =<< runClient port listSessions
+                endedRegistry
+                    `shouldSatisfy` all (not . hasSessionId testPaneSession)
+                ended `shouldSatisfy` hasExactExecutionSchema
+
+        it
+            "fails closed for invalid, reused, superseded, wrong-session, and wrong-scope tokens"
+            $ \(port, testPaneSession, _) -> do
+                callProcess
+                    "tmux"
+                    ["split-window", "-v", "-t", T.unpack testPaneSession]
+                initial <- tmuxIdentities "list-panes" testPaneSession
+                expectConflict
+                    =<< runClient
+                        port
+                        ( executePaneClose testPaneSession $
+                            object ["confirmation" .= ("unknown" :: Text)]
+                        )
+                tmuxIdentities "list-panes" testPaneSession
+                    `shouldReturn` initial
+                first <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                newest <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                tokenText first `shouldSatisfy` (/= tokenText newest)
+                expectConflict
+                    =<< runClient
+                        port
+                        (executePaneClose testPaneSession $ confirmationBody first)
+                tmuxIdentities "list-panes" testPaneSession
+                    `shouldReturn` initial
+                _ <-
+                    requireRight
+                        =<< runClient
+                            port
+                            (executePaneClose testPaneSession $ confirmationBody newest)
+                expectConflict
+                    =<< runClient
+                        port
+                        (executePaneClose testPaneSession $ confirmationBody newest)
+                afterSuccess <- tmuxIdentities "list-panes" testPaneSession
+                length afterSuccess `shouldBe` 1
+
+        it
+            "consumes recognized tokens used through the wrong session or scope"
+            $ \(port, testPaneSession, boundary) -> do
+                initial <- tmuxIdentities "list-panes" testPaneSession
+                wrongSession <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                expectConflict
+                    =<< runClient
+                        port
+                        (executePaneClose "another-session" $ confirmationBody wrongSession)
+                expectConflict
+                    =<< runClient
+                        port
+                        (executePaneClose testPaneSession $ confirmationBody wrongSession)
+                tmuxIdentities "list-panes" testPaneSession
+                    `shouldReturn` initial
+                wrongScope <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                expectConflict
+                    =<< runClient
+                        port
+                        (executeWindowClose testPaneSession $ confirmationBody wrongScope)
+                expectConflict
+                    =<< runClient
+                        port
+                        (executePaneClose testPaneSession $ confirmationBody wrongScope)
+                tmuxIdentities "list-panes" testPaneSession
+                    `shouldReturn` initial
+                registry <- readTVarIO $ sessions $ testSessionManager boundary
+                Map.member (SessionId testPaneSession) registry `shouldBe` True
+
+        it "keeps confirmations independent across close scopes" $
+            \(port, testPaneSession, boundary) -> do
+                callProcess
+                    "tmux"
+                    ["split-window", "-v", "-t", T.unpack testPaneSession]
+                panePreview <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                windowPreview <-
+                    requireRight =<< runClient port (previewWindowClose testPaneSession)
+                tokenText panePreview `shouldSatisfy` (/= tokenText windowPreview)
+                paneResult <-
+                    requireRight
+                        =<< runClient
+                            port
+                            (executePaneClose testPaneSession $ confirmationBody panePreview)
+                field "consequence" paneResult
+                    `shouldBe` Just (String "pane-removed")
+                expectConflict
+                    =<< runClient
+                        port
+                        ( executeWindowClose testPaneSession $
+                            confirmationBody windowPreview
+                        )
+                attempts <- readIORef $ testBoundaryAttempts boundary
+                attempts `shouldBe` 2
+
+        it "consumes a token when tmux becomes unavailable" $
+            \(port, testPaneSession, boundary) -> do
+                preview <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                callProcess
+                    "tmux"
+                    ["kill-session", "-t", T.unpack testPaneSession]
+                failure <-
+                    runClient port $
+                        executePaneClose testPaneSession $
+                            confirmationBody preview
+                expectTmuxFailure failure
+                registry <- readTVarIO $ sessions $ testSessionManager boundary
+                Map.member (SessionId testPaneSession) registry `shouldBe` True
+                expectConflict
+                    =<< runClient
+                        port
+                        (executePaneClose testPaneSession $ confirmationBody preview)
+
+        it "maps and consumes tmux process and parse failures" $
+            \(port, testPaneSession, boundary) -> do
+                mapM_
+                    ( \(injected, expectedError) -> do
+                        preview <-
+                            requireRight
+                                =<< runClient
+                                    port
+                                    (previewPaneClose testPaneSession)
+                        atomicWriteIORef
+                            (testBoundaryFailure boundary)
+                            (Just injected)
+                        failure <-
+                            runClient port $
+                                executePaneClose testPaneSession $
+                                    confirmationBody preview
+                        expectTmuxFailureWith expectedError failure
+                        registry <- requireRight =<< runClient port listSessions
+                        registry
+                            `shouldSatisfy` any (hasSessionId testPaneSession)
+                        expectConflict
+                            =<< runClient
+                                port
+                                ( executePaneClose testPaneSession $
+                                    confirmationBody preview
+                                )
+                    )
+                    [
+                        ( CloseActionProcessFailure "injected process failure"
+                        , "tmux-process-failure"
+                        )
+                    ,
+                        ( CloseActionParseFailure "injected parse failure"
+                        , "tmux-parse-failure"
+                        )
+                    ]
+
+        it
+            "rejects raced current panes and windows without closing any context"
+            $ \(port, testPaneSession, _) -> do
+                callProcess
+                    "tmux"
+                    ["split-window", "-v", "-t", T.unpack testPaneSession]
+                panePreview <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                inactivePane <- tmuxInactivePane testPaneSession
+                callProcess
+                    "tmux"
+                    [ "select-pane"
+                    , "-t"
+                    , T.unpack inactivePane
+                    ]
+                paneBefore <- tmuxTopology testPaneSession
+                expectConflict
+                    =<< runClient
+                        port
+                        (executePaneClose testPaneSession $ confirmationBody panePreview)
+                expectConflict
+                    =<< runClient
+                        port
+                        (executePaneClose testPaneSession $ confirmationBody panePreview)
+                tmuxTopology testPaneSession
+                    `shouldReturn` paneBefore
+                callProcess
+                    "tmux"
+                    ["new-window", "-t", T.unpack testPaneSession, "-n", "race"]
+                windowPreview <-
+                    requireRight =<< runClient port (previewWindowClose testPaneSession)
+                callProcess
+                    "tmux"
+                    ["select-window", "-t", T.unpack testPaneSession <> ":first"]
+                windowBefore <- tmuxTopology testPaneSession
+                expectConflict
+                    =<< runClient
+                        port
+                        (executeWindowClose testPaneSession $ confirmationBody windowPreview)
+                expectConflict
+                    =<< runClient
+                        port
+                        (executeWindowClose testPaneSession $ confirmationBody windowPreview)
+                tmuxTopology testPaneSession
+                    `shouldReturn` windowBefore
+                registry <- requireRight =<< runClient port listSessions
+                registry `shouldSatisfy` any (hasSessionId testPaneSession)
+
+        it "permits at most one concurrent replay boundary attempt" $
+            \(port, testPaneSession, boundary) -> do
+                callProcess
+                    "tmux"
+                    ["split-window", "-v", "-t", T.unpack testPaneSession]
+                preview <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                let request =
+                        runClient port $
+                            executePaneClose testPaneSession $
+                                confirmationBody preview
+                entered <- newEmptyMVar
+                release <- newEmptyMVar
+                atomicWriteIORef
+                    (testBoundaryGate boundary)
+                    (Just (entered, release))
+                firstResult <- newEmptyMVar
+                _ <- forkIO $ request >>= putMVar firstResult
+                requireWithin "boundary entry" $ takeMVar entered
+                second <- requireWithin "losing replay" request
+                expectConflict second
+                attempts <- readIORef $ testBoundaryAttempts boundary
+                attempts `shouldBe` 1
+                requireWithin "boundary release" $ putMVar release ()
+                first <- requireWithin "winning replay" $ takeMVar firstResult
+                first `shouldSatisfy` isRight
+                tmuxCount "list-panes" testPaneSession `shouldReturnCount` 1
+
+        it "accepts only an opaque confirmation field on execute routes" $
+            \(port, testPaneSession, _) -> do
+                panePreview <-
+                    requireRight =<< runClient port (previewPaneClose testPaneSession)
+                paneSecrets <- tmuxTokenSecrets testPaneSession
+                tokenText panePreview
+                    `shouldSatisfy` opaqueToken testPaneSession paneSecrets
+                paneResult <-
+                    runClient port $
+                        executePaneClose testPaneSession $
+                            object
+                                [ "confirmation" .= tokenText panePreview
+                                , "paneId" .= ("%1" :: Text)
+                                ]
+                expectBadRequest paneResult
+                windowPreview <-
+                    requireRight =<< runClient port (previewWindowClose testPaneSession)
+                windowSecrets <- tmuxTokenSecrets testPaneSession
+                tokenText windowPreview
+                    `shouldSatisfy` opaqueToken testPaneSession windowSecrets
+                windowResult <-
+                    runClient port $
+                        executeWindowClose testPaneSession $
+                            object
+                                [ "confirmation" .= tokenText windowPreview
+                                , "windowIndex" .= (1 :: Int)
+                                ]
+                expectBadRequest windowResult
+                expectPreviewTargetRejected
+                    port
+                    testPaneSession
+                    "current-pane"
+                expectPreviewBodyRejected
+                    port
+                    testPaneSession
+                    "current-pane"
+                expectPreviewTargetRejected
+                    port
+                    testPaneSession
+                    "current-window"
+                expectPreviewBodyRejected
+                    port
+                    testPaneSession
+                    "current-window"
+
         it "DELETE /sessions/:sid requires exact confirmation" $
-            \port -> do
+            \(port, testPaneSession, _) -> do
                 result <-
                     runClient
                         port
@@ -331,7 +843,7 @@ spec = describe "REST API" $ do
                                 <> show other
 
         it "GET /sessions/:sid/panes returns tmux pane metadata" $
-            \port -> do
+            \(port, testPaneSession, _) -> do
                 result <-
                     runClient
                         port
@@ -345,7 +857,7 @@ spec = describe "REST API" $ do
                         fail $ "Expected pane list, got: " <> show err
 
         it "POST /sessions/:sid/panes creates a new pane" $
-            \port -> do
+            \(port, testPaneSession, _) -> do
                 result <-
                     runClient
                         port
@@ -372,7 +884,7 @@ spec = describe "REST API" $ do
                         Left _ -> False
 
         it "GET /sessions/:sid/windows returns tmux window metadata" $
-            \port -> do
+            \(port, testPaneSession, _) -> do
                 result <-
                     runClient
                         port
@@ -386,7 +898,7 @@ spec = describe "REST API" $ do
                         fail $ "Expected window list, got: " <> show err
 
         it "POST /sessions/:sid/windows/new creates a selected tmux window" $
-            \port -> do
+            \(port, testPaneSession, _) -> do
                 result <-
                     runClient
                         port
@@ -409,7 +921,7 @@ spec = describe "REST API" $ do
                         Left _ -> False
 
         it "POST /sessions/:sid/windows selects a tmux window" $
-            \port -> do
+            \(port, testPaneSession, _) -> do
                 callProcess
                     "tmux"
                     [ "new-window"
@@ -471,6 +983,222 @@ spec = describe "REST API" $ do
 isRight :: Either a b -> Bool
 isRight (Right _) = True
 isRight _ = False
+
+requireRight :: (Show a) => Either a b -> IO b
+requireRight (Right value) = pure value
+requireRight (Left err) = fail $ "Expected success, got: " <> show err
+
+field :: Text -> Value -> Maybe Value
+field key (Object value) = KM.lookup (Key.fromText key) value
+field _ _ = Nothing
+
+tokenText :: Value -> Text
+tokenText value =
+    case field "confirmation" value of
+        Just (String token) -> token
+        other -> error $ "missing confirmation: " <> show other
+
+confirmationBody :: Value -> Value
+confirmationBody value = object ["confirmation" .= tokenText value]
+
+expectConflict :: (Show a) => Either ClientError a -> IO ()
+expectConflict (Left (FailureResponse _ response)) = do
+    responseStatusCode response `shouldBe` status409
+    let body = decode (responseBody response) :: Maybe Value
+    (body >>= field "error")
+        `shouldBe` Just (String "stale-current-context")
+    (body >>= field "status")
+        `shouldBe` Just (String "stale-current-context")
+expectConflict other = fail $ "Expected 409, got: " <> show other
+
+expectTmuxFailure :: (Show a) => Either ClientError a -> IO ()
+expectTmuxFailure (Left (FailureResponse _ response)) = do
+    responseStatusCode response `shouldBe` status500
+    let body = decode (responseBody response) :: Maybe Value
+    (body >>= field "status") `shouldBe` Just (String "tmux-failure")
+    (body >>= field "error") `shouldSatisfy` \case
+        Just (String message) -> not $ T.null message
+        _ -> False
+expectTmuxFailure other = fail $ "Expected tmux failure, got: " <> show other
+
+expectTmuxFailureWith
+    :: (Show a) => Text -> Either ClientError a -> IO ()
+expectTmuxFailureWith expected (Left (FailureResponse _ response)) = do
+    responseStatusCode response `shouldBe` status500
+    let body = decode (responseBody response) :: Maybe Value
+    (body >>= field "status") `shouldBe` Just (String "tmux-failure")
+    (body >>= field "error") `shouldBe` Just (String expected)
+expectTmuxFailureWith _ other =
+    fail $ "Expected injected tmux failure, got: " <> show other
+
+requireWithin :: String -> IO a -> IO a
+requireWithin label action = do
+    result <- timeout 3000000 action
+    maybe (fail $ label <> " timed out") pure result
+
+expectBadRequest :: (Show a) => Either ClientError a -> IO ()
+expectBadRequest (Left (FailureResponse _ response)) =
+    responseStatusCode response `shouldBe` status400
+expectBadRequest other = fail $ "Expected 400, got: " <> show other
+
+expectPreviewTargetRejected :: Int -> Text -> Text -> IO ()
+expectPreviewTargetRejected port sessionName scope = do
+    manager <- newManager defaultManagerSettings
+    request <-
+        parseRequest $
+            "http://127.0.0.1:"
+                <> show port
+                <> "/sessions/"
+                <> T.unpack sessionName
+                <> "/"
+                <> T.unpack scope
+                <> "/close/preview?target=%251"
+    response <-
+        httpLbs
+            request
+                { method = "POST"
+                }
+            manager
+    responseStatus response `shouldBe` status400
+
+expectPreviewBodyRejected :: Int -> Text -> Text -> IO ()
+expectPreviewBodyRejected port sessionName scope = do
+    manager <- newManager defaultManagerSettings
+    request <-
+        parseRequest $
+            "http://127.0.0.1:"
+                <> show port
+                <> "/sessions/"
+                <> T.unpack sessionName
+                <> "/"
+                <> T.unpack scope
+                <> "/close/preview"
+    response <-
+        httpLbs
+            request
+                { method = "POST"
+                , requestHeaders = [("Content-Type", "application/json")]
+                , requestBody = RequestBodyLBS "{\"paneId\":\"%1\"}"
+                }
+            manager
+    responseStatus response `shouldBe` status400
+
+tmuxCount :: String -> Text -> IO Int
+tmuxCount command sessionName =
+    length . lines
+        <$> readProcess
+            "tmux"
+            [ command
+            , "-t"
+            , T.unpack sessionName
+            , "-F"
+            , if command == "list-panes" then "#{pane_id}" else "#{window_id}"
+            ]
+            ""
+
+shouldReturnCount :: IO Int -> Int -> IO ()
+shouldReturnCount action expected = action >>= (`shouldBe` expected)
+
+tmuxIdentities :: String -> Text -> IO [Text]
+tmuxIdentities command sessionName =
+    T.lines . T.pack
+        <$> readProcess
+            "tmux"
+            [ command
+            , "-t"
+            , T.unpack sessionName
+            , "-F"
+            , if command == "list-panes" then "#{pane_id}" else "#{window_id}"
+            ]
+            ""
+
+tmuxActive :: Text -> Text -> IO Text
+tmuxActive kind sessionName =
+    T.strip . T.pack
+        <$> readProcess
+            "tmux"
+            [ "display-message"
+            , "-p"
+            , "-t"
+            , T.unpack sessionName
+            , if kind == "pane" then "#{pane_id}" else "#{window_id}"
+            ]
+            ""
+
+tmuxInactivePane :: Text -> IO Text
+tmuxInactivePane sessionName = do
+    rows <-
+        T.lines . T.pack
+            <$> readProcess
+                "tmux"
+                [ "list-panes"
+                , "-t"
+                , T.unpack sessionName
+                , "-F"
+                , "#{pane_id} #{pane_active}"
+                ]
+                ""
+    case [pane | row <- rows, [pane, "0"] <- [T.words row]] of
+        pane : _ -> pure pane
+        [] -> fail "expected an inactive pane"
+
+tmuxTopology :: Text -> IO [Text]
+tmuxTopology sessionName =
+    T.lines . T.pack
+        <$> readProcess
+            "tmux"
+            [ "list-panes"
+            , "-s"
+            , "-t"
+            , T.unpack sessionName
+            , "-F"
+            , "#{window_id}:#{window_index}:#{window_name}:#{pane_id}:#{pane_index}"
+            ]
+            ""
+
+tmuxTokenSecrets :: Text -> IO [Text]
+tmuxTokenSecrets sessionName =
+    filter (not . T.all isDigit) . concatMap (T.splitOn ":")
+        <$> tmuxTopology sessionName
+
+opaqueToken :: Text -> [Text] -> Text -> Bool
+opaqueToken sessionName identities token =
+    not (T.null token)
+        && T.all (\character -> isAsciiLower character || character == '-') token
+        && all
+            (\revealed -> T.null revealed || not (revealed `T.isInfixOf` token))
+            ( sessionName
+                : identities
+                    <> [ "pane"
+                       , "window"
+                       , "current"
+                       , "target"
+                       , "first"
+                       , "survivor"
+                       , "race"
+                       ]
+            )
+
+hasExactPreviewSchema :: Value -> Bool
+hasExactPreviewSchema (Object value) =
+    KM.size value == 2
+        && all (`KM.member` value) ["consequence", "confirmation"]
+hasExactPreviewSchema _ = False
+
+hasExactExecutionSchema :: Value -> Bool
+hasExactExecutionSchema (Object value) =
+    KM.size value == 2
+        && all (`KM.member` value) ["consequence", "sessionEnded"]
+hasExactExecutionSchema _ = False
+
+hasSessionId :: Text -> Value -> Bool
+hasSessionId sid value = field "id" value == Just (String sid)
+
+containsNoTmuxIdentity :: Value -> Bool
+containsNoTmuxIdentity value =
+    not $ any (`T.isInfixOf` encoded) ["%", "@", "paneId", "windowId"]
+  where
+    encoded = T.pack $ show value
 
 -- | Check that a JSON value looks like a pane object.
 hasPaneFields :: Value -> Bool

--- a/test/AgentDaemon/CloseSpec.hs
+++ b/test/AgentDaemon/CloseSpec.hs
@@ -1,0 +1,428 @@
+module AgentDaemon.CloseSpec (spec) where
+
+import AgentDaemon.Close
+import Data.List (find, sort)
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (fromMaybe)
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck
+    ( Gen
+    , Property
+    , checkCoverage
+    , chooseInt
+    , classify
+    , counterexample
+    , cover
+    , elements
+    , forAll
+    , property
+    , vectorOf
+    , (.&&.)
+    , (===)
+    )
+
+spec :: Spec
+spec = describe "close-current state machine" $ do
+    prop "removes only the prepared current context" $
+        forAll genScopeAndTopology propCurrentOnly
+    prop "leaves stale topology unchanged and consumes confirmation" $
+        forAll genStaleAttempt propStaleIdentity
+    prop "returns a valid topology whenever the session survives" $
+        forAll genScopeAndTopology propValidSurvivor
+    prop "makes exactly the scope-specific cardinality change" $
+        forAll genScopeAndTopology propExactCardinality
+    prop "terminates exactly when the last window is removed" $
+        forAll genScopeAndTopology propTruthfulTermination
+    prop "rejects replay without changing the survivor" $
+        forAll genScopeAndTopology propReplayIdentity
+    prop "covers required scope and topology combinations" $
+        forAll genScopeAndTopology propTopologyCoverage
+    prop "covers pane and window currentness races" $
+        forAll genStaleAttempt propStaleCoverage
+    it "rejects an invalid live topology at preparation" $ do
+        prepareClose CloseCurrentPane invalidTopology
+            `shouldBe` Left InvalidTopology
+    it "rejects duplicate window identities at preparation" $ do
+        prepareClose CloseCurrentWindow duplicateWindowTopology
+            `shouldBe` Left InvalidTopology
+    it "rejects duplicate pane identities at preparation" $ do
+        prepareClose CloseCurrentPane duplicatePaneTopology
+            `shouldBe` Left InvalidTopology
+    it "rejects consequence-changing pane redistribution" $ do
+        case prepareClose CloseCurrentPane redistributionPreparedTopology of
+            Left failure -> failure `shouldBe` StaleCurrentContext
+            Right prepared -> do
+                let (consumed, result) =
+                        executeClose prepared redistributedTopology
+                isConsumed consumed `shouldBe` True
+                result `shouldBe` Left StaleCurrentContext
+
+propCurrentOnly :: (CloseScope, CloseTopology) -> Property
+propCurrentOnly (scope, topology) =
+    checkCoverage
+        $ cover 30 (scope == CloseCurrentPane) "pane scope"
+        $ cover 30 (scope == CloseCurrentWindow) "window scope"
+        $ cover 10 (windowCount topology == 1) "one window"
+        $ cover 50 (windowCount topology > 1) "many windows"
+        $ cover 10 (currentPaneCount topology == 1) "one current pane"
+        $ cover 50 (currentPaneCount topology > 1) "many current panes"
+        $ cover
+            1
+            (scope == CloseCurrentPane && removesLastWindow scope topology)
+            "pane ends session"
+        $ cover
+            5
+            ( scope == CloseCurrentPane
+                && currentPaneCount topology == 1
+                && windowCount topology > 1
+            )
+            "pane removes window"
+        $ cover
+            5
+            (scope == CloseCurrentWindow && windowCount topology == 1)
+            "window ends session"
+        $ classify (scope == CloseCurrentPane) "pane scope"
+        $ classify (scope == CloseCurrentWindow) "window scope"
+        $ classify (windowCount topology == 1) "one window"
+        $ classify (windowCount topology > 1) "many windows"
+        $ classify (currentPaneCount topology == 1) "one current pane"
+        $ classify (currentPaneCount topology > 1) "many current panes"
+        $ case runClose scope topology of
+            Left failure ->
+                counterexample (show failure) False
+            Right outcome ->
+                removedWindowIds topology outcome
+                    === expectedRemovedWindows scope topology
+                    .&&. removedPaneIds topology outcome
+                        === expectedRemovedPanes scope topology
+
+propStaleIdentity
+    :: (CloseScope, CloseTopology, CloseTopology) -> Property
+propStaleIdentity (scope, preparedAt, changedCurrent) =
+    case prepareClose scope preparedAt of
+        Left failure -> counterexample (show failure) False
+        Right prepared ->
+            case executeClose prepared changedCurrent of
+                (consumed, Left StaleCurrentContext) ->
+                    property (isConsumed consumed)
+                result -> counterexample (show result) False
+
+propValidSurvivor :: (CloseScope, CloseTopology) -> Property
+propValidSurvivor (scope, topology) =
+    case runClose scope topology of
+        Left failure -> counterexample (show failure) False
+        Right CloseOutcome{outcomeTopology = Nothing} -> property True
+        Right CloseOutcome{outcomeTopology = Just survivor} ->
+            counterexample (show survivor) $ property (isValidTopology survivor)
+
+propExactCardinality :: (CloseScope, CloseTopology) -> Property
+propExactCardinality (scope, topology) =
+    case runClose scope topology of
+        Left failure -> counterexample (show failure) False
+        Right outcome ->
+            resultingWindowCount outcome
+                === windowCount topology - expectedWindowDelta scope topology
+                .&&. resultingPaneCount outcome
+                    === paneCount topology - expectedPaneDelta scope topology
+
+propTruthfulTermination :: (CloseScope, CloseTopology) -> Property
+propTruthfulTermination (scope, topology) =
+    case runClose scope topology of
+        Left failure -> counterexample (show failure) False
+        Right CloseOutcome{outcomeConsequence, outcomeTopology} ->
+            (outcomeTopology == Nothing)
+                === removesLastWindow scope topology
+                .&&. (outcomeConsequence == SessionEnded)
+                    === (outcomeTopology == Nothing)
+
+propReplayIdentity :: (CloseScope, CloseTopology) -> Property
+propReplayIdentity (scope, topology) =
+    case prepareClose scope topology of
+        Left failure -> counterexample (show failure) False
+        Right prepared ->
+            case executeClose prepared topology of
+                (_, Left failure) -> counterexample (show failure) False
+                (consumed, Right firstOutcome) ->
+                    let afterFirst = maybe topology id (outcomeTopology firstOutcome)
+                    in  case executeClose consumed afterFirst of
+                            (stillConsumed, Left ConfirmationConsumed) ->
+                                property (isConsumed stillConsumed)
+                            result -> counterexample (show result) False
+
+propTopologyCoverage :: (CloseScope, CloseTopology) -> Property
+propTopologyCoverage (scope, topology) =
+    checkCoverage
+        $ cover 30 (scope == CloseCurrentPane) "pane scope"
+        $ cover 30 (scope == CloseCurrentWindow) "window scope"
+        $ cover 10 (windowCount topology == 1) "one window"
+        $ cover 50 (windowCount topology > 1) "many windows"
+        $ cover 10 (currentPaneCount topology == 1) "one current pane"
+        $ cover 50 (currentPaneCount topology > 1) "many current panes"
+        $ cover
+            1
+            (scope == CloseCurrentPane && removesLastWindow scope topology)
+            "pane ends session"
+        $ cover
+            5
+            ( scope == CloseCurrentPane
+                && currentPaneCount topology == 1
+                && windowCount topology > 1
+            )
+            "pane removes window"
+        $ cover
+            5
+            (scope == CloseCurrentWindow && windowCount topology == 1)
+            "window ends session"
+        $ property True
+
+propStaleCoverage
+    :: (CloseScope, CloseTopology, CloseTopology) -> Property
+propStaleCoverage (scope, before, after) =
+    checkCoverage
+        $ cover
+            30
+            (scope == CloseCurrentWindow)
+            "window-scope current window changed"
+        $ cover 30 (scope == CloseCurrentPane) "pane-scope stale"
+        $ cover
+            10
+            (scope == CloseCurrentPane && windowChanged)
+            "pane scope current window changed"
+        $ cover
+            10
+            (scope == CloseCurrentPane && not windowChanged)
+            "pane scope current pane changed"
+        $ property True
+  where
+    windowChanged =
+        topologyCurrentWindow before /= topologyCurrentWindow after
+
+genScopeAndTopology :: Gen (CloseScope, CloseTopology)
+genScopeAndTopology =
+    (,)
+        <$> elements [CloseCurrentPane, CloseCurrentWindow]
+        <*> genTopology
+
+genTopology :: Gen CloseTopology
+genTopology = do
+    numberOfWindows <- chooseInt (1, 4)
+    paneCounts <- vectorOf numberOfWindows (chooseInt (1, 4))
+    currentWindowPosition <- chooseInt (0, numberOfWindows - 1)
+    currentPanePositions <-
+        mapM (\count -> chooseInt (0, count - 1)) paneCounts
+    pure $
+        topologyFromShape
+            paneCounts
+            currentWindowPosition
+            currentPanePositions
+
+genStaleAttempt :: Gen (CloseScope, CloseTopology, CloseTopology)
+genStaleAttempt = do
+    scope <- elements [CloseCurrentPane, CloseCurrentWindow]
+    case scope of
+        CloseCurrentWindow -> do
+            numberOfWindows <- chooseInt (2, 4)
+            paneCounts <- vectorOf numberOfWindows (chooseInt (1, 4))
+            currentPanePositions <-
+                mapM (\count -> chooseInt (0, count - 1)) paneCounts
+            oldPosition <- chooseInt (0, numberOfWindows - 1)
+            offset <- chooseInt (1, numberOfWindows - 1)
+            let newPosition = (oldPosition + offset) `mod` numberOfWindows
+                before = topologyFromShape paneCounts oldPosition currentPanePositions
+                after = topologyFromShape paneCounts newPosition currentPanePositions
+            pure (scope, before, after)
+        CloseCurrentPane -> do
+            numberOfWindows <- chooseInt (2, 4)
+            currentWindowPosition <- chooseInt (0, numberOfWindows - 1)
+            paneCounts <- vectorOf numberOfWindows (chooseInt (2, 4))
+            currentPanePositions <-
+                mapM (\count -> chooseInt (0, count - 1)) paneCounts
+            changeWindow <- elements [False, True]
+            offset <-
+                chooseInt
+                    ( 1
+                    , if changeWindow
+                        then numberOfWindows - 1
+                        else paneCounts !! currentWindowPosition - 1
+                    )
+            let oldPanePosition = currentPanePositions !! currentWindowPosition
+                newWindowPosition = (currentWindowPosition + offset) `mod` numberOfWindows
+                newPanePosition =
+                    (oldPanePosition + offset) `mod` (paneCounts !! currentWindowPosition)
+                changedPositions =
+                    replaceAt currentWindowPosition newPanePosition currentPanePositions
+                before =
+                    topologyFromShape
+                        paneCounts
+                        currentWindowPosition
+                        currentPanePositions
+                after
+                    | changeWindow =
+                        topologyFromShape paneCounts newWindowPosition currentPanePositions
+                    | otherwise =
+                        topologyFromShape paneCounts currentWindowPosition changedPositions
+            pure (scope, before, after)
+
+topologyFromShape :: [Int] -> Int -> [Int] -> CloseTopology
+topologyFromShape paneCounts currentWindowPosition currentPanePositions =
+    CloseTopology
+        { topologySession = SessionId 1
+        , topologyWindows =
+            NE.fromList $ zipWith3 mkWindow [1 ..] paneCounts currentPanePositions
+        , topologyCurrentWindow = WindowId currentWindowPosition
+        }
+  where
+    mkWindow windowNumber numberOfPanes currentPanePosition =
+        let firstPaneNumber = sum (take (windowNumber - 1) paneCounts)
+            panes =
+                NE.fromList $
+                    PaneId <$> [firstPaneNumber .. firstPaneNumber + numberOfPanes - 1]
+        in  CloseWindow
+                { closeWindowId = WindowId (windowNumber - 1)
+                , closeWindowPanes = panes
+                , closeWindowCurrentPane = panes NE.!! currentPanePosition
+                }
+
+invalidTopology :: CloseTopology
+invalidTopology =
+    CloseTopology
+        { topologySession = SessionId 1
+        , topologyWindows =
+            CloseWindow (WindowId 1) (PaneId 1 :| []) (PaneId 2) :| []
+        , topologyCurrentWindow = WindowId 1
+        }
+
+duplicateWindowTopology :: CloseTopology
+duplicateWindowTopology =
+    CloseTopology
+        { topologySession = SessionId 1
+        , topologyWindows =
+            CloseWindow (WindowId 1) (PaneId 1 :| []) (PaneId 1)
+                :| [CloseWindow (WindowId 1) (PaneId 2 :| []) (PaneId 2)]
+        , topologyCurrentWindow = WindowId 1
+        }
+
+duplicatePaneTopology :: CloseTopology
+duplicatePaneTopology =
+    CloseTopology
+        { topologySession = SessionId 1
+        , topologyWindows =
+            CloseWindow (WindowId 1) (PaneId 1 :| []) (PaneId 1)
+                :| [CloseWindow (WindowId 2) (PaneId 1 :| []) (PaneId 1)]
+        , topologyCurrentWindow = WindowId 1
+        }
+
+redistributionPreparedTopology :: CloseTopology
+redistributionPreparedTopology =
+    CloseTopology
+        { topologySession = SessionId 1
+        , topologyWindows =
+            CloseWindow (WindowId 1) (PaneId 1 :| []) (PaneId 1)
+                :| [ CloseWindow
+                        (WindowId 2)
+                        (PaneId 2 :| [PaneId 3])
+                        (PaneId 2)
+                   ]
+        , topologyCurrentWindow = WindowId 1
+        }
+
+redistributedTopology :: CloseTopology
+redistributedTopology =
+    CloseTopology
+        { topologySession = SessionId 1
+        , topologyWindows =
+            CloseWindow
+                (WindowId 1)
+                (PaneId 1 :| [PaneId 3])
+                (PaneId 1)
+                :| [CloseWindow (WindowId 2) (PaneId 2 :| []) (PaneId 2)]
+        , topologyCurrentWindow = WindowId 1
+        }
+
+runClose
+    :: CloseScope -> CloseTopology -> Either CloseFailure CloseOutcome
+runClose scope topology = do
+    prepared <- prepareClose scope topology
+    snd $ executeClose prepared topology
+
+currentWindow :: CloseTopology -> CloseWindow
+currentWindow CloseTopology{topologyCurrentWindow, topologyWindows} =
+    fromMaybe (NE.head topologyWindows) $
+        find
+            ((== topologyCurrentWindow) . closeWindowId)
+            (NE.toList topologyWindows)
+
+currentPaneCount :: CloseTopology -> Int
+currentPaneCount = NE.length . closeWindowPanes . currentWindow
+
+windowCount :: CloseTopology -> Int
+windowCount = NE.length . topologyWindows
+
+paneCount :: CloseTopology -> Int
+paneCount =
+    sum
+        . fmap (NE.length . closeWindowPanes)
+        . NE.toList
+        . topologyWindows
+
+resultingWindowCount :: CloseOutcome -> Int
+resultingWindowCount = maybe 0 windowCount . outcomeTopology
+
+resultingPaneCount :: CloseOutcome -> Int
+resultingPaneCount = maybe 0 paneCount . outcomeTopology
+
+windowIds :: CloseTopology -> [WindowId]
+windowIds = fmap closeWindowId . NE.toList . topologyWindows
+
+paneIds :: CloseTopology -> [PaneId]
+paneIds =
+    concatMap (NE.toList . closeWindowPanes) . NE.toList . topologyWindows
+
+removedWindowIds :: CloseTopology -> CloseOutcome -> [WindowId]
+removedWindowIds before =
+    difference (windowIds before) . maybe [] windowIds . outcomeTopology
+
+removedPaneIds :: CloseTopology -> CloseOutcome -> [PaneId]
+removedPaneIds before = difference (paneIds before) . maybe [] paneIds . outcomeTopology
+
+expectedRemovedWindows :: CloseScope -> CloseTopology -> [WindowId]
+expectedRemovedWindows CloseCurrentWindow topology = [topologyCurrentWindow topology]
+expectedRemovedWindows CloseCurrentPane topology
+    | currentPaneCount topology == 1 = [topologyCurrentWindow topology]
+    | otherwise = []
+
+expectedRemovedPanes :: CloseScope -> CloseTopology -> [PaneId]
+expectedRemovedPanes CloseCurrentWindow = NE.toList . closeWindowPanes . currentWindow
+expectedRemovedPanes CloseCurrentPane = pure . closeWindowCurrentPane . currentWindow
+
+expectedWindowDelta :: CloseScope -> CloseTopology -> Int
+expectedWindowDelta CloseCurrentWindow _ = 1
+expectedWindowDelta CloseCurrentPane topology
+    | currentPaneCount topology == 1 = 1
+    | otherwise = 0
+
+expectedPaneDelta :: CloseScope -> CloseTopology -> Int
+expectedPaneDelta CloseCurrentWindow topology =
+    NE.length . closeWindowPanes $ currentWindow topology
+expectedPaneDelta CloseCurrentPane _ = 1
+
+removesLastWindow :: CloseScope -> CloseTopology -> Bool
+removesLastWindow CloseCurrentWindow topology = windowCount topology == 1
+removesLastWindow CloseCurrentPane topology =
+    windowCount topology == 1 && currentPaneCount topology == 1
+
+difference :: (Ord a) => [a] -> [a] -> [a]
+difference left right = sort left `without` sort right
+  where
+    without [] _ = []
+    without xs [] = xs
+    without xs@(x : xt) ys@(y : yt)
+        | x < y = x : without xt ys
+        | x == y = without xt yt
+        | otherwise = without xs yt
+
+replaceAt :: Int -> a -> [a] -> [a]
+replaceAt index replacement values =
+    take index values <> [replacement] <> drop (index + 1) values

--- a/test/AgentDaemon/TmuxCloseSpec.hs
+++ b/test/AgentDaemon/TmuxCloseSpec.hs
@@ -1,0 +1,251 @@
+module AgentDaemon.TmuxCloseSpec
+    ( spec
+    ) where
+
+{- |
+Module      : AgentDaemon.TmuxCloseSpec
+Description : Live tmux proof for current-context close boundaries
+Copyright   : (c) Paolo Veronelli, 2026
+License     : MIT
+
+Exercises close preparation and execution against uniquely named,
+disposable tmux sessions.
+-}
+
+import AgentDaemon.Close
+    ( CloseConsequence (..)
+    , CloseScope (..)
+    )
+import AgentDaemon.Tmux
+    ( PreparedTmuxClose
+    , TmuxCloseFailure (..)
+    , TmuxCloseResult (..)
+    , executeCurrentClose
+    , prepareCurrentClose
+    )
+import Control.Exception (bracket)
+import Data.List (sort)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Unique (hashUnique, newUnique)
+import System.Exit (ExitCode (..))
+import System.Process
+    ( callProcess
+    , readProcess
+    , readProcessWithExitCode
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    )
+
+spec :: Spec
+spec = describe "current-only tmux close boundary" $ do
+    it "removes only the prepared active pane and preserves its window" $
+        withSession $ \sessionName -> do
+            tmux ["split-window", "-d", "-t", target sessionName]
+            preparedPane <- currentPane sessionName
+            preparedWindow <- currentWindow sessionName
+            beforeWindows <- windowIds sessionName
+            prepared <- expectPrepared sessionName CloseCurrentPane
+            result <- executeCurrentClose sessionName prepared
+            afterPanes <- paneIds sessionName
+            windowIds sessionName `shouldReturnSorted` beforeWindows
+            afterPanes `shouldExclude` preparedPane
+            currentWindow sessionName `shouldReturnText` preparedWindow
+            result `shouldBe` Right (TmuxCloseResult PaneRemoved False)
+
+    it "removes the current last-pane window and preserves a survivor" $
+        withSession $ \sessionName -> do
+            tmux ["new-window", "-d", "-t", target sessionName]
+            preparedWindow <- currentWindow sessionName
+            preparedPane <- currentPane sessionName
+            prepared <- expectPrepared sessionName CloseCurrentPane
+            result <- executeCurrentClose sessionName prepared
+            windowIds sessionName >>= (`shouldExclude` preparedWindow)
+            paneIds sessionName >>= (`shouldExclude` preparedPane)
+            sessionExists sessionName >>= (`shouldBe` True)
+            result `shouldBe` Right (TmuxCloseResult PaneAndWindowRemoved False)
+
+    it "ends the session when closing its only pane" $
+        withSession $ \sessionName -> do
+            prepared <- expectPrepared sessionName CloseCurrentPane
+            result <- executeCurrentClose sessionName prepared
+            sessionExists sessionName >>= (`shouldBe` False)
+            result `shouldBe` Right (TmuxCloseResult SessionEnded True)
+
+    it "removes only the prepared current window and all of its panes" $
+        withSession $ \sessionName -> do
+            tmux ["split-window", "-d", "-t", target sessionName]
+            preparedWindow <- currentWindow sessionName
+            preparedPanes <- paneIds sessionName
+            tmux ["new-window", "-d", "-t", target sessionName]
+            prepared <- expectPrepared sessionName CloseCurrentWindow
+            result <- executeCurrentClose sessionName prepared
+            survivingWindows <- windowIds sessionName
+            survivingPanes <- paneIds sessionName
+            survivingWindows `shouldExclude` preparedWindow
+            mapM_ (survivingPanes `shouldExclude`) preparedPanes
+            sessionExists sessionName >>= (`shouldBe` True)
+            result `shouldBe` Right (TmuxCloseResult WindowRemoved False)
+
+    it "ends the session when closing its only window" $
+        withSession $ \sessionName -> do
+            prepared <- expectPrepared sessionName CloseCurrentWindow
+            result <- executeCurrentClose sessionName prepared
+            sessionExists sessionName >>= (`shouldBe` False)
+            result `shouldBe` Right (TmuxCloseResult SessionEnded True)
+
+    it "rejects a changed active pane and preserves every pane" $
+        withSession $ \sessionName -> do
+            tmux ["split-window", "-d", "-t", target sessionName]
+            before <- paneIds sessionName
+            prepared <- expectPrepared sessionName CloseCurrentPane
+            otherPane <- inactivePane sessionName
+            tmux ["select-pane", "-t", T.unpack otherPane]
+            result <- executeCurrentClose sessionName prepared
+            paneIds sessionName >>= (`shouldBe` before)
+            result `shouldBe` Left TmuxCloseStaleCurrentContext
+
+    it "rejects a changed active window and preserves every context" $
+        withSession $ \sessionName -> do
+            tmux ["new-window", "-d", "-t", target sessionName]
+            beforeWindows <- windowIds sessionName
+            beforePanes <- paneIds sessionName
+            prepared <- expectPrepared sessionName CloseCurrentWindow
+            otherWindow <- inactiveWindow sessionName
+            tmux ["select-window", "-t", T.unpack otherWindow]
+            result <- executeCurrentClose sessionName prepared
+            windowIds sessionName >>= (`shouldBe` beforeWindows)
+            paneIds sessionName >>= (`shouldBe` beforePanes)
+            result `shouldBe` Left TmuxCloseStaleCurrentContext
+
+    it "rejects a changed current-window pane count and closes nothing" $
+        withSession $ \sessionName -> do
+            prepared <- expectPrepared sessionName CloseCurrentPane
+            tmux ["split-window", "-d", "-t", target sessionName]
+            before <- paneIds sessionName
+            result <- executeCurrentClose sessionName prepared
+            paneIds sessionName >>= (`shouldBe` before)
+            result `shouldBe` Left TmuxCloseStaleCurrentContext
+
+    it "rejects a changed session window count and closes nothing" $
+        withSession $ \sessionName -> do
+            prepared <- expectPrepared sessionName CloseCurrentWindow
+            tmux ["new-window", "-d", "-t", target sessionName]
+            before <- windowIds sessionName
+            result <- executeCurrentClose sessionName prepared
+            windowIds sessionName >>= (`shouldBe` before)
+            result `shouldBe` Left TmuxCloseStaleCurrentContext
+
+    it "propagates the conditional false-branch sentinel exit" $
+        withSession $ \sessionName -> do
+            (falseExit, _, _) <-
+                tmuxResult
+                    [ "if-shell"
+                    , "-F"
+                    , "-t"
+                    , target sessionName
+                    , "0"
+                    , "display-message -p boundary-true"
+                    , "run-shell 'exit 71'"
+                    ]
+            (trueExit, _, _) <-
+                tmuxResult
+                    [ "if-shell"
+                    , "-F"
+                    , "-t"
+                    , target sessionName
+                    , "1"
+                    , "display-message -p boundary-true"
+                    , "run-shell 'exit 71'"
+                    ]
+            falseExit `shouldBe` ExitFailure 71
+            trueExit `shouldBe` ExitSuccess
+
+withSession :: (Text -> IO a) -> IO a
+withSession action = do
+    unique <- hashUnique <$> newUnique
+    let sessionName = "agent-daemon-close-" <> T.pack (show unique)
+    bracket
+        (createDisposableSession sessionName)
+        cleanupSession
+        (const $ action sessionName)
+
+createDisposableSession :: Text -> IO Text
+createDisposableSession sessionName = do
+    tmux
+        [ "new-session"
+        , "-d"
+        , "-s"
+        , T.unpack sessionName
+        , "-n"
+        , "prepared"
+        , "sleep 60"
+        ]
+    pure sessionName
+
+cleanupSession :: Text -> IO ()
+cleanupSession sessionName = do
+    _ <- tmuxResult ["kill-session", "-t", target sessionName]
+    pure ()
+
+expectPrepared :: Text -> CloseScope -> IO PreparedTmuxClose
+expectPrepared sessionName scope = do
+    result <- prepareCurrentClose sessionName scope
+    case result of
+        Right prepared -> pure prepared
+        Left failure -> expectationFailure (show failure) >> error "unreachable"
+
+currentPane :: Text -> IO Text
+currentPane sessionName =
+    tmuxText ["display-message", "-p", "-t", target sessionName, "#{pane_id}"]
+
+currentWindow :: Text -> IO Text
+currentWindow sessionName =
+    tmuxText ["display-message", "-p", "-t", target sessionName, "#{window_id}"]
+
+inactivePane :: Text -> IO Text
+inactivePane sessionName =
+    tmuxText ["list-panes", "-t", target sessionName, "-f", "#{==:#{pane_active},0}", "-F", "#{pane_id}"]
+
+inactiveWindow :: Text -> IO Text
+inactiveWindow sessionName =
+    tmuxText ["list-windows", "-t", target sessionName, "-f", "#{==:#{window_active},0}", "-F", "#{window_id}"]
+
+paneIds :: Text -> IO [Text]
+paneIds sessionName =
+    sort . T.lines <$> tmuxText ["list-panes", "-s", "-t", target sessionName, "-F", "#{pane_id}"]
+
+windowIds :: Text -> IO [Text]
+windowIds sessionName =
+    sort . T.lines <$> tmuxText ["list-windows", "-t", target sessionName, "-F", "#{window_id}"]
+
+sessionExists :: Text -> IO Bool
+sessionExists sessionName = do
+    (exitCode, _, _) <- tmuxResult ["has-session", "-t", target sessionName]
+    pure $ exitCode == ExitSuccess
+
+tmux :: [String] -> IO ()
+tmux = callProcess "tmux"
+
+tmuxText :: [String] -> IO Text
+tmuxText args = T.strip . T.pack <$> readProcess "tmux" args ""
+
+tmuxResult :: [String] -> IO (ExitCode, String, String)
+tmuxResult args = readProcessWithExitCode "tmux" args ""
+
+target :: Text -> String
+target = T.unpack
+
+shouldExclude :: (Eq a) => [a] -> a -> IO ()
+values `shouldExclude` value = (value `elem` values) `shouldBe` False
+
+shouldReturnSorted :: IO [Text] -> [Text] -> IO ()
+action `shouldReturnSorted` expected = action >>= (`shouldBe` sort expected)
+
+shouldReturnText :: IO Text -> Text -> IO ()
+action `shouldReturnText` expected = action >>= (`shouldBe` expected)

--- a/ui/dist/index.css
+++ b/ui/dist/index.css
@@ -1165,3 +1165,103 @@ button:active:not(:disabled),
     background: var(--surface-active);
   }
 }
+
+.destructive-settings-group {
+  display: grid;
+  gap: 8px;
+  border-top: 1px solid var(--border);
+  margin-top: 2px;
+  padding-top: 12px;
+}
+
+.destructive-settings-copy,
+.close-preview-status,
+.close-execute-status {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.close-current-action {
+  width: 100%;
+  min-height: 44px;
+  justify-content: flex-start;
+}
+
+.close-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  padding: calc(18px + var(--safe-top)) calc(18px + var(--safe-right)) calc(18px + var(--safe-bottom)) calc(18px + var(--safe-left));
+  background: rgba(0, 0, 0, 0.56);
+}
+
+.close-sheet {
+  width: min(480px, 100%);
+  max-width: 100%;
+  max-height: calc(100vh - 36px - var(--safe-top) - var(--safe-bottom));
+  max-height: calc(100dvh - 36px - var(--safe-top) - var(--safe-bottom));
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  display: grid;
+  gap: 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  background: var(--surface);
+  padding: 18px;
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.42);
+}
+
+.close-sheet-title {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.close-sheet-copy {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.close-sheet-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 10px;
+  min-width: 0;
+}
+
+.close-sheet-cancel,
+.close-sheet-submit {
+  width: 100%;
+  min-width: 0;
+  min-height: 48px;
+  white-space: normal;
+}
+
+@media (max-width: 420px) {
+  .close-sheet-backdrop {
+    place-items: end center;
+    padding: calc(10px + var(--safe-top)) calc(10px + var(--safe-right)) calc(10px + var(--safe-bottom)) calc(10px + var(--safe-left));
+  }
+
+  .close-sheet {
+    max-height: calc(100vh - 20px - var(--safe-top) - var(--safe-bottom));
+    max-height: calc(100dvh - 20px - var(--safe-top) - var(--safe-bottom));
+    padding: 16px;
+  }
+
+  .close-sheet-actions {
+    grid-template-columns: 1fr;
+  }
+}

--- a/ui/src/AgentDaemon/Api.js
+++ b/ui/src/AgentDaemon/Api.js
@@ -44,6 +44,33 @@ export const deleteSessionImpl = (base) => (sessionId) => () =>
     { method: "DELETE" }
   ).then(readJsonResponse).then(() => undefined);
 
+const closeCurrentUrl = (base, sessionId, path) =>
+  `${base}/sessions/${encodeURIComponent(sessionId)}/${path}`;
+
+const previewCloseCurrent = (base, sessionId, path) =>
+  fetch(closeCurrentUrl(base, sessionId, path), {
+    method: "POST"
+  }).then(readJsonResponse);
+
+const closeCurrent = (base, sessionId, path, confirmation) =>
+  fetch(closeCurrentUrl(base, sessionId, path), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ confirmation })
+  }).then(readJsonResponse);
+
+export const previewCloseCurrentPaneImpl = (base) => (sessionId) => () =>
+  previewCloseCurrent(base, sessionId, "current-pane/close/preview");
+
+export const closeCurrentPaneImpl = (base) => (sessionId) => (confirmation) => () =>
+  closeCurrent(base, sessionId, "current-pane/close", confirmation);
+
+export const previewCloseCurrentWindowImpl = (base) => (sessionId) => () =>
+  previewCloseCurrent(base, sessionId, "current-window/close/preview");
+
+export const closeCurrentWindowImpl = (base) => (sessionId) => (confirmation) => () =>
+  closeCurrent(base, sessionId, "current-window/close", confirmation);
+
 export const selectWindowImpl = (base) => (sessionId) => (index) => () =>
   fetch(`${base}/sessions/${encodeURIComponent(sessionId)}/windows`, {
     method: "POST",

--- a/ui/src/AgentDaemon/Api.purs
+++ b/ui/src/AgentDaemon/Api.purs
@@ -1,8 +1,12 @@
 module AgentDaemon.Api
-  ( fetchSessions
+  ( closeCurrentPane
+  , closeCurrentWindow
+  , fetchSessions
   , fetchWindows
   , createWindow
   , deleteSession
+  , previewCloseCurrentPane
+  , previewCloseCurrentWindow
   , selectWindow
   , liveSession
   , scrollSession
@@ -10,7 +14,7 @@ module AgentDaemon.Api
 
 import Prelude
 
-import AgentDaemon.Types (Session, WindowInfo)
+import AgentDaemon.Types (CloseExecution, ClosePreview, Session, WindowInfo)
 import Control.Promise (Promise, toAffE)
 import Effect (Effect)
 import Effect.Aff (Aff)
@@ -26,6 +30,18 @@ foreign import createWindowImpl
 
 foreign import deleteSessionImpl
   :: String -> String -> Effect (Promise Unit)
+
+foreign import previewCloseCurrentPaneImpl
+  :: String -> String -> Effect (Promise ClosePreview)
+
+foreign import closeCurrentPaneImpl
+  :: String -> String -> String -> Effect (Promise CloseExecution)
+
+foreign import previewCloseCurrentWindowImpl
+  :: String -> String -> Effect (Promise ClosePreview)
+
+foreign import closeCurrentWindowImpl
+  :: String -> String -> String -> Effect (Promise CloseExecution)
 
 foreign import selectWindowImpl
   :: String -> String -> Int -> Effect (Promise Unit)
@@ -51,6 +67,22 @@ createWindow base sessionId =
 deleteSession :: String -> String -> Aff Unit
 deleteSession base sessionId =
   toAffE (deleteSessionImpl base sessionId)
+
+previewCloseCurrentPane :: String -> String -> Aff ClosePreview
+previewCloseCurrentPane base sessionId =
+  toAffE (previewCloseCurrentPaneImpl base sessionId)
+
+closeCurrentPane :: String -> String -> String -> Aff CloseExecution
+closeCurrentPane base sessionId confirmation =
+  toAffE (closeCurrentPaneImpl base sessionId confirmation)
+
+previewCloseCurrentWindow :: String -> String -> Aff ClosePreview
+previewCloseCurrentWindow base sessionId =
+  toAffE (previewCloseCurrentWindowImpl base sessionId)
+
+closeCurrentWindow :: String -> String -> String -> Aff CloseExecution
+closeCurrentWindow base sessionId confirmation =
+  toAffE (closeCurrentWindowImpl base sessionId confirmation)
 
 selectWindow :: String -> String -> Int -> Aff Unit
 selectWindow base sessionId index =

--- a/ui/src/AgentDaemon/FFI/Terminal.js
+++ b/ui/src/AgentDaemon/FFI/Terminal.js
@@ -480,8 +480,7 @@ export const mountTerminal = (controller) => (elementId) => () => {
   }
 };
 
-export const attachTerminal = (controller) => (url) => (label) => () => {
-  disconnectTerminal(controller)();
+const openTerminalSocket = (controller, url, label) => {
   controller.term.clear();
   const socket = new WebSocket(url);
   controller.socket = socket;
@@ -512,15 +511,32 @@ export const attachTerminal = (controller) => (url) => (label) => () => {
   };
 
   socket.onerror = () => {
+    if (controller.socket !== socket) return;
     controller.callbacks.onError();
   };
+};
+
+export const attachTerminal = (controller) => (url) => (label) => () => {
+  disconnectTerminal(controller)();
+  openTerminalSocket(controller, url, label);
+};
+
+export const replaceTerminalAfterDestructiveClose = (controller) => (url) => (label) => () => {
+  abandonTerminal(controller)();
+  openTerminalSocket(controller, url, label);
 };
 
 export const disconnectTerminal = (controller) => () => {
   if (!controller.socket) return;
   const socket = controller.socket;
   controller.socket = null;
-  socket.close();
+  if (socket.readyState < WebSocket.CLOSING) {
+    socket.close();
+  }
+};
+
+export const abandonTerminal = (controller) => () => {
+  controller.socket = null;
 };
 
 export const fitTerminal = (controller) => () => {

--- a/ui/src/AgentDaemon/FFI/Terminal.purs
+++ b/ui/src/AgentDaemon/FFI/Terminal.purs
@@ -1,11 +1,13 @@
 module AgentDaemon.FFI.Terminal
   ( TerminalCallbacks
   , TerminalController
+  , abandonTerminal
   , attachTerminal
   , createTerminal
   , disconnectTerminal
   , fitTerminal
   , mountTerminal
+  , replaceTerminalAfterDestructiveClose
   , sendCtrlB
   , sendCtrlBCommand
   , sendEscape
@@ -41,7 +43,12 @@ foreign import mountTerminal :: TerminalController -> String -> Effect Unit
 foreign import attachTerminal
   :: TerminalController -> String -> String -> Effect Unit
 
+foreign import replaceTerminalAfterDestructiveClose
+  :: TerminalController -> String -> String -> Effect Unit
+
 foreign import disconnectTerminal :: TerminalController -> Effect Unit
+
+foreign import abandonTerminal :: TerminalController -> Effect Unit
 
 foreign import fitTerminal :: TerminalController -> Effect Unit
 

--- a/ui/src/AgentDaemon/Types.purs
+++ b/ui/src/AgentDaemon/Types.purs
@@ -1,8 +1,20 @@
 module AgentDaemon.Types
-  ( PasteSnippet
+  ( CloseExecution
+  , ClosePreview
+  , PasteSnippet
   , Session
   , WindowInfo
   ) where
+
+type ClosePreview =
+  { consequence :: String
+  , confirmation :: String
+  }
+
+type CloseExecution =
+  { consequence :: String
+  , sessionEnded :: Boolean
+  }
 
 type PasteSnippet =
   { name :: String

--- a/ui/src/Main.purs
+++ b/ui/src/Main.purs
@@ -5,11 +5,11 @@ import Prelude
 import AgentDaemon.Api as Api
 import AgentDaemon.FFI.Browser as Browser
 import AgentDaemon.FFI.Terminal as Terminal
-import AgentDaemon.Types (PasteSnippet, Session, WindowInfo)
+import AgentDaemon.Types (CloseExecution, ClosePreview, PasteSnippet, Session, WindowInfo)
 import Data.Array as Array
 import Data.Either (Either(..))
 import Data.Int as Int
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..), fromMaybe, isNothing)
 import Effect (Effect)
 import Effect.Aff (Aff, attempt)
 import Effect.Aff.Class (liftAff)
@@ -30,6 +30,22 @@ main = HA.runHalogenAff do
 
 type Slots :: forall k. Row k
 type Slots = ()
+
+data CloseScope
+  = ClosePane
+  | CloseWindow
+
+type CloseDialog =
+  { scope :: CloseScope
+  , sessionId :: String
+  , consequence :: String
+  , confirmation :: String
+  }
+
+type ReconnectNotice =
+  { sessionId :: String
+  , status :: String
+  }
 
 type State =
   { sessions :: Array Session
@@ -54,6 +70,11 @@ type State =
   , autoAttachAttempted :: Boolean
   , pendingStop :: Maybe Session
   , confirmInput :: String
+  , pendingClose :: Maybe CloseDialog
+  , closePreviewLoading :: Boolean
+  , closeExecuting :: Boolean
+  , endedNotice :: Maybe String
+  , reconnectNotice :: Maybe ReconnectNotice
   , terminal :: Maybe Terminal.TerminalController
   }
 
@@ -99,6 +120,9 @@ data Action
   | CloseStopDialog
   | SetConfirmInput String
   | ConfirmStopSession
+  | OpenCloseCurrent CloseScope
+  | CancelCloseCurrent
+  | ConfirmCloseCurrent
   | AttachSession String
   | ChooseSession String
   | CreateWindow
@@ -131,6 +155,11 @@ appComponent = H.mkComponent
       , autoAttachAttempted: false
       , pendingStop: Nothing
       , confirmInput: ""
+      , pendingClose: Nothing
+      , closePreviewLoading: false
+      , closeExecuting: false
+      , endedNotice: Nothing
+      , reconnectNotice: Nothing
       , terminal: Nothing
       }
   , render
@@ -148,6 +177,7 @@ render state =
     , renderMain state
     , renderActionDock state
     , renderConfirm state
+    , renderCloseConfirm state
     ]
 
 renderHeader :: State -> H.ComponentHTML Action Slots Aff
@@ -615,6 +645,42 @@ renderSettings state =
             (AdjustTerminalFontSize 1)
             Nothing
         ]
+    , if state.attachedSession == "" then
+        HH.text ""
+      else
+        HH.div
+          [ cls "destructive-settings-group" ]
+          [ HH.div
+              [ cls "section-title" ]
+              [ HH.text "Current tmux context" ]
+          , HH.p
+              [ cls "destructive-settings-copy" ]
+              [ HH.text "The server confirms what will close before either action runs." ]
+          , HH.button
+              [ cls "close-current-action danger-outline"
+              , HP.disabled state.closePreviewLoading
+              , HE.onClick \_ -> OpenCloseCurrent ClosePane
+              ]
+              [ icon "trash-2"
+              , HH.text "Close this pane"
+              ]
+          , HH.button
+              [ cls "close-current-action danger-outline"
+              , HP.disabled state.closePreviewLoading
+              , HE.onClick \_ -> OpenCloseCurrent CloseWindow
+              ]
+              [ icon "trash-2"
+              , HH.text "Close this window"
+              ]
+          , if state.closePreviewLoading then
+              HH.p
+                [ cls "close-preview-status"
+                , HP.attr (HH.AttrName "role") "status"
+                ]
+                [ HH.text "Loading close consequence…" ]
+            else
+              HH.text ""
+          ]
     ]
 
 renderMain :: State -> H.ComponentHTML Action Slots Aff
@@ -726,6 +792,57 @@ renderConfirm state =
             ]
         ]
 
+renderCloseConfirm :: State -> H.ComponentHTML Action Slots Aff
+renderCloseConfirm state =
+  case state.pendingClose of
+    Nothing ->
+      HH.text ""
+    Just pending ->
+      HH.div
+        [ cls "close-sheet-backdrop" ]
+        [ HH.div
+            [ cls "close-sheet"
+            , HP.attr (HH.AttrName "role") "dialog"
+            , HP.attr (HH.AttrName "aria-modal") "true"
+            , HP.attr (HH.AttrName "aria-labelledby") "close-sheet-title"
+            , HP.attr (HH.AttrName "aria-describedby") "close-sheet-copy"
+            ]
+            [ HH.h2
+                [ cls "close-sheet-title"
+                , HP.id "close-sheet-title"
+                ]
+                [ HH.text (closeActionLabel pending.scope) ]
+            , HH.p
+                [ cls "close-sheet-copy"
+                , HP.id "close-sheet-copy"
+                ]
+                [ HH.text (closeConsequenceCopy pending.scope pending.consequence) ]
+            , HH.div
+                [ cls "close-sheet-actions" ]
+                [ HH.button
+                    [ cls "close-sheet-cancel"
+                    , HP.disabled state.closeExecuting
+                    , HE.onClick \_ -> CancelCloseCurrent
+                    ]
+                    [ HH.text "Cancel" ]
+                , HH.button
+                    [ cls "close-sheet-submit danger"
+                    , HP.disabled state.closeExecuting
+                    , HE.onClick \_ -> ConfirmCloseCurrent
+                    ]
+                    [ HH.text (closeActionLabel pending.scope) ]
+                ]
+            , if state.closeExecuting then
+                HH.p
+                  [ cls "close-execute-status"
+                  , HP.attr (HH.AttrName "role") "status"
+                  ]
+                  [ HH.text "Closing the server-confirmed current context…" ]
+              else
+                HH.text ""
+            ]
+        ]
+
 handleAction
   :: forall o
    . Action
@@ -806,7 +923,9 @@ handleAction = case _ of
               if attached == "" then false else state.terminalSelectionMode
           , pasteMenuOpen =
               if attached == "" then false else state.pasteMenuOpen
-          , status = show (Array.length sessions) <> " session(s)"
+          , status = fromMaybe
+              (show (Array.length sessions) <> " session(s)")
+              state.endedNotice
           }
         if shouldAutoAttach then
           handleAction (AttachSession selected)
@@ -1059,6 +1178,18 @@ handleAction = case _ of
               H.modify_ _ { status = "stopped: " <> session.id }
               syncUi
 
+  OpenCloseCurrent scope ->
+    openCloseCurrent scope
+
+  CancelCloseCurrent -> do
+    state <- H.get
+    when (not state.closeExecuting) do
+      H.modify_ _ { pendingClose = Nothing }
+      syncUi
+
+  ConfirmCloseCurrent ->
+    confirmCloseCurrent
+
   AttachSession sessionId -> do
     state <- H.get
     case state.terminal of
@@ -1073,6 +1204,11 @@ handleAction = case _ of
           { selectedSession = sessionId
           , attachedSession = sessionId
           , windows = []
+          , pendingClose = Nothing
+          , closePreviewLoading = false
+          , closeExecuting = false
+          , endedNotice = Nothing
+          , reconnectNotice = Nothing
           , sessionMenuOpen = false
           , windowMenuOpen = false
           , terminalMenuOpen = false
@@ -1165,6 +1301,11 @@ handleAction = case _ of
     H.modify_ _
       { attachedSession = ""
       , windows = []
+      , pendingClose = Nothing
+      , closePreviewLoading = false
+      , closeExecuting = false
+      , endedNotice = Nothing
+      , reconnectNotice = Nothing
       , sessionMenuOpen = false
       , windowMenuOpen = false
       , terminalMenuOpen = false
@@ -1176,9 +1317,22 @@ handleAction = case _ of
 
   HandleTerminal event -> do
     case event of
-      TerminalOpened label ->
-        H.modify_ _ { status = "attached: " <> label }
-      TerminalClosed ->
+      TerminalOpened label -> do
+        state <- H.get
+        case state.reconnectNotice of
+          Just reconnect -> do
+            H.modify_ _
+              { attachedSession = reconnect.sessionId
+              , selectedSession = reconnect.sessionId
+              , reconnectNotice = Nothing
+              , status = reconnect.status
+              }
+            refreshWindows reconnect.sessionId
+          Nothing ->
+            H.modify_ _
+              { status = fromMaybe ("attached: " <> label) state.endedNotice }
+      TerminalClosed -> do
+        state <- H.get
         H.modify_ _
           { attachedSession = ""
           , windows = []
@@ -1187,11 +1341,12 @@ handleAction = case _ of
           , terminalMenuOpen = false
           , terminalSelectionMode = false
           , pasteMenuOpen = false
-          , status = "disconnected"
+          , status = fromMaybe "disconnected" state.endedNotice
           }
       TerminalErrored ->
         H.modify_ _
           { status = "connection error"
+          , reconnectNotice = Nothing
           , terminalMenuOpen = false
           , terminalSelectionMode = false
           , pasteMenuOpen = false
@@ -1205,6 +1360,248 @@ handleAction = case _ of
     case event of
       TerminalScrollGesture _ -> pure unit
       _ -> syncUi
+
+openCloseCurrent
+  :: forall o
+   . CloseScope
+  -> H.HalogenM State Action Slots o Aff Unit
+openCloseCurrent scope = do
+  state <- H.get
+  when
+    ( state.attachedSession /= ""
+        && not state.closePreviewLoading
+        && isNothing state.pendingClose
+    )
+    do
+      let sessionId = state.attachedSession
+      H.modify_ _
+        { closePreviewLoading = true
+        , status = "Loading consequence for " <> closeActionLabel scope <> "…"
+        }
+      syncUi
+      base <- liftEffect $ Browser.apiBase state.server
+      result <- liftAff $ attempt (previewCloseCurrent scope base sessionId)
+      latest <- H.get
+      when
+        ( latest.attachedSession == sessionId
+            && latest.closePreviewLoading
+        )
+        do
+          case result of
+            Left err -> do
+              let notice = closeActionLabel scope <> " preview failed: " <> message err
+              H.modify_ _
+                { pendingClose = Nothing
+                , closePreviewLoading = false
+                , closeExecuting = false
+                , settingsOpen = false
+                , status = notice
+                }
+              void $ refreshSurvivingClose sessionId notice
+            Right preview ->
+              H.modify_ _
+                { pendingClose = Just
+                    { scope: scope
+                    , sessionId: sessionId
+                    , consequence: preview.consequence
+                    , confirmation: preview.confirmation
+                    }
+                , closePreviewLoading = false
+                , closeExecuting = false
+                , settingsOpen = false
+                , status = "Review " <> closeActionLabel scope
+                }
+          syncUi
+
+confirmCloseCurrent
+  :: forall o
+   . H.HalogenM State Action Slots o Aff Unit
+confirmCloseCurrent = do
+  state <- H.get
+  case state.pendingClose of
+    Nothing -> pure unit
+    Just pending ->
+      when (not state.closeExecuting) do
+        H.modify_ _
+          { closeExecuting = true
+          , status = "Closing the server-confirmed current context…"
+          }
+        syncUi
+        base <- liftEffect $ Browser.apiBase state.server
+        result <- liftAff $ attempt
+          (executeCloseCurrent pending.scope base pending.sessionId pending.confirmation)
+        case result of
+          Left err -> do
+            let notice = closeActionLabel pending.scope <> " failed: " <> message err
+            H.modify_ _
+              { pendingClose = Nothing
+              , closePreviewLoading = false
+              , closeExecuting = false
+              , status = notice
+              }
+            void $ refreshSurvivingClose pending.sessionId notice
+          Right execution ->
+            if execution.sessionEnded then
+              finishEndedClose pending execution
+            else
+              finishSurvivingClose pending execution
+        syncUi
+
+previewCloseCurrent :: CloseScope -> String -> String -> Aff ClosePreview
+previewCloseCurrent scope base sessionId =
+  case scope of
+    ClosePane -> Api.previewCloseCurrentPane base sessionId
+    CloseWindow -> Api.previewCloseCurrentWindow base sessionId
+
+executeCloseCurrent
+  :: CloseScope
+  -> String
+  -> String
+  -> String
+  -> Aff CloseExecution
+executeCloseCurrent scope base sessionId confirmation =
+  case scope of
+    ClosePane -> Api.closeCurrentPane base sessionId confirmation
+    CloseWindow -> Api.closeCurrentWindow base sessionId confirmation
+
+finishSurvivingClose
+  :: forall o
+   . CloseDialog
+  -> CloseExecution
+  -> H.HalogenM State Action Slots o Aff Unit
+finishSurvivingClose pending execution = do
+  let notice = closeSuccessStatus pending.scope execution.consequence false
+  H.modify_ _
+    { pendingClose = Nothing
+    , closePreviewLoading = false
+    , closeExecuting = false
+    , status = notice
+    }
+  sessionExists <- refreshSurvivingClose pending.sessionId notice
+  when sessionExists do
+    state <- H.get
+    case state.terminal of
+      Nothing -> H.modify_ _ { status = notice <> "; terminal not ready" }
+      Just terminal -> do
+        let reconnectStatus = state.status
+        url <- liftEffect $
+          Browser.sessionTerminalWsUrl state.server pending.sessionId
+        H.modify_ _
+          { reconnectNotice = Just
+              { sessionId: pending.sessionId
+              , status: reconnectStatus
+              }
+          }
+        liftEffect do
+          Terminal.setSelectionMode terminal false
+          Terminal.replaceTerminalAfterDestructiveClose terminal url
+            ("session " <> pending.sessionId)
+
+finishEndedClose
+  :: forall o
+   . CloseDialog
+  -> CloseExecution
+  -> H.HalogenM State Action Slots o Aff Unit
+finishEndedClose pending execution = do
+  let notice = closeSuccessStatus pending.scope execution.consequence true
+  state <- H.get
+  H.modify_ _
+    { pendingClose = Nothing
+    , closePreviewLoading = false
+    , closeExecuting = false
+    , endedNotice = Just notice
+    , reconnectNotice = Nothing
+    , attachedSession = ""
+    , selectedSession = ""
+    , windows = []
+    , settingsOpen = false
+    , sessionMenuOpen = false
+    , windowMenuOpen = false
+    , terminalMenuOpen = false
+    , terminalSelectionMode = false
+    , pasteMenuOpen = false
+    , status = notice
+    }
+  case state.terminal of
+    Nothing -> pure unit
+    Just terminal -> liftEffect do
+      Terminal.setSelectionMode terminal false
+      Terminal.abandonTerminal terminal
+  refreshEndedClose notice
+
+refreshSurvivingClose
+  :: forall o
+   . String
+  -> String
+  -> H.HalogenM State Action Slots o Aff Boolean
+refreshSurvivingClose sessionId notice = do
+  state <- H.get
+  base <- liftEffect $ Browser.apiBase state.server
+  sessionsResult <- liftAff $ attempt (Api.fetchSessions base)
+  case sessionsResult of
+    Left err -> do
+      let refreshNotice = notice <> "; session refresh failed: " <> message err
+      H.modify_ _ { status = refreshNotice }
+      pure false
+    Right sessions ->
+      if Array.any (\session -> session.id == sessionId) sessions then do
+        windowsResult <- liftAff $ attempt (Api.fetchWindows base sessionId)
+        case windowsResult of
+          Left err -> do
+            let refreshNotice = notice <> "; window refresh failed: " <> message err
+            H.modify_ _
+              { sessions = sessions
+              , windows = []
+              , attachedSession = sessionId
+              , selectedSession = sessionId
+              , status = refreshNotice
+              }
+          Right windows ->
+            H.modify_ _
+              { sessions = sessions
+              , windows = windows
+              , attachedSession = sessionId
+              , selectedSession = sessionId
+              , status = notice
+              }
+        pure true
+      else do
+        let missingNotice = notice <> "; session no longer exists"
+        H.modify_ _
+          { sessions = sessions
+          , windows = []
+          , attachedSession = ""
+          , selectedSession = maybeSessionId (Array.head sessions)
+          , status = missingNotice
+          }
+        case state.terminal of
+          Nothing -> pure unit
+          Just terminal -> liftEffect do
+            Terminal.setSelectionMode terminal false
+            Terminal.disconnectTerminal terminal
+        pure false
+
+refreshEndedClose
+  :: forall o
+   . String
+  -> H.HalogenM State Action Slots o Aff Unit
+refreshEndedClose notice = do
+  state <- H.get
+  base <- liftEffect $ Browser.apiBase state.server
+  result <- liftAff $ attempt (Api.fetchSessions base)
+  case result of
+    Left err -> do
+      let refreshNotice = notice <> "; session refresh failed: " <> message err
+      H.modify_ _ { endedNotice = Just refreshNotice, status = refreshNotice }
+    Right sessions ->
+      H.modify_ _
+        { sessions = sessions
+        , selectedSession = maybeSessionId (Array.head sessions)
+        , attachedSession = ""
+        , windows = []
+        , endedNotice = Just notice
+        , status = notice
+        }
 
 sendTerminalAction
   :: forall o
@@ -1448,6 +1845,36 @@ windowLabel :: WindowInfo -> String
 windowLabel windowInfo =
   if windowInfo.name == "" then "window " <> show windowInfo.index
   else windowInfo.name
+
+closeActionLabel :: CloseScope -> String
+closeActionLabel = case _ of
+  ClosePane -> "Close this pane"
+  CloseWindow -> "Close this window"
+
+closeConsequenceCopy :: CloseScope -> String -> String
+closeConsequenceCopy scope consequence =
+  case consequence of
+    "pane-removed" ->
+      "The current pane will close. Its window and session will remain."
+    "pane-and-window-removed" ->
+      "This is the window's last pane. The current pane and window will close while the session remains."
+    "window-removed" ->
+      "The current window and all its panes will close. The session will remain."
+    "session-ended" ->
+      case scope of
+        ClosePane ->
+          "This is the final pane in the final window. Closing it will end the session."
+        CloseWindow ->
+          "This is the final window. Closing it and all its panes will end the session."
+    _ ->
+      "The server reports consequence “" <> consequence <> "”."
+
+closeSuccessStatus :: CloseScope -> String -> Boolean -> String
+closeSuccessStatus scope consequence sessionEnded =
+  closeActionLabel scope
+    <> " complete: "
+    <> consequence
+    <> if sessionEnded then " — session ended" else " — session remains"
 
 pastePreview :: String -> String
 pastePreview = identity


### PR DESCRIPTION
Closes #82

Parent epic: #80
Depends on #75, merged via PR #76 at `177679658ed21dc30cf59f5895195d2a73831ccb`.

## Goal

Add exactly two touch-first destructive actions: **Close this pane** and **Close this window**. The server resolves the current context at execution time; the client cannot name or select an arbitrary pane or window.

## Safety contract

- Consequence-based, no-typing confirmation with large Cancel and destructive controls.
- Closing the last pane warns that the window also closes; closing the last window warns that the session ends.
- Success follows tmux to the surviving context, or shows a truthful ended/disconnected state.
- Stale or raced requests fail closed and refresh truthfully without closing a different context.

## Design and proof

- The server mints a single-use opaque confirmation bound to its own current-context snapshot; execution resolves currentness again and rejects mismatch.
- Pure Haskell state-machine transitions and QuickCheck properties cover current-only effect, stale identity, exact removal, survivor validity, termination, and replay rejection.
- Disposable tmux and live HTTP tests cover actual current-only close behavior, atomic consumption, failure mapping, and concurrency.
- Touch browser proof covers confirmation, cancellation, success recovery, failure refresh, and ended state at 390×844, 768×1024, and 1024×768.

The operator explicitly waived adding the repository's first Lean toolchain for #82. This is a deliberate proof-mechanism decision: precise prose, Haskell/QuickCheck, live tmux, API, and browser proof replace Lean; all product and gate requirements remain binding.

## Planning artifacts

- [Specification](https://github.com/lambdasistemi/tmux-ws/blob/feat/close-current-pane-or-window/specs/082-close-current-context/spec.md)
- [Implementation plan](https://github.com/lambdasistemi/tmux-ws/blob/feat/close-current-pane-or-window/specs/082-close-current-context/plan.md)
- [Task ledger](https://github.com/lambdasistemi/tmux-ws/blob/feat/close-current-pane-or-window/specs/082-close-current-context/tasks.md)

## Status

Ready for review: all behavior and verification tasks are complete, `gate.sh` is absent at the final sentinel head, and all authoritative final-head hosted checks are successful.

### Landed slices

- Pure state-machine model and QuickCheck preservation proof: `86c7b488368d4aa7bffdc16f041ee77f313911d7`
  - Behavioral RED: five invariant properties failed with counterexamples; coverage guards passed.
  - Review correction RED: same-total pane redistribution changed the confirmation consequence without staleness (67 examples, 1 failure).
  - GREEN: current-window cardinality joins the opaque snapshot fingerprint; 67 examples, 0 failures.
  - Independent focused tests and `./gate.sh`: exit 0.

- Atomic current-only tmux boundary and disposable live proof: `25ae59e67b8a11c89a2f5c2356119ebb233f7f2b`
  - Behavioral RED: five live success paths retained prepared contexts under the safe no-op scaffold (77 examples, 5 failures).
  - GREEN: one guarded `tmux if-shell -F` mutation uses prepared stable identities and consequence-relevant counts; stale mismatches fail closed.
  - Independent navigator proof: formatting exit 0 and 77 examples, 0 failures; committed tree matched the approved handoff exactly before task stamping.
  - Ticket-owner focused verification and `./gate.sh`: exit 0.

- Opaque single-use current-close API: `15d13c4cc01a3fe45250718992cad8ef9d028cff`
  - Final executable RED: 89 examples, 12 intended preview failures, all 77 prior examples passing; four review rounds closed concurrency, exact topology, route shape, token opacity, failure lifecycle, registry, and fixture observability gaps.
  - GREEN: four target-free Servant routes, per-session/scope pending state, atomic consume-before-IO, exhaustive stale/tmux mappings, and registry deletion only on truthful session end.
  - The API-neutral boundary seam keeps all test observation/injection outside `SessionManager`; the prepared tmux close remains opaque and exposes only its computed consequence.
  - Independent formatting, HLint, 89/0 tests, navigator commit verification, and ticket-owner `./gate.sh`: exit 0.

- Touch confirmations and truthful terminal recovery: `23e38b760aa41b7be40aab3b0229fb284e615562`
  - Exactly two attached-session actions use server-provided consequence copy and pointer-only Cancel/destructive sheets; execute bodies contain only the opaque `confirmation`.
  - Destructive survivor/ended recovery abandons the server-closing socket, while ordinary switching and explicit disconnect retain normal close behavior; a six-branch executable lifecycle proof passed.
  - The final cache-disabled click-only matrix covered both actions and Cancel at 390×844, 768×1024, and 1024×768, with 44/48px controls, bounded sheets, no overflow or typing, pane and window survivor reconnect, session-ended persistence, and stale fail-closed refresh.
  - Core browser paths recorded zero console errors. The deliberate stale execute produced only its accepted HTTP 409 resource diagnostic, with zero JavaScript/WebSocket errors and no retry.
  - `nix run --quiet .#ui`, UI `just ci`, full `./gate.sh`, xhigh browser approval, and navigator verification of the owner-stamped commit all passed.

## Final verification

- Review links: [complete PR diff](https://github.com/lambdasistemi/tmux-ws/pull/83/files), [touch UI/lifecycle slice](https://github.com/lambdasistemi/tmux-ws/commit/23e38b760aa41b7be40aab3b0229fb284e615562), and [final sentinel](https://github.com/lambdasistemi/tmux-ws/commit/520d6134abfae3ff277fa380d6626cec279557cb).
- Focused Haskell/API/state-machine and disposable live-tmux proof: 89 examples, 0 failures.
- Focused PureScript/UI proof: formatting clean, 0 compiler warnings, 0 errors, bundle success.
- Fresh full local verification: `./gate.sh` exit 0 and `nix develop --quiet -c just ci` exit 0.
- Browser evidence: cache-disabled, click-only matrix at 390×844, 768×1024, and 1024×768; screenshots and request/topology transcript independently reviewed by the xhigh navigator.
- Formalization decision: the operator-approved Lean waiver is recorded in the specification, plan, task ledger, and this PR body; the replacement proof stack is complete.
- PR metadata: assigned to `paolino`, labeled `feat`, closes #82, references parent #80 and dependency #75/PR #76.
- Finalization audit: every branch commit passed the Conventional Commit/body/task gate, all T001–T019 tasks are checked, and final sentinel `520d6134abfae3ff277fa380d6626cec279557cb` removed `gate.sh`.
- Final-head hosted run [29158640824](https://github.com/lambdasistemi/tmux-ws/actions/runs/29158640824): 9/9 successful — Build Gate, Haskell build and tests, Cabal package validation, HLint, PureScript UI, Workflow lint, Formatting, Dev shell build, and Darwin build.
