### PR TITLE
fix(release): preserve feature minor bumps before 1.0

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix run --quiet .#workflow-lint
+nix develop --quiet -c just ci

--- a/gate.sh
+++ b/gate.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix run --quiet .#workflow-lint
-nix develop --quiet -c just ci

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -271,8 +271,8 @@ let
           "$(jq -r '.packages["."]."bump-minor-pre-major"' "$release_config")" \
           true 'pre-major minor bump'
         assert_eq \
-          "$(jq -r '.packages["."]."bump-patch-for-minor-pre-major"' "$release_config")" \
-          true 'pre-major patch bump'
+          "$(jq -r '.packages["."] | if has("bump-patch-for-minor-pre-major") then ."bump-patch-for-minor-pre-major" == false else true end' "$release_config")" \
+          true 'pre-major feature-minor conversion is absent or false'
         assert_eq \
           "$(jq -r 'has("skip-labeling")' "$release_config")" \
           false 'release config omits unsupported skip-labeling property'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
     ".": {
       "release-type": "simple",
       "include-v-in-tag": true,
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-minor-pre-major": true
     }
   }
 }

--- a/specs/84-touch-docs-release/plan.md
+++ b/specs/84-touch-docs-release/plan.md
@@ -29,6 +29,14 @@ host utilities such as `awk` before entering the flake environment. Parse both
 manifest and Cabal versions through `nix eval`, and make the flake-owned
 workflow contract reject host-tool leakage in this preflight step.
 
+## Slice 4 — preserve feature minor releases
+
+The first live release-please run proposed `0.1.2`, proving that
+`bump-patch-for-minor-pre-major` converts pre-1.0 feature minors into patches.
+Remove that conversion policy while retaining the breaking-change
+`bump-minor-pre-major` rule, and enforce the distinction in the flake-owned
+release contract. Release PR #86 must regenerate as `0.2.0`.
+
 ## Publication sequence
 
 1. Merge this issue PR with green CI.

--- a/specs/84-touch-docs-release/tasks.md
+++ b/specs/84-touch-docs-release/tasks.md
@@ -18,10 +18,10 @@
 
 ## Slice 4 — preserve feature minor releases
 
-- [ ] T011-S4 Remove pre-1.0 feature-to-patch conversion and enforce the release policy.
+- [X] T011-S4 Remove pre-1.0 feature-to-patch conversion and enforce the release policy.
 
 ## Publication
 
-- [ ] P007 Merge the green implementation PR and verify Pages.
+- [X] P007 Merge the green implementation PR and verify Pages.
 - [ ] P008 Merge the green release PR and verify `v0.2.0` artifacts.
 - [ ] P009 Pin and smoke the development service from the released revision.

--- a/specs/84-touch-docs-release/tasks.md
+++ b/specs/84-touch-docs-release/tasks.md
@@ -16,6 +16,10 @@
 
 - [X] T010-S3 Remove the CI drift check's dependency on host `awk` and enforce the boundary.
 
+## Slice 4 — preserve feature minor releases
+
+- [ ] T011-S4 Remove pre-1.0 feature-to-patch conversion and enforce the release policy.
+
 ## Publication
 
 - [ ] P007 Merge the green implementation PR and verify Pages.


### PR DESCRIPTION
Refs #84

## Root cause

`bump-patch-for-minor-pre-major: true` tells release-please to turn pre-1.0 `feat:` minor bumps into patches. The first live release PR therefore proposed `0.1.2` instead of the intended `0.2.0`.

## Fix

- remove the feature-minor-to-patch conversion while retaining pre-major breaking-change behavior
- enforce in the flake-owned workflow contract that the conversion is absent or false
- record the completed release-policy slice and the verified Pages publication

## Verification

- RED: `nix run --quiet .#workflow-lint` rejected the enabled conversion
- GREEN: focused workflow lint passed after the correction
- `./gate.sh` passed, including flake checks and the full local CI suite

## Post-merge proof

Release Please must regenerate PR #86 as `chore(main): release 0.2.0` before it is eligible to merge.
