### PR TITLE
fix(release): make recovery rebase-safe

### DIFF
--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -98,6 +98,14 @@ jobs:
             while IFS= read -r library; do
               case "$library" in
                 /usr/lib/*|/System/*) continue ;;
+              esac
+
+              if test "$target" != "$binary" && \
+                test "$library" = "@rpath/$(basename "$target")"; then
+                continue
+              fi
+
+              case "$library" in
                 @*) printf 'unresolved install name in %s: %s\n' "$target" "$library" >&2; exit 1 ;;
               esac
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     name: Plan or create release
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
-      sha: ${{ steps.release.outputs.sha }}
+      release_created: ${{ steps.resolve.outputs.release_created }}
+      tag_name: ${{ steps.resolve.outputs.tag_name }}
+      version: ${{ steps.resolve.outputs.version }}
+      sha: ${{ steps.resolve.outputs.sha }}
     steps:
       - name: Mint a scoped release token
         id: app-token
@@ -29,12 +29,178 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      - uses: actions/checkout@v6
+
+      - name: Record release recovery start time
+        id: recovery-context
+        run: echo "started_at=$(date --utc +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Plan or create release
         id: release
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           skip-labeling: true
+
+      - name: Recover a rebased generated release PR
+        id: recover
+        if: ${{ github.event_name == 'push' && steps.release.outputs.release_created != 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RECOVERY_STARTED_AT: ${{ steps.recovery-context.outputs.started_at }}
+        run: |
+          set -euo pipefail
+
+          write_recovery_outputs() {
+            {
+              echo 'release_created=true'
+              echo "tag_name=$tag"
+              echo "version=$version"
+              echo "sha=$GITHUB_SHA"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          pull_requests="$RUNNER_TEMP/commit-pulls.json"
+          gh api --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls?per_page=100" \
+            > "$pull_requests"
+
+          matches="$RUNNER_TEMP/recovery-prs.json"
+          jq '[.[][] | select(
+            .merged_at != null and
+            .user.login == "lambdasistemi-ci[bot]" and
+            .base.ref == "main" and
+            .head.ref == "release-please--branches--main"
+          )]' "$pull_requests" > "$matches"
+          match_count="$(jq 'length' "$matches")"
+          case "$match_count" in
+            0) exit 0 ;;
+            1) ;;
+            *)
+              printf 'ambiguous generated release PRs for pushed commit: %s\n' \
+                "$match_count" >&2
+              exit 1
+              ;;
+          esac
+
+          version="$(jq -er '."."' .release-please-manifest.json)"
+          case "$version" in
+            [0-9]*.[0-9]*.[0-9]*) ;;
+            *) printf 'invalid release manifest version: %s\n' "$version" >&2; exit 1 ;;
+          esac
+          tag="v$version"
+          title="chore(main): release $version"
+          if test "$(jq -r '.[0].title' "$matches")" != "$title"; then
+            printf 'release metadata mismatch: generated PR title\n' >&2
+            exit 1
+          fi
+          if test "$(awk '$1 == "version:" { print $2; exit }' agent-daemon.cabal)" != "$version"; then
+            printf 'release metadata mismatch: Cabal version\n' >&2
+            exit 1
+          fi
+          if ! grep -Eq "^## \\[$version\\]" CHANGELOG.md; then
+            printf 'release metadata mismatch: changelog section\n' >&2
+            exit 1
+          fi
+
+          tag_status=0
+          git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1 \
+            || tag_status=$?
+          case "$tag_status" in
+            0) tag_exists=true ;;
+            2) tag_exists=false ;;
+            *)
+            printf 'could not determine whether %s already exists\n' "$tag" >&2
+            exit "$tag_status"
+              ;;
+          esac
+
+          release_response="$RUNNER_TEMP/release-response"
+          release_status=0
+          gh api --include "repos/${GITHUB_REPOSITORY}/releases/tags/$tag" \
+            > "$release_response" 2>&1 || release_status=$?
+          if test "$release_status" = 0; then
+            release_exists=true
+          elif grep -Eq '^HTTP/[0-9.]+ 404' "$release_response"; then
+            release_exists=false
+          else
+            cat "$release_response" >&2
+            exit "$release_status"
+          fi
+
+          if test "$tag_exists" = true && test "$release_exists" = true; then
+            write_recovery_outputs
+            exit 0
+          fi
+          if test "$tag_exists" != "$release_exists"; then
+            printf 'release state conflict for %s: tag=%s release=%s\n' \
+              "$tag" "$tag_exists" "$release_exists" >&2
+            exit 1
+          fi
+
+          notes="$RUNNER_TEMP/release-notes.md"
+          awk -v version="$version" '
+            $0 ~ "^## \\[" version "\\]" { printing = 1; next }
+            printing && /^## / { exit }
+            printing { print }
+          ' CHANGELOG.md > "$notes"
+          test -s "$notes"
+          gh release create "$tag" --target "$GITHUB_SHA" --title "$tag" \
+            --notes-file "$notes" --repo "$GITHUB_REPOSITORY"
+          write_recovery_outputs
+
+          false_prs="$RUNNER_TEMP/false-release-prs.json"
+          if ! gh pr list --state open --head release-please--branches--main \
+            --repo "$GITHUB_REPOSITORY" --json number,createdAt,author \
+            > "$false_prs"; then
+            printf 'warning: could not list false release PRs for cleanup\n' >&2
+            exit 0
+          fi
+          false_pr_numbers="$RUNNER_TEMP/false-release-pr-numbers"
+          if ! jq -r --arg started_at "$RECOVERY_STARTED_AT" '
+            .[] | select(
+              .author.login == "lambdasistemi-ci[bot]" and
+              .createdAt >= $started_at
+            ) | .number
+          ' "$false_prs" > "$false_pr_numbers"; then
+            printf 'warning: could not select false release PRs for cleanup\n' >&2
+            exit 0
+          fi
+          while IFS= read -r number; do
+            if ! gh pr close "$number" --delete-branch --repo "$GITHUB_REPOSITORY"; then
+              printf 'warning: could not close false release PR %s\n' "$number" >&2
+            fi
+          done < "$false_pr_numbers"
+
+      - name: Resolve primary or recovered release outputs
+        id: resolve
+        env:
+          PRIMARY_RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
+          PRIMARY_TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          PRIMARY_VERSION: ${{ steps.release.outputs.version }}
+          PRIMARY_SHA: ${{ steps.release.outputs.sha }}
+          RECOVERED_RELEASE_CREATED: ${{ steps.recover.outputs.release_created }}
+          RECOVERED_TAG_NAME: ${{ steps.recover.outputs.tag_name }}
+          RECOVERED_VERSION: ${{ steps.recover.outputs.version }}
+          RECOVERED_SHA: ${{ steps.recover.outputs.sha }}
+        run: |
+          if test "$PRIMARY_RELEASE_CREATED" = true; then
+            {
+              echo 'release_created=true'
+              echo "tag_name=$PRIMARY_TAG_NAME"
+              echo "version=$PRIMARY_VERSION"
+              echo "sha=$PRIMARY_SHA"
+            } >> "$GITHUB_OUTPUT"
+          elif test "$RECOVERED_RELEASE_CREATED" = true; then
+            {
+              echo 'release_created=true'
+              echo "tag_name=$RECOVERED_TAG_NAME"
+              echo "version=$RECOVERED_VERSION"
+              echo "sha=$RECOVERED_SHA"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo 'release_created=false' >> "$GITHUB_OUTPUT"
+          fi
 
   publish-darwin:
     name: Publish Darwin asset and Homebrew formula

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix run --quiet .#workflow-lint
+nix develop --quiet -c just ci

--- a/gate.sh
+++ b/gate.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix run --quiet .#workflow-lint
-nix develop --quiet -c just ci

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -307,6 +307,44 @@ let
             "$release_workflow")" \
           true 'release-please action skips labels'
         assert_eq \
+          "$(yq -r '.jobs."release-please".outputs.release_created' "$release_workflow")" \
+          '$'"{{ steps.resolve.outputs.release_created }}" \
+          'release output resolves primary or recovered release'
+        assert_eq \
+          "$(yq -r '.jobs."release-please".outputs.tag_name' "$release_workflow")" \
+          '$'"{{ steps.resolve.outputs.tag_name }}" \
+          'release tag resolves primary or recovered release'
+        assert_eq \
+          "$(yq -r '.jobs."release-please".steps[] | select(.id == "recover") | .if' "$release_workflow")" \
+          '$'"{{ github.event_name == 'push' && steps.release.outputs.release_created != 'true' }}" \
+          'recovery only follows a non-release main push'
+        # shellcheck disable=SC2016
+        grep -Fq 'repos/''${GITHUB_REPOSITORY}/commits/''${GITHUB_SHA}/pulls' "$release_workflow"
+        grep -Fq 'release-please--branches--main' "$release_workflow"
+        grep -Fq '.user.login == "lambdasistemi-ci[bot]"' "$release_workflow"
+        grep -Fq '.base.ref == "main"' "$release_workflow"
+        grep -Fq 'lambdasistemi-ci[bot]' "$release_workflow"
+        # shellcheck disable=SC2016
+        grep -Fq 'git ls-remote --exit-code origin "refs/tags/$tag"' "$release_workflow"
+        # shellcheck disable=SC2016
+        grep -Fq 'repos/''${GITHUB_REPOSITORY}/releases/tags/$tag' "$release_workflow"
+        grep -Fq 'release state conflict for %s' "$release_workflow"
+        grep -Fq 'release metadata mismatch: generated PR title' "$release_workflow"
+        grep -Fq 'release metadata mismatch: Cabal version' "$release_workflow"
+        grep -Fq 'release metadata mismatch: changelog section' "$release_workflow"
+        grep -Fq 'ambiguous generated release PRs for pushed commit' "$release_workflow"
+        grep -Fq 'write_recovery_outputs' "$release_workflow"
+        grep -Fq 'Record release recovery start time' "$release_workflow"
+        grep -Fq 'RECOVERY_STARTED_AT' "$release_workflow"
+        grep -Fq 'gh pr list --state open --head release-please--branches--main' "$release_workflow"
+        # shellcheck disable=SC2016
+        grep -Fq 'gh pr close "$number" --delete-branch --repo "$GITHUB_REPOSITORY"' "$release_workflow"
+        grep -Fq 'warning: could not list false release PRs for cleanup' "$release_workflow"
+        grep -Fq 'warning: could not close false release PR %s' "$release_workflow"
+        # Assert literal workflow source; expansion would make this weaker.
+        # shellcheck disable=SC2016
+        grep -Fq 'gh release create "$tag" --target "$GITHUB_SHA"' "$release_workflow"
+        assert_eq \
           "$(yq -r '.jobs."publish-darwin".uses' "$release_workflow")" \
           './.github/workflows/darwin-release.yml' 'release calls Darwin publisher'
 
@@ -349,6 +387,13 @@ let
           exit 1
         fi
         grep -Fq 'gh release view' "$darwin_workflow"
+        # A copied dylib reports its own @rpath ID in `otool -L`; it is not
+        # an unresolved dependency. The executable and every other @ name
+        # must continue through the fatal branch.
+        # shellcheck disable=SC2016
+        grep -Fq 'test "$target" != "$binary"' "$darwin_workflow"
+        # shellcheck disable=SC2016
+        grep -Fq '@rpath/$(basename "$target")' "$darwin_workflow"
         # Assert literal workflow source; expansion would make this weaker.
         # shellcheck disable=SC2016
         grep -Fq 'gh release upload "$TAG" "$ASSET" --clobber' "$darwin_workflow"

--- a/specs/89-release-recovery/plan.md
+++ b/specs/89-release-recovery/plan.md
@@ -1,0 +1,10 @@
+# Plan: rebase-safe release recovery
+
+1. Extend the workflow contract with failing assertions for safe fallback
+   release resolution and the staged-dylib self-ID exception.
+2. Add a narrowly guarded release recovery step and route job outputs through
+   the resolved result.
+3. Teach the Darwin scanner to distinguish self install IDs from dependency
+   install names.
+4. Run focused RED/GREEN workflow lint, the full gate, final CI, and the live
+   v0.2.0 Darwin publisher boundary.

--- a/specs/89-release-recovery/spec.md
+++ b/specs/89-release-recovery/spec.md
@@ -1,0 +1,24 @@
+# Specification: rebase-safe release recovery
+
+## Outcome
+
+Release publication remains safe and automatic when Release Please cannot
+recognize a rebased generated release PR, and Darwin bundling correctly ignores
+only a copied dylib's own install ID.
+
+## Requirements
+
+- Release Please remains the primary release creator.
+- A fallback may create a release only when the pushed main SHA is associated
+  with a merged generated release PR and PR title, manifest, Cabal version,
+  changelog, and missing tag all agree.
+- Existing tags/releases and ordinary main pushes remain no-ops.
+- The resolved release outputs drive the existing Darwin publisher.
+- Recursive Darwin dependency scanning skips a staged dylib's self install ID
+  but still rejects unresolved dependency install names.
+- The flake-owned workflow contract covers the safety guards and self-ID rule.
+
+## Live evidence
+
+- Release run 29192687901 skipped v0.2.0 and opened false PR #88 after rebase.
+- Darwin run 29192773902 failed on `libz.dylib` self ID `@rpath/libz.dylib`.

--- a/specs/89-release-recovery/tasks.md
+++ b/specs/89-release-recovery/tasks.md
@@ -2,12 +2,12 @@
 
 ## Release resolution
 
-- [ ] T001 Add guarded fallback release creation for rebased generated release PRs.
-- [ ] T002 Route resolved release outputs to the Darwin publisher and cover the no-op boundaries.
+- [X] T001 Add guarded fallback release creation for rebased generated release PRs.
+- [X] T002 Route resolved release outputs to the Darwin publisher and cover the no-op boundaries.
 
 ## Darwin bundling
 
-- [ ] T003 Skip staged dylib self install IDs while rejecting unresolved dependencies.
+- [X] T003 Skip staged dylib self install IDs while rejecting unresolved dependencies.
 
 ## Publication
 

--- a/specs/89-release-recovery/tasks.md
+++ b/specs/89-release-recovery/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: rebase-safe release recovery
+
+## Release resolution
+
+- [ ] T001 Add guarded fallback release creation for rebased generated release PRs.
+- [ ] T002 Route resolved release outputs to the Darwin publisher and cover the no-op boundaries.
+
+## Darwin bundling
+
+- [ ] T003 Skip staged dylib self install IDs while rejecting unresolved dependencies.
+
+## Publication
+
+- [ ] P001 Merge final-head green PR.
+- [ ] P002 Rerun v0.2.0 Darwin publication and verify release asset plus Homebrew smoke.


### PR DESCRIPTION
Refs #89

## Root causes

- with labeling disabled, a rebase merge left Release Please unable to identify the generated release PR, so it skipped v0.2.0 and opened false v0.3.0 PR #88
- the Darwin recursive scanner treated a copied dylib's own `@rpath/<basename>` install ID as an unresolved dependency

## Fix

- keep Release Please as the primary creator
- on a non-release main push, recover only an exact associated merged PR authored by `lambdasistemi-ci[bot]`, based on main, and headed by `release-please--branches--main`
- require PR title, manifest, Cabal version, and changelog to agree; reject ambiguous PRs and partial tag/release state
- preserve retry-safe resolved outputs so the idempotent publisher can resume after a partial failure
- clean up only false bot PRs created during that recovery invocation, warning rather than suppressing publication if cleanup itself fails
- skip only a staged dylib's own install ID; every other unresolved `@...` dependency remains fatal

## Verification

- focused contract RED: release outputs still referenced the primary action directly
- focused contract GREEN with exact recovery and Darwin self-ID guards
- `./gate.sh` passed, including 89 Haskell examples, PureScript/UI, formatting, HLint, Cabal validation, and workflow lint
- live read-only simulation: release head `5cc1e1d` matches exactly PR #86; normal head `07a9221` matches zero generated release PRs; v0.2.0 tag/release/manifest/Cabal all resolve to `5cc1e1d`

## Post-merge boundary

Rerun the v0.2.0 Darwin publisher and require bundle smoke, release asset upload, Homebrew update, trust/install, and formula smoke to pass.
