### PR TITLE
feat: add touch terminal command deck

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,50 @@ For unattended, reboot-persistent access, see the
 [NixOS deployment](https://lambdasistemi.github.io/tmux-ws/docs/deployment/)
 and [Tailscale Serve](https://lambdasistemi.github.io/tmux-ws/docs/tailscale/)
 guides.
+
+## Terminal command deck
+
+When a terminal is attached, a compact **command deck** appears below the
+terminal. It is a touch surface for the keys tmux and interactive TUIs need,
+not a full on-screen alphanumeric keyboard: type text with the tablet's own
+keyboard and reach for the deck for the keys that keyboard lacks. The deck is
+shown only while a session is attached.
+
+The deck has eleven controls: **Esc**, **Tab**, **Ctrl**, **Alt**, **Shift**,
+**Tmux**, **Left**, **Up**, **Down**, **Right**, and **Enter**. `Esc`, `Tab`,
+and `Enter` are sent immediately, the arrows move the cursor, and `Ctrl`,
+`Alt`, `Shift`, and `Tmux` are one-shot latches.
+
+### One-shot latches
+
+**Ctrl**, **Alt**, **Shift**, and **Tmux** arm a single modifier. A latch is
+visibly armed (reported truthfully through `aria-pressed`), applies to the very
+next key, and then disarms itself. Tap an armed latch again to cancel it; a
+cancelled latch sends nothing and leaves the next key unmodified. A latch also
+composes with the **next key you type on the tablet's own keyboard**: arm
+**Ctrl** and press `c` to send Ctrl-C once, and the following plain `c` stays
+plain. Each armed latch is consumed exactly once.
+
+Examples: **Ctrl** then `c` sends Ctrl-C; **Shift** then **Tab** sends a
+back-tab; **Alt** then a letter sends an Alt-prefixed (Meta) key; **Tmux** then
+an arrow sends the tmux prefix followed by the arrow.
+
+**Tmux** is a literal tmux **Ctrl-B** prefix. It composes with whatever comes
+next — an accessory key, an arrow, or a native-keyboard key — so any tmux
+binding is reachable by touch. It is a fixed prefix, not a remappable one. The
+older **Ctrl-b** / **Ctrl-b :** shortcuts in the Terminal menu remain as
+compatibility shortcuts.
+
+### Arrows, cursor mode, and focus
+
+The arrow controls follow xterm's application-cursor-keys mode, so full-screen
+programs such as vim, less, and tmux copy mode receive the arrow encoding they
+expect. Press and hold an arrow to repeat it; the repeat is bounded and stops as
+soon as you lift, cancel, or move off the control, or when the terminal loses
+focus or detaches, so a held arrow never runs away.
+
+Operating the deck preserves terminal focus and does not dismiss the tablet's
+native keyboard, so you can alternate between typing text and tapping deck keys.
+The whole deck is touch-operable with 44×44 CSS-pixel targets and dark/light
+states, which makes tmux and TUIs fully usable on a tablet without a hardware
+keyboard.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,45 @@ The persistent action dock at the bottom contains four touch targets:
 Swiping the terminal scrolls the current pane. The **Terminal** menu's **Live**
 action returns from tmux copy mode to live output.
 
+### Terminal command deck
+
+While a terminal is attached, a compact **command deck** sits below the terminal
+output. It is a touch surface for the control keys that tmux and interactive
+TUIs need — not a replacement alphanumeric keyboard. Type text with the tablet's
+own keyboard; use the deck for the keys that keyboard cannot send. The deck is
+present only while a session is attached.
+
+It has eleven controls: **Esc**, **Tab**, **Ctrl**, **Alt**, **Shift**,
+**Tmux**, **Left**, **Up**, **Down**, **Right**, and **Enter**. `Esc`, `Tab`,
+and `Enter` are sent immediately; the arrows move the cursor; `Ctrl`, `Alt`,
+`Shift`, and `Tmux` are one-shot latches.
+
+**One-shot latches.** Tapping `Ctrl`, `Alt`, `Shift`, or `Tmux` arms a single
+modifier. The armed state is visible and reported truthfully through
+`aria-pressed`. The latch applies to the very next key and then disarms itself;
+tapping an armed latch again cancels it, sending nothing and leaving the next
+key unmodified. A latch also composes with the **next key typed on the tablet's
+native keyboard** — arm `Ctrl` and press `c` to send Ctrl-C once, after which a
+plain `c` remains plain. Each armed latch is consumed exactly once. Typical
+combinations: `Ctrl`+`c` (Ctrl-C), `Shift`+`Tab` (back-tab), `Alt`+letter
+(Alt/Meta-prefixed input), and `Tmux`+arrow.
+
+**Tmux prefix.** `Tmux` is a literal tmux **Ctrl-B** prefix. It is one-shot and
+composes with the next accessory, arrow, or native key, so any tmux binding is
+reachable by touch. It is a fixed prefix, not a remappable one; the Terminal
+menu's `Ctrl-b` and `Ctrl-b :` shortcuts remain for compatibility.
+
+**Arrows and cursor mode.** The arrow controls honor xterm's
+application-cursor-keys mode, so full-screen programs receive the arrow encoding
+they expect. Press and hold an arrow to repeat it: the repeat is bounded and
+stops on release, on pointer cancel or leave, and when the terminal loses focus
+or detaches, so a held arrow never runs away.
+
+**Focus.** Operating the deck preserves terminal focus and does not dismiss the
+tablet keyboard, so you can move freely between typing text and tapping deck
+keys. With 44×44 CSS-pixel targets and dark/light states, the deck makes tmux
+and TUIs fully operable on a tablet with no hardware keyboard.
+
 ### Close the current pane or window
 
 Open **Settings** and tap **Close this pane** or **Close this window**. This is

--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix develop --quiet -c just ci

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix develop --quiet -c just ci

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -61,13 +61,14 @@ let
     };
 
     ui = {
-      runtimeInputs = [ pkgs.purs-tidy-bin.purs-tidy-0_10_0 ];
+      runtimeInputs = [ pkgs.nodejs_22 pkgs.purs-tidy-bin.purs-tidy-0_10_0 ];
       text = ''
         test -d ${uiNodeModules}/node_modules
         test -e ${uiBuild}
         test -s ${uiBundle}/index.html
         test -s ${uiBundle}/index.js
         purs-tidy check 'ui/src/**/*.purs'
+        node --test ui/test/TerminalInput.test.mjs
       '';
     };
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -61,7 +61,9 @@ let
     };
 
     ui = {
-      runtimeInputs = [ pkgs.nodejs_22 pkgs.purs-tidy-bin.purs-tidy-0_10_0 ];
+      runtimeInputs = [ pkgs.nodejs_22 pkgs.purs-tidy-bin.purs-tidy-0_10_0 ]
+        ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux
+        [ pkgs.playwright-test ];
       text = ''
         test -d ${uiNodeModules}/node_modules
         test -e ${uiBuild}
@@ -69,6 +71,13 @@ let
         test -s ${uiBundle}/index.js
         purs-tidy check 'ui/src/**/*.purs'
         node --test ui/test/TerminalInput.test.mjs
+        if [[ "$(uname)" == Linux ]]; then
+          export UI_BUNDLE=${uiBundle}
+          export NODE_PATH=${pkgs.playwright-test}/lib/node_modules
+          export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+          export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+          node --test ui/test/CommandDeckLayout.test.mjs
+        fi
       '';
     };
 

--- a/specs/092-touch-command-deck/plan.md
+++ b/specs/092-touch-command-deck/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Touch terminal command deck
 
-**Branch:** `feat/92-touch-command-deck`  
+**Branch:** `feat/92-touch-command-deck`
 **Draft PR:** [#93](https://github.com/lambdasistemi/tmux-ws/pull/93)
 
 ## Technical context

--- a/specs/092-touch-command-deck/plan.md
+++ b/specs/092-touch-command-deck/plan.md
@@ -105,4 +105,8 @@ the canonical main checkout.
 - Correction slice: first observe the Playwright layout regression fail on the
   clipped hierarchy; after the minimal repair, run it at all three viewports,
   the focused UI checks, and `./gate.sh`. Refresh the real tailnet preview and
-  its screenshots at the corrected exact head before final hosted CI.
+  its screenshots at the corrected exact head before final hosted CI. For the
+  hardened self-hosted runner only, reproduce the Chromium zygote SIGTRAP
+  under its exact system-call filter, then add only `--no-zygote` to the
+  Playwright launch with a concise rationale. Do not weaken runner hardening
+  or alter application behavior.

--- a/specs/092-touch-command-deck/plan.md
+++ b/specs/092-touch-command-deck/plan.md
@@ -55,6 +55,26 @@ sizes, overflow, latch semantics, cursor modes, repeat cleanup, and no
 console/runtime errors. Publish the hosted preview URL and link all evidence
 from the PR.
 
+### Correction slice — visible deck layout regression
+
+The accepted screenshot evidence found a hierarchy bug: the deck is nested in
+`.terminal-wrap`, whose `overflow: hidden` clips the controls while the
+workspace grid can allocate rows only to direct children. First add a failing
+browser-layout regression. It must serve the built UI with an attached-session
+fixture, then at 390×844, 768×1024, and 1024×768 assert all eleven
+`[data-command-deck-control]` elements have 44×44-or-larger boxes that
+intersect the viewport and win a centre-point `elementFromPoint` hit test.
+That proves neither terminal clipping nor a fixed workspace dock covers them.
+
+Run the regression in the authoritative Linux UI check with Nix-provided
+Playwright and its browsers—no npm dependency, package-lock, or pin change.
+Then make the smallest render hierarchy/CSS correction: the terminal remains
+in the flexible workspace row and the deck becomes a direct workspace child in
+the allocated auto row. Preserve safe-area padding, target sizes, source
+order, xterm sizing, and all input semantics. The navigator must independently
+reproduce the test, inspect hit targets, and capture fresh screenshots at all
+three viewports before acceptance.
+
 ## Owned files
 
 - Slice 1: `ui/src/AgentDaemon/TerminalInput.mjs`,
@@ -65,6 +85,8 @@ from the PR.
   `ui/test/TerminalInput.test.mjs`, `ui/dist/index.css`, and
   `ui/dist/index.html` only for an asset cache token.
 - Slice 3: `README.md`, `docs/index.md`, and external evidence files only.
+- Correction slice: `ui/src/Main.purs`, `ui/dist/index.css`,
+  `ui/test/CommandDeckLayout.test.mjs`, and `nix/checks.nix` only.
 - Orchestrator: `specs/092-touch-command-deck/*`, `gate.sh`, PR metadata, and
   runtime protocol files.
 
@@ -80,3 +102,7 @@ the canonical main checkout.
 - Slice 3: fresh full gate, three browser viewports, hosted preview, PR-body
   evidence, task/commit audit, and exact hosted checks. The PR stays draft;
   finalization does not merge it.
+- Correction slice: first observe the Playwright layout regression fail on the
+  clipped hierarchy; after the minimal repair, run it at all three viewports,
+  the focused UI checks, and `./gate.sh`. Refresh the real tailnet preview and
+  its screenshots at the corrected exact head before final hosted CI.

--- a/specs/092-touch-command-deck/plan.md
+++ b/specs/092-touch-command-deck/plan.md
@@ -28,6 +28,8 @@ writing model output to the existing socket, intercepting native keys only
 while latches are armed, focus-preserving pointer handling, and bounded arrow
 repeat cleanup. PureScript owns rendered latch state and accessible controls;
 the FFI callback clears visual state when a native key consumes latches.
+The existing Node model test also owns a pure native-key adapter proof: an
+armed native key is consumed once, and the next unarmed key remains plain.
 
 ## Slices
 
@@ -57,9 +59,11 @@ from the PR.
 
 - Slice 1: `ui/src/AgentDaemon/TerminalInput.mjs`,
   `ui/test/TerminalInput.test.mjs`, `ui/src/bootstrap.js`, `nix/checks.nix`.
-- Slice 2: `ui/src/AgentDaemon/FFI/Terminal.purs`,
+- Slice 2: `ui/src/AgentDaemon/TerminalInput.mjs`,
+  `ui/src/AgentDaemon/FFI/Terminal.purs`,
   `ui/src/AgentDaemon/FFI/Terminal.js`, `ui/src/Main.purs`,
-  `ui/dist/index.css`, and `ui/dist/index.html` only for an asset cache token.
+  `ui/test/TerminalInput.test.mjs`, `ui/dist/index.css`, and
+  `ui/dist/index.html` only for an asset cache token.
 - Slice 3: `README.md`, `docs/index.md`, and external evidence files only.
 - Orchestrator: `specs/092-touch-command-deck/*`, `gate.sh`, PR metadata, and
   runtime protocol files.

--- a/specs/092-touch-command-deck/plan.md
+++ b/specs/092-touch-command-deck/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Touch terminal command deck
+
+**Branch:** `feat/92-touch-command-deck`  
+**Draft PR:** [#93](https://github.com/lambdasistemi/tmux-ws/pull/93)
+
+## Technical context
+
+- The frontend is PureScript/Halogen with xterm.js wired through
+  `ui/src/AgentDaemon/FFI/Terminal.{purs,js}` and rendered by `Main.purs`.
+- `ui/dist/index.css` already owns responsive, safe-area, touch-target, and
+  dark/light state rules. No new runtime package is needed.
+- The xterm controller already sends terminal bytes over its existing socket.
+  The new encoder uses only terminal data and xterm's public modes API; it does
+  not create browser keyboard events.
+- `nix/checks.nix` owns the authoritative UI check. The new dependency-free
+  Node test runs there with the pinned Nix Node runtime.
+
+## Design
+
+`TerminalInput.mjs` is a browser-independent model with a small state value
+(`ctrl`, `alt`, `shift`, `tmux`) and logical keys. It returns terminal data,
+the next latch state, and repeat lifecycle decisions. `bootstrap.js` exposes
+that module to the existing FFI global boundary, keeping FFI files free of
+module imports. Node tests import the same module directly.
+
+`Terminal.js` owns xterm-bound concerns: reading application-cursor mode,
+writing model output to the existing socket, intercepting native keys only
+while latches are armed, focus-preserving pointer handling, and bounded arrow
+repeat cleanup. PureScript owns rendered latch state and accessible controls;
+the FFI callback clears visual state when a native key consumes latches.
+
+## Slices
+
+### Slice 1 — Pure input model and authoritative tests
+
+Create the dependency-free logical-key/latch/encoding model and Node tests.
+Register the module in the bootstrap global boundary and run its test file from
+the existing Nix UI check. This foundation is independently testable and adds
+no user-visible behavior yet.
+
+### Slice 2 — xterm integration and responsive command deck
+
+Extend the typed FFI, controller, Halogen state/actions/rendering, and CSS to
+  expose the eleven controls. Integrate the model for accessory and armed-native
+input, public xterm cursor modes, focus preservation, and bounded arrow
+repetition. The completed slice is usable end-to-end without a hardware key.
+
+### Slice 3 — Operator documentation and live evidence
+
+Document the deck in the supported operator guides. Run a live daemon/session
+browser smoke at 390×844, 768×1024, and 1024×768, asserting controls, target
+sizes, overflow, latch semantics, cursor modes, repeat cleanup, and no
+console/runtime errors. Publish the hosted preview URL and link all evidence
+from the PR.
+
+## Owned files
+
+- Slice 1: `ui/src/AgentDaemon/TerminalInput.mjs`,
+  `ui/test/TerminalInput.test.mjs`, `ui/src/bootstrap.js`, `nix/checks.nix`.
+- Slice 2: `ui/src/AgentDaemon/FFI/Terminal.purs`,
+  `ui/src/AgentDaemon/FFI/Terminal.js`, `ui/src/Main.purs`,
+  `ui/dist/index.css`, and `ui/dist/index.html` only for an asset cache token.
+- Slice 3: `README.md`, `docs/index.md`, and external evidence files only.
+- Orchestrator: `specs/092-touch-command-deck/*`, `gate.sh`, PR metadata, and
+  runtime protocol files.
+
+No slice may modify API/WebSocket/backend behavior, dependency pins, release
+or packaging work, broad #79 documentation/governance, the GHC version, or
+the canonical main checkout.
+
+## Verification
+
+- Slice 1: `nix run --quiet .#ui`, the focused Node test, then `./gate.sh`.
+- Slice 2: focused model tests, UI build/lint/bundle, `./gate.sh`, and a live
+  xterm smoke proving required byte sequences without synthetic key events.
+- Slice 3: fresh full gate, three browser viewports, hosted preview, PR-body
+  evidence, task/commit audit, and exact hosted checks. The PR stays draft;
+  finalization does not merge it.

--- a/specs/092-touch-command-deck/spec.md
+++ b/specs/092-touch-command-deck/spec.md
@@ -54,7 +54,8 @@ never schedule a repeat.
   or dismiss the tablet keyboard merely by operating a control.
 - **FR-006:** Every deck target is at least 44 by 44 CSS pixels on touch
   layouts, has dark/light active and focus states, honours safe areas, and is
-  never horizontally clipped at 390×844, 768×1024, or 1024×768.
+  wholly visible in the viewport—never clipped by an ancestor or covered by
+  the terminal or workspace dock—at 390×844, 768×1024, or 1024×768.
 - **FR-007:** A pure input model has automated tests for encoding, latch
   consumption/cancellation, cursor modes, and repeat lifecycle. The
   authoritative Nix UI check executes those tests.
@@ -68,7 +69,8 @@ never schedule a repeat.
 - Touching each control sends the documented bytes once; untouched native text
   entry remains plain xterm input.
 - Browser assertions report no horizontal overflow, every deck target is at
-  least 44×44 CSS pixels, and the deck remains reachable at every viewport.
+  least 44×44 CSS pixels, intersects the visible viewport, and wins a
+  center-point hit test rather than being clipped or covered at every viewport.
 - The focused model tests, `nix flake check --no-eval-cache`,
   `nix develop --quiet -c just ci`, and `./gate.sh` pass.
 

--- a/specs/092-touch-command-deck/spec.md
+++ b/specs/092-touch-command-deck/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Touch terminal command deck
 
-**Issue:** [#92](https://github.com/lambdasistemi/tmux-ws/issues/92)  
-**Parent:** [#80](https://github.com/lambdasistemi/tmux-ws/issues/80)  
+**Issue:** [#92](https://github.com/lambdasistemi/tmux-ws/issues/92)
+**Parent:** [#80](https://github.com/lambdasistemi/tmux-ws/issues/80)
 **Priority:** P1
 
 ## P1 user story

--- a/specs/092-touch-command-deck/spec.md
+++ b/specs/092-touch-command-deck/spec.md
@@ -1,0 +1,81 @@
+# Feature Specification: Touch terminal command deck
+
+**Issue:** [#92](https://github.com/lambdasistemi/tmux-ws/issues/92)  
+**Parent:** [#80](https://github.com/lambdasistemi/tmux-ws/issues/80)  
+**Priority:** P1
+
+## P1 user story
+
+As a touch-only tablet operator, I can send the tmux prefixes, modifiers, and
+terminal navigation keys that an interactive terminal application expects,
+without replacing the native alphanumeric keyboard.
+
+## Input contract
+
+The command deck presents **Esc**, **Tab**, **Ctrl**, **Alt**, **Shift**,
+**Tmux**, **Left**, **Up**, **Down**, **Right**, and **Enter** whenever a
+terminal is attached. Ctrl, Alt, Shift, and Tmux are visible one-shot latches:
+
+- Tapping an inactive latch arms it; tapping that same latch cancels it.
+- A key dispatch consumes every armed latch exactly once and clears its
+  `aria-pressed` state. Cancelling a latch sends no terminal data.
+- **Tmux** contributes the literal Ctrl-B prefix (`\x02`) before the next
+  accessory or native-keyboard key; it is not a configurable shortcut.
+- Native keyboard input is left to xterm unchanged when no latch is armed. If
+  one or more latches are armed, the next native key is encoded once by the
+  command-deck model and xterm's default handling for that key is suppressed.
+
+The encoder emits Esc, Tab, Enter, C0 control combinations, Alt-prefixed
+input, and normal or modified cursor sequences. A plain arrow is `CSI A/B/C/D`
+in normal cursor mode and `SS3 A/B/C/D` while xterm's public
+`terminal.modes.applicationCursorKeysMode` is true. Modified cursor keys use
+the standard CSI modifier form. A Tmux-plus-arrow dispatch therefore begins
+with Ctrl-B and then uses the current cursor mode's arrow sequence.
+
+Only arrow buttons support press-and-hold. A primary pointer-down sends one
+arrow immediately, then begins deliberate bounded repetition after a short
+delay. Pointer-up, pointer-cancel, pointer-leave, window blur, terminal
+detach, and the configured repeat bound all stop the lifecycle; ordinary taps
+never schedule a repeat.
+
+## Functional requirements
+
+- **FR-001:** An attached terminal exposes every required control in a compact,
+  always-reachable deck; detached terminals expose no actionable deck.
+- **FR-002:** Ctrl, Alt, Shift, and Tmux are individually cancellable, have
+  truthful `aria-pressed` values, and are consumed once by accessory and native
+  input alike.
+- **FR-003:** The deck proves Ctrl-C, Shift-Tab, Alt-prefixed text, and
+  Tmux-plus-arrow encodings.
+- **FR-004:** Arrow encoding reads xterm's public cursor-mode state at dispatch
+  time and its repeat lifecycle cannot leak a timer after release or cancel.
+- **FR-005:** Deck pointer/touch handling preserves an existing terminal/native
+  keyboard focus relationship; it does not synthesize browser `KeyboardEvent`s
+  or dismiss the tablet keyboard merely by operating a control.
+- **FR-006:** Every deck target is at least 44 by 44 CSS pixels on touch
+  layouts, has dark/light active and focus states, honours safe areas, and is
+  never horizontally clipped at 390×844, 768×1024, or 1024×768.
+- **FR-007:** A pure input model has automated tests for encoding, latch
+  consumption/cancellation, cursor modes, and repeat lifecycle. The
+  authoritative Nix UI check executes those tests.
+- **FR-008:** Operator documentation explains the deck, one-shot modifiers,
+  Tmux prefix, native-keyboard composition, and touch-only TUI workflow.
+- **FR-009:** The draft PR supplies a live preview URL and browser evidence at
+  all three accepted viewports.
+
+## Success criteria
+
+- Touching each control sends the documented bytes once; untouched native text
+  entry remains plain xterm input.
+- Browser assertions report no horizontal overflow, every deck target is at
+  least 44×44 CSS pixels, and the deck remains reachable at every viewport.
+- The focused model tests, `nix flake check --no-eval-cache`,
+  `nix develop --quiet -c just ci`, and `./gate.sh` pass.
+
+## Non-goals
+
+- A full virtual alphanumeric/function/symbol keyboard or third-party keyboard
+  dependency.
+- Configurable layouts or a remappable tmux prefix.
+- Browser `KeyboardEvent` synthesis, backend/API/WebSocket changes, packaging,
+  release automation, or a GHC upgrade.

--- a/specs/092-touch-command-deck/tasks.md
+++ b/specs/092-touch-command-deck/tasks.md
@@ -24,8 +24,10 @@ Trailer: `Tasks: T9201, T9202, T9203, T9204`
 
 ## Slice 2 — xterm integration and responsive command deck
 
-- [ ] T9205 Extend the typed xterm FFI for logical command-deck input, armed
-  native-key handling, public cursor-mode selection, and repeat cleanup.
+- [ ] T9205 Extend the pure model and typed xterm FFI for logical command-deck
+  input, armed native-key handling, public cursor-mode selection, and repeat
+  cleanup; add a RED/GREEN Node proof that native input consumes an armed latch
+  once and leaves the following unarmed key plain.
 - [ ] T9206 Render accessible, cancellable Ctrl/Alt/Shift/Tmux latches and
   Esc/Tab/arrows/Enter controls that consume latches exactly once.
 - [ ] T9207 Preserve terminal/native-keyboard focus while operating controls;

--- a/specs/092-touch-command-deck/tasks.md
+++ b/specs/092-touch-command-deck/tasks.md
@@ -19,7 +19,7 @@ RED → navigator review → GREEN; each accepted commit retains its exact
   the authoritative Nix UI check without adding a dependency or pin.
 - [X] T9204 Run focused tests, `nix run --quiet .#ui`, and `./gate.sh`.
 
-Commit: `feat: model terminal command deck input`  
+Commit: `feat: model terminal command deck input`
 Trailer: `Tasks: T9201, T9202, T9203, T9204`
 
 ## Slice 2 — xterm integration and responsive command deck
@@ -37,24 +37,24 @@ Trailer: `Tasks: T9201, T9202, T9203, T9204`
 - [X] T9209 Run focused model/UI checks and `./gate.sh`; record live sequence
   smoke evidence in WIP.
 
-Commit: `feat: add touch terminal command deck`  
+Commit: `feat: add touch terminal command deck`
 Trailer: `Tasks: T9205, T9206, T9207, T9208, T9209`
 
 ## Slice 3 — Operator documentation and evidence
 
-- [ ] T9210 Document command-deck controls, modifier cancellation/consumption,
+- [X] T9210 Document command-deck controls, modifier cancellation/consumption,
   Tmux prefix, native-keyboard composition, cursor mode, and touch-only TUI use.
-- [ ] T9211 Capture browser evidence at 390×844, 768×1024, and 1024×768 for
+- [X] T9211 Capture browser evidence at 390×844, 768×1024, and 1024×768 for
   reachability, overflow, target size, latch semantics, repeat cleanup, and
   console/runtime-error absence.
-- [ ] T9212 Link the live PR preview and durable evidence from the draft PR,
+- [X] T9212 Link the live PR preview and durable evidence from the draft PR,
   then re-run the full local gate.
 
-Commit: `docs: document touch terminal command deck`  
+Commit: `docs: document touch terminal command deck`
 Trailer: `Tasks: T9210, T9211, T9212`
 
 ## Final verification and handoff — orchestrator owned
 
-- [ ] T9213 Independently review every accepted diff and commit/task linkage,
+- [X] T9213 Independently review every accepted diff and commit/task linkage,
   run the fresh full gate, audit PR labels/assignee/links/body, and collect
   exact hosted check results without merging.

--- a/specs/092-touch-command-deck/tasks.md
+++ b/specs/092-touch-command-deck/tasks.md
@@ -55,23 +55,28 @@ Trailer: `Tasks: T9210, T9211, T9212`
 
 ## Correction slice — visible command-deck layout
 
-- [ ] T9214 Add a failing browser-layout regression that serves the built UI
+- [X] T9214 Add a failing browser-layout regression that serves the built UI
   with an attached session and proves all eleven deck controls intersect the
   visible viewport and win centre-point hit testing at 390×844, 768×1024, and
   1024×768.
-- [ ] T9215 Make the minimal render hierarchy/CSS repair that allocates the
+- [X] T9215 Make the minimal render hierarchy/CSS repair that allocates the
   deck its visible workspace row while preserving terminal sizing, safe areas,
   44×44 targets, control order, and every existing input semantic.
-- [ ] T9216 Re-run the focused browser/UI proof and the full gate; navigator
+- [X] T9216 Re-run the focused browser/UI proof and the full gate; navigator
   independently reproduces visibility/hit testing and records fresh three-
   viewport screenshots for the corrected exact branch head.
+- [X] T9217 Reproduce the Chromium zygote SIGTRAP under the runner's exact
+  system-call filter, then add only `--no-zygote` to the Playwright harness
+  with a concise runner-hardening rationale; prove hardened-unit GREEN,
+  focused UI checks, and `./gate.sh` without changing application behavior or
+  runner hardening.
 
 Commit: `fix: keep touch command deck visible`
-Trailer: `Tasks: T9214, T9215, T9216`
+Trailer: `Tasks: T9214, T9215, T9216, T9217`
 
 ## Final verification and handoff — orchestrator owned
 
-- [ ] T9213 Independently review every accepted diff and commit/task linkage,
+- [X] T9213 Independently review every accepted diff and commit/task linkage,
   run the fresh full gate, audit PR labels/assignee/links/body, refresh the
   corrected preview/evidence, and collect exact hosted check results without
   merging.

--- a/specs/092-touch-command-deck/tasks.md
+++ b/specs/092-touch-command-deck/tasks.md
@@ -11,13 +11,13 @@ RED → navigator review → GREEN; each accepted commit retains its exact
 
 ## Slice 1 — Pure input model and authoritative tests
 
-- [ ] T9201 Define the dependency-free logical key, latch, sequence, cursor
+- [X] T9201 Define the dependency-free logical key, latch, sequence, cursor
   mode, and bounded-repeat model.
-- [ ] T9202 Add Node tests for Ctrl-C, Shift-Tab, Alt text, Tmux-plus-arrow,
+- [X] T9202 Add Node tests for Ctrl-C, Shift-Tab, Alt text, Tmux-plus-arrow,
   cancellation/one-shot consumption, both cursor modes, and repeat stop paths.
-- [ ] T9203 Expose the model through `bootstrap.js` and run the focused test in
+- [X] T9203 Expose the model through `bootstrap.js` and run the focused test in
   the authoritative Nix UI check without adding a dependency or pin.
-- [ ] T9204 Run focused tests, `nix run --quiet .#ui`, and `./gate.sh`.
+- [X] T9204 Run focused tests, `nix run --quiet .#ui`, and `./gate.sh`.
 
 Commit: `feat: model terminal command deck input`  
 Trailer: `Tasks: T9201, T9202, T9203, T9204`

--- a/specs/092-touch-command-deck/tasks.md
+++ b/specs/092-touch-command-deck/tasks.md
@@ -24,17 +24,17 @@ Trailer: `Tasks: T9201, T9202, T9203, T9204`
 
 ## Slice 2 — xterm integration and responsive command deck
 
-- [ ] T9205 Extend the pure model and typed xterm FFI for logical command-deck
+- [X] T9205 Extend the pure model and typed xterm FFI for logical command-deck
   input, armed native-key handling, public cursor-mode selection, and repeat
   cleanup; add a RED/GREEN Node proof that native input consumes an armed latch
   once and leaves the following unarmed key plain.
-- [ ] T9206 Render accessible, cancellable Ctrl/Alt/Shift/Tmux latches and
+- [X] T9206 Render accessible, cancellable Ctrl/Alt/Shift/Tmux latches and
   Esc/Tab/arrows/Enter controls that consume latches exactly once.
-- [ ] T9207 Preserve terminal/native-keyboard focus while operating controls;
+- [X] T9207 Preserve terminal/native-keyboard focus while operating controls;
   implement bounded pointer-hold arrow repetition without synthetic events.
-- [ ] T9208 Add safe-area-aware responsive CSS with 44×44 targets and visible
+- [X] T9208 Add safe-area-aware responsive CSS with 44×44 targets and visible
   dark/light, pressed, and focus states at every accepted viewport.
-- [ ] T9209 Run focused model/UI checks and `./gate.sh`; record live sequence
+- [X] T9209 Run focused model/UI checks and `./gate.sh`; record live sequence
   smoke evidence in WIP.
 
 Commit: `feat: add touch terminal command deck`  

--- a/specs/092-touch-command-deck/tasks.md
+++ b/specs/092-touch-command-deck/tasks.md
@@ -53,8 +53,25 @@ Trailer: `Tasks: T9205, T9206, T9207, T9208, T9209`
 Commit: `docs: document touch terminal command deck`
 Trailer: `Tasks: T9210, T9211, T9212`
 
+## Correction slice — visible command-deck layout
+
+- [ ] T9214 Add a failing browser-layout regression that serves the built UI
+  with an attached session and proves all eleven deck controls intersect the
+  visible viewport and win centre-point hit testing at 390×844, 768×1024, and
+  1024×768.
+- [ ] T9215 Make the minimal render hierarchy/CSS repair that allocates the
+  deck its visible workspace row while preserving terminal sizing, safe areas,
+  44×44 targets, control order, and every existing input semantic.
+- [ ] T9216 Re-run the focused browser/UI proof and the full gate; navigator
+  independently reproduces visibility/hit testing and records fresh three-
+  viewport screenshots for the corrected exact branch head.
+
+Commit: `fix: keep touch command deck visible`
+Trailer: `Tasks: T9214, T9215, T9216`
+
 ## Final verification and handoff — orchestrator owned
 
-- [X] T9213 Independently review every accepted diff and commit/task linkage,
-  run the fresh full gate, audit PR labels/assignee/links/body, and collect
-  exact hosted check results without merging.
+- [ ] T9213 Independently review every accepted diff and commit/task linkage,
+  run the fresh full gate, audit PR labels/assignee/links/body, refresh the
+  corrected preview/evidence, and collect exact hosted check results without
+  merging.

--- a/specs/092-touch-command-deck/tasks.md
+++ b/specs/092-touch-command-deck/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: Touch terminal command deck
+
+Every behavior-changing slice is a single bisect-safe commit. Drivers perform
+RED → navigator review → GREEN; each accepted commit retains its exact
+`Tasks:` trailer and receives these checked boxes by amend before push.
+
+## Bootstrap — already complete
+
+- [X] T000 Create the isolated worktree, validate the baseline, add `gate.sh`,
+  and open draft PR #93.
+
+## Slice 1 — Pure input model and authoritative tests
+
+- [ ] T9201 Define the dependency-free logical key, latch, sequence, cursor
+  mode, and bounded-repeat model.
+- [ ] T9202 Add Node tests for Ctrl-C, Shift-Tab, Alt text, Tmux-plus-arrow,
+  cancellation/one-shot consumption, both cursor modes, and repeat stop paths.
+- [ ] T9203 Expose the model through `bootstrap.js` and run the focused test in
+  the authoritative Nix UI check without adding a dependency or pin.
+- [ ] T9204 Run focused tests, `nix run --quiet .#ui`, and `./gate.sh`.
+
+Commit: `feat: model terminal command deck input`  
+Trailer: `Tasks: T9201, T9202, T9203, T9204`
+
+## Slice 2 — xterm integration and responsive command deck
+
+- [ ] T9205 Extend the typed xterm FFI for logical command-deck input, armed
+  native-key handling, public cursor-mode selection, and repeat cleanup.
+- [ ] T9206 Render accessible, cancellable Ctrl/Alt/Shift/Tmux latches and
+  Esc/Tab/arrows/Enter controls that consume latches exactly once.
+- [ ] T9207 Preserve terminal/native-keyboard focus while operating controls;
+  implement bounded pointer-hold arrow repetition without synthetic events.
+- [ ] T9208 Add safe-area-aware responsive CSS with 44×44 targets and visible
+  dark/light, pressed, and focus states at every accepted viewport.
+- [ ] T9209 Run focused model/UI checks and `./gate.sh`; record live sequence
+  smoke evidence in WIP.
+
+Commit: `feat: add touch terminal command deck`  
+Trailer: `Tasks: T9205, T9206, T9207, T9208, T9209`
+
+## Slice 3 — Operator documentation and evidence
+
+- [ ] T9210 Document command-deck controls, modifier cancellation/consumption,
+  Tmux prefix, native-keyboard composition, cursor mode, and touch-only TUI use.
+- [ ] T9211 Capture browser evidence at 390×844, 768×1024, and 1024×768 for
+  reachability, overflow, target size, latch semantics, repeat cleanup, and
+  console/runtime-error absence.
+- [ ] T9212 Link the live PR preview and durable evidence from the draft PR,
+  then re-run the full local gate.
+
+Commit: `docs: document touch terminal command deck`  
+Trailer: `Tasks: T9210, T9211, T9212`
+
+## Final verification and handoff — orchestrator owned
+
+- [ ] T9213 Independently review every accepted diff and commit/task linkage,
+  run the fresh full gate, audit PR labels/assignee/links/body, and collect
+  exact hosted check results without merging.

--- a/ui/dist/index.css
+++ b/ui/dist/index.css
@@ -250,6 +250,46 @@ main {
   padding: 4px;
 }
 
+.workspace {
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.command-deck {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(44px, 1fr));
+  gap: 6px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  padding: 8px calc(8px + var(--safe-right)) calc(8px + var(--safe-bottom)) calc(8px + var(--safe-left));
+}
+
+.command-deck-control {
+  min-width: 44px;
+  min-height: 44px;
+  justify-content: center;
+  padding: 6px 8px;
+  touch-action: manipulation;
+}
+
+.command-deck-latch.armed,
+.command-deck-latch[aria-pressed="true"] {
+  border-color: var(--active-border);
+  background: var(--surface-active);
+  color: var(--text-strong);
+}
+
+.command-deck-control:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: -3px;
+}
+
+.command-deck-control:active:not(:disabled) {
+  border-color: var(--active-border);
+  background: var(--button-hover);
+  transform: translateY(1px);
+}
+
 #terminal {
   width: 100%;
   height: 100%;
@@ -1139,6 +1179,11 @@ button:active:not(:disabled),
 
   .terminal-wrap {
     padding: 2px;
+  }
+
+  .command-deck {
+    gap: 5px;
+    padding: 6px calc(6px + var(--safe-right)) calc(6px + var(--safe-bottom)) calc(6px + var(--safe-left));
   }
 
   .session-menu-item {

--- a/ui/src/AgentDaemon/FFI/Terminal.js
+++ b/ui/src/AgentDaemon/FFI/Terminal.js
@@ -76,6 +76,104 @@ const sendTerminalData = (controller, data) => {
   }
 };
 
+const commandDeckKey = (key) => (key === "Escape" ? "Esc" : key);
+
+const hasCommandDeckLatch = (latches) => Object.values(latches).some(Boolean);
+
+const applicationCursorKeysMode = (controller) =>
+  Boolean(controller.term.modes && controller.term.modes.applicationCursorKeysMode);
+
+const clearCommandDeckRepeat = (controller) => {
+  if (controller.commandDeckRepeatTimer != null) {
+    window.clearTimeout(controller.commandDeckRepeatTimer);
+  }
+  controller.commandDeckRepeatTimer = null;
+  controller.commandDeckRepeat = null;
+  controller.commandDeckPointerId = null;
+};
+
+const notifyCommandDeckConsumption = (controller, consumed) => {
+  if (consumed) controller.callbacks.onCommandDeckConsumed();
+};
+
+const dispatchCommandDeckKey = (controller, key) => {
+  const input = globalThis.AgentTerminal.TerminalInput;
+  const consumed = hasCommandDeckLatch(controller.commandDeckLatches);
+  const result = input.dispatchKey(controller.commandDeckLatches, key, {
+    applicationCursorKeysMode: applicationCursorKeysMode(controller)
+  });
+  controller.commandDeckLatches = result.latches;
+  sendTerminalData(controller, result.data);
+  notifyCommandDeckConsumption(controller, consumed);
+};
+
+const scheduleCommandDeckRepeat = (controller, delayMs) => {
+  controller.commandDeckRepeatTimer = window.setTimeout(() => {
+    controller.commandDeckRepeatTimer = null;
+    const input = globalThis.AgentTerminal.TerminalInput;
+    const next = input.advanceArrowRepeat(controller.commandDeckRepeat);
+    controller.commandDeckRepeat = next.repeat;
+    if (next.decision.type === "none") return;
+    dispatchCommandDeckKey(controller, controller.commandDeckRepeatKey);
+    if (next.decision.type === "emit-and-schedule") {
+      scheduleCommandDeckRepeat(controller, next.decision.delayMs);
+    } else {
+      clearCommandDeckRepeat(controller);
+    }
+  }, delayMs);
+};
+
+const beginCommandDeckArrowRepeat = (controller, key, pointerId) => {
+  const input = globalThis.AgentTerminal.TerminalInput;
+  clearCommandDeckRepeat(controller);
+  dispatchCommandDeckKey(controller, key);
+  const next = input.beginArrowRepeat(key);
+  if (next.decision.type !== "schedule") return;
+  controller.commandDeckRepeat = next.repeat;
+  controller.commandDeckRepeatKey = key;
+  controller.commandDeckPointerId = pointerId;
+  scheduleCommandDeckRepeat(controller, next.decision.delayMs);
+};
+
+const commandDeckControl = (event) =>
+  event.target instanceof Element
+    ? event.target.closest("[data-command-deck-control]")
+    : null;
+
+const installCommandDeckHandling = (controller) => {
+  const stopRepeat = (event) => {
+    if (
+      controller.commandDeckPointerId != null &&
+      (!event || event.pointerId === controller.commandDeckPointerId)
+    ) {
+      clearCommandDeckRepeat(controller);
+    }
+  };
+
+  const onPointerDown = (event) => {
+    const control = commandDeckControl(event);
+    if (!control || !event.isPrimary) return;
+    event.preventDefault();
+    const key = control.dataset.commandDeckKey;
+    if (key) beginCommandDeckArrowRepeat(controller, key, event.pointerId);
+  };
+
+  const onClick = (event) => {
+    const control = commandDeckControl(event);
+    if (!control || event.detail !== 0) return;
+    const key = control.dataset.commandDeckKey;
+    if (key) dispatchCommandDeckKey(controller, key);
+  };
+
+  document.addEventListener("pointerdown", onPointerDown, true);
+  document.addEventListener("pointerup", stopRepeat, true);
+  document.addEventListener("pointercancel", stopRepeat, true);
+  document.addEventListener("pointerleave", stopRepeat, true);
+  document.addEventListener("click", onClick, true);
+  window.addEventListener("blur", stopRepeat);
+  controller.commandDeckListeners = { onClick, onPointerDown, stopRepeat };
+};
+
 const normalizePasteData = (value) =>
   String(value).replace(/\r\n/g, "\n").replace(/\n/g, "\r");
 
@@ -429,8 +527,43 @@ export const createTerminal = (theme) => (fontSize) => (callbacks) => () => {
     touchSelectionAnchor: null,
     touchSelectionStart: null,
     touchSelectionMoved: false,
+    commandDeckLatches: globalThis.AgentTerminal.TerminalInput.createTerminalInput(),
+    commandDeckListeners: null,
+    commandDeckPointerId: null,
+    commandDeckRepeat: null,
+    commandDeckRepeatKey: null,
+    commandDeckRepeatTimer: null,
+    suppressedNativeKey: null,
     callbacks
   };
+
+  term.attachCustomKeyEventHandler((event) => {
+    const input = globalThis.AgentTerminal.TerminalInput;
+    const key = commandDeckKey(event.key);
+    const phase = input.suppressNativeKeyPhase(
+      controller.suppressedNativeKey,
+      key,
+      event.type
+    );
+    if (phase.suppressed) {
+      controller.suppressedNativeKey = phase.suppressedKey;
+      return false;
+    }
+    if (event.type !== "keydown" || !hasCommandDeckLatch(controller.commandDeckLatches)) {
+      return true;
+    }
+    const result = input.consumeNativeKey(
+      controller.commandDeckLatches,
+      key,
+      { applicationCursorKeysMode: applicationCursorKeysMode(controller) }
+    );
+    if (!result.consumed) return true;
+    controller.commandDeckLatches = result.latches;
+    controller.suppressedNativeKey = key;
+    sendTerminalData(controller, result.data);
+    notifyCommandDeckConsumption(controller, true);
+    return false;
+  });
 
   term.onData((data) => {
     sendTerminalData(controller, data);
@@ -449,6 +582,7 @@ export const mountTerminal = (controller) => (elementId) => () => {
   controller.element = target;
   controller.term.open(target);
   installTouchScrolling(controller, target);
+  installCommandDeckHandling(controller);
   try {
     const xterm = globalThis.AgentTerminal;
     const webgl = new xterm.WebglAddon();
@@ -506,6 +640,8 @@ const openTerminalSocket = (controller, url, label) => {
 
   socket.onclose = () => {
     if (controller.socket !== socket) return;
+    clearCommandDeckRepeat(controller);
+    controller.suppressedNativeKey = null;
     controller.socket = null;
     controller.callbacks.onClose();
   };
@@ -527,6 +663,8 @@ export const replaceTerminalAfterDestructiveClose = (controller) => (url) => (la
 };
 
 export const disconnectTerminal = (controller) => () => {
+  clearCommandDeckRepeat(controller);
+  controller.suppressedNativeKey = null;
   if (!controller.socket) return;
   const socket = controller.socket;
   controller.socket = null;
@@ -536,6 +674,8 @@ export const disconnectTerminal = (controller) => () => {
 };
 
 export const abandonTerminal = (controller) => () => {
+  clearCommandDeckRepeat(controller);
+  controller.suppressedNativeKey = null;
   controller.socket = null;
 };
 
@@ -557,6 +697,14 @@ export const sendCtrlBCommand = (controller) => () => {
 
 export const sendText = (controller) => (text) => () => {
   sendTerminalData(controller, normalizePasteData(text));
+};
+
+export const sendCommandDeckKey = (controller) => (key) => () => {
+  dispatchCommandDeckKey(controller, key);
+};
+
+export const setCommandDeckLatches = (controller) => (ctrl) => (alt) => (shift) => (tmux) => () => {
+  controller.commandDeckLatches = { ctrl, alt, shift, tmux };
 };
 
 export const copySelectionImpl = (controller) => async () => {

--- a/ui/src/AgentDaemon/FFI/Terminal.purs
+++ b/ui/src/AgentDaemon/FFI/Terminal.purs
@@ -14,6 +14,8 @@ module AgentDaemon.FFI.Terminal
   , sendText
   , copySelection
   , setSelectionMode
+  , sendCommandDeckKey
+  , setCommandDeckLatches
   , setTerminalFontSize
   , setTerminalTheme
   ) where
@@ -33,6 +35,7 @@ type TerminalCallbacks =
   , onLinkOpened :: Effect Unit
   , onLinkBlocked :: Effect Unit
   , onScrollGesture :: Int -> Effect Unit
+  , onCommandDeckConsumed :: Effect Unit
   }
 
 foreign import createTerminal
@@ -67,6 +70,11 @@ copySelection terminal =
   toAffE (copySelectionImpl terminal)
 
 foreign import setSelectionMode :: TerminalController -> Boolean -> Effect Unit
+
+foreign import sendCommandDeckKey :: TerminalController -> String -> Effect Unit
+
+foreign import setCommandDeckLatches
+  :: TerminalController -> Boolean -> Boolean -> Boolean -> Boolean -> Effect Unit
 
 foreign import setTerminalTheme :: TerminalController -> String -> Effect Unit
 

--- a/ui/src/AgentDaemon/TerminalInput.mjs
+++ b/ui/src/AgentDaemon/TerminalInput.mjs
@@ -1,0 +1,121 @@
+const latchNames = new Set(["ctrl", "alt", "shift", "tmux"]);
+const arrowFinals = {
+  ArrowDown: "B",
+  ArrowLeft: "D",
+  ArrowRight: "C",
+  ArrowUp: "A"
+};
+
+const emptyLatches = () => ({
+  alt: false,
+  ctrl: false,
+  shift: false,
+  tmux: false
+});
+
+export const createTerminalInput = emptyLatches;
+
+export const toggleLatch = (latches, latch) => {
+  if (!latchNames.has(latch)) {
+    throw new Error(`Unknown terminal latch: ${latch}`);
+  }
+
+  return { ...latches, [latch]: !latches[latch] };
+};
+
+const cursorModifier = latches =>
+  1 + (latches.shift ? 1 : 0) + (latches.alt ? 2 : 0) + (latches.ctrl ? 4 : 0);
+
+const controlCharacter = key => {
+  if (!/^[a-z]$/i.test(key)) {
+    return key;
+  }
+
+  return String.fromCharCode(key.toUpperCase().charCodeAt(0) - 64);
+};
+
+const encodeArrow = (key, latches, applicationCursorKeysMode) => {
+  const final = arrowFinals[key];
+  const modifier = cursorModifier(latches);
+
+  if (modifier !== 1) {
+    return `\x1b[1;${modifier}${final}`;
+  }
+
+  return applicationCursorKeysMode ? `\x1bO${final}` : `\x1b[${final}`;
+};
+
+const encodeKey = (key, latches, applicationCursorKeysMode) => {
+  if (key in arrowFinals) {
+    return encodeArrow(key, latches, applicationCursorKeysMode);
+  }
+
+  if (key === "Esc") {
+    return "\x1b";
+  }
+
+  if (key === "Tab") {
+    return latches.shift ? "\x1b[Z" : "\t";
+  }
+
+  if (key === "Enter") {
+    return "\r";
+  }
+
+  const text = latches.shift && key.length === 1 ? key.toUpperCase() : key;
+  const encoded = latches.ctrl ? controlCharacter(text) : text;
+  return latches.alt ? `\x1b${encoded}` : encoded;
+};
+
+export const dispatchKey = (
+  latches,
+  key,
+  { applicationCursorKeysMode = false } = {}
+) => ({
+  data: `${latches.tmux ? "\x02" : ""}${encodeKey(
+    key,
+    latches,
+    applicationCursorKeysMode
+  )}`,
+  latches: emptyLatches()
+});
+
+export const beginArrowRepeat = (
+  key,
+  { delayMs = 250, limit = 12 } = {}
+) => {
+  if (!(key in arrowFinals)) {
+    return { decision: { type: "none" }, repeat: null };
+  }
+
+  return {
+    decision: { type: "schedule", delayMs },
+    repeat: { delayMs, key, remaining: limit }
+  };
+};
+
+export const advanceArrowRepeat = state => {
+  const repeat = state?.repeat ?? state;
+
+  if (repeat == null || repeat.remaining <= 0) {
+    return { decision: { type: "none" }, repeat: null };
+  }
+
+  const next = { ...repeat, remaining: repeat.remaining - 1 };
+  if (next.remaining === 0) {
+    return {
+      decision: { type: "emit-and-stop", reason: "bound" },
+      repeat: null
+    };
+  }
+
+  return {
+    decision: { type: "emit-and-schedule", delayMs: next.delayMs },
+    repeat: next
+  };
+};
+
+export const stopArrowRepeat = (_repeat, reason) => ({
+  decision: { type: "stop", reason },
+  repeat: null
+});

--- a/ui/src/AgentDaemon/TerminalInput.mjs
+++ b/ui/src/AgentDaemon/TerminalInput.mjs
@@ -80,6 +80,25 @@ export const dispatchKey = (
   latches: emptyLatches()
 });
 
+export const consumeNativeKey = (latches, key, options) => {
+  if (!Object.values(latches).some(Boolean)) {
+    return { consumed: false, data: key, latches };
+  }
+
+  return { consumed: true, ...dispatchKey(latches, key, options) };
+};
+
+export const suppressNativeKeyPhase = (suppressedKey, key, phase) => {
+  if (suppressedKey !== key) {
+    return { suppressed: false, suppressedKey };
+  }
+
+  return {
+    suppressed: true,
+    suppressedKey: phase === "keyup" ? null : suppressedKey
+  };
+};
+
 export const beginArrowRepeat = (
   key,
   { delayMs = 250, limit = 12 } = {}

--- a/ui/src/Main.purs
+++ b/ui/src/Main.purs
@@ -722,8 +722,8 @@ renderMain state =
             [ HH.div
                 [ HP.id "terminal" ]
                 []
-            , renderCommandDeck state
             ]
+        , renderCommandDeck state
         ]
     ]
 

--- a/ui/src/Main.purs
+++ b/ui/src/Main.purs
@@ -47,6 +47,31 @@ type ReconnectNotice =
   , status :: String
   }
 
+type CommandDeckLatches =
+  { ctrl :: Boolean
+  , alt :: Boolean
+  , shift :: Boolean
+  , tmux :: Boolean
+  }
+
+emptyCommandDeckLatches :: CommandDeckLatches
+emptyCommandDeckLatches =
+  { ctrl: false
+  , alt: false
+  , shift: false
+  , tmux: false
+  }
+
+toggleCommandDeckLatch
+  :: CommandDeckLatches -> String -> CommandDeckLatches
+toggleCommandDeckLatch latches latch =
+  case latch of
+    "ctrl" -> latches { ctrl = not latches.ctrl }
+    "alt" -> latches { alt = not latches.alt }
+    "shift" -> latches { shift = not latches.shift }
+    "tmux" -> latches { tmux = not latches.tmux }
+    _ -> latches
+
 type State =
   { sessions :: Array Session
   , windows :: Array WindowInfo
@@ -76,6 +101,7 @@ type State =
   , endedNotice :: Maybe String
   , reconnectNotice :: Maybe ReconnectNotice
   , terminal :: Maybe Terminal.TerminalController
+  , commandDeckLatches :: CommandDeckLatches
   }
 
 data TerminalEvent
@@ -85,6 +111,7 @@ data TerminalEvent
   | TerminalLinkOpened
   | TerminalLinkBlocked
   | TerminalScrollGesture Int
+  | TerminalCommandDeckConsumed
 
 data Action
   = Initialize
@@ -102,6 +129,7 @@ data Action
   | SendCtrlB
   | SendCtrlBCommand
   | SendLive
+  | ToggleCommandDeckLatch String
   | CopyTerminalText
   | ToggleTerminalSelectionMode
   | TogglePasteMenu
@@ -161,6 +189,7 @@ appComponent = H.mkComponent
       , endedNotice: Nothing
       , reconnectNotice: Nothing
       , terminal: Nothing
+      , commandDeckLatches: emptyCommandDeckLatches
       }
   , render
   , eval: H.mkEval H.defaultEval
@@ -684,7 +713,7 @@ renderSettings state =
     ]
 
 renderMain :: State -> H.ComponentHTML Action Slots Aff
-renderMain _ =
+renderMain state =
   HH.main_
     [ HH.section
         [ cls "workspace" ]
@@ -693,9 +722,64 @@ renderMain _ =
             [ HH.div
                 [ HP.id "terminal" ]
                 []
+            , renderCommandDeck state
             ]
         ]
     ]
+
+renderCommandDeck :: State -> H.ComponentHTML Action Slots Aff
+renderCommandDeck state =
+  if state.attachedSession == "" then
+    HH.text ""
+  else
+    HH.div
+      [ cls "command-deck"
+      , HP.attr (HH.AttrName "aria-label") "Terminal command deck"
+      ]
+      [ commandDeckKey "Esc" "Esc"
+      , commandDeckKey "Tab" "Tab"
+      , commandDeckLatch state "ctrl" "Ctrl"
+      , commandDeckLatch state "alt" "Alt"
+      , commandDeckLatch state "shift" "Shift"
+      , commandDeckLatch state "tmux" "Tmux"
+      , commandDeckKey "ArrowLeft" "Left"
+      , commandDeckKey "ArrowUp" "Up"
+      , commandDeckKey "ArrowDown" "Down"
+      , commandDeckKey "ArrowRight" "Right"
+      , commandDeckKey "Enter" "Enter"
+      ]
+
+commandDeckKey :: String -> String -> H.ComponentHTML Action Slots Aff
+commandDeckKey key label =
+  HH.button
+    [ cls "command-deck-control command-deck-key"
+    , HP.attr (HH.AttrName "data-command-deck-control") ""
+    , HP.attr (HH.AttrName "data-command-deck-key") key
+    , HP.attr (HH.AttrName "aria-label") label
+    ]
+    [ HH.text label ]
+
+commandDeckLatch :: State -> String -> String -> H.ComponentHTML Action Slots Aff
+commandDeckLatch state latch label =
+  let
+    armed = case latch of
+      "ctrl" -> state.commandDeckLatches.ctrl
+      "alt" -> state.commandDeckLatches.alt
+      "shift" -> state.commandDeckLatches.shift
+      "tmux" -> state.commandDeckLatches.tmux
+      _ -> false
+  in
+    HH.button
+      [ cls
+          ( "command-deck-control command-deck-latch"
+              <> if armed then " armed" else ""
+          )
+      , HP.attr (HH.AttrName "data-command-deck-control") ""
+      , HP.attr (HH.AttrName "aria-label") label
+      , HP.attr (HH.AttrName "aria-pressed") (if armed then "true" else "false")
+      , HE.onClick \_ -> ToggleCommandDeckLatch latch
+      ]
+      [ HH.text label ]
 
 renderSessions :: State -> Array (H.ComponentHTML Action Slots Aff)
 renderSessions state =
@@ -870,6 +954,8 @@ handleAction = case _ of
           HS.notify listener (HandleTerminal TerminalLinkBlocked)
       , onScrollGesture: \lines ->
           HS.notify listener (HandleTerminal (TerminalScrollGesture lines))
+      , onCommandDeckConsumed:
+          HS.notify listener (HandleTerminal TerminalCommandDeckConsumed)
       }
     void $ H.subscribe emitter
     H.modify_ _
@@ -1038,6 +1124,16 @@ handleAction = case _ of
   SendLive ->
     returnAttachedSessionLive
 
+  ToggleCommandDeckLatch latch -> do
+    state <- H.get
+    let latches = toggleCommandDeckLatch state.commandDeckLatches latch
+    case state.terminal of
+      Nothing -> pure unit
+      Just terminal -> liftEffect $
+        Terminal.setCommandDeckLatches terminal latches.ctrl latches.alt latches.shift latches.tmux
+    H.modify_ _ { commandDeckLatches = latches }
+    syncUi
+
   CopyTerminalText ->
     copyTerminalText
 
@@ -1199,6 +1295,7 @@ handleAction = case _ of
         url <- liftEffect $ Browser.sessionTerminalWsUrl state.server sessionId
         let label = "session " <> sessionId
         liftEffect $ Terminal.setSelectionMode terminal false
+        liftEffect $ Terminal.setCommandDeckLatches terminal false false false false
         liftEffect $ Terminal.attachTerminal terminal url label
         H.modify_ _
           { selectedSession = sessionId
@@ -1215,6 +1312,7 @@ handleAction = case _ of
           , terminalSelectionMode = false
           , pasteMenuOpen = false
           , status = "connecting: " <> label
+          , commandDeckLatches = emptyCommandDeckLatches
           }
         refreshWindows sessionId
         syncUi
@@ -1297,6 +1395,7 @@ handleAction = case _ of
       Nothing -> pure unit
       Just terminal -> liftEffect do
         Terminal.setSelectionMode terminal false
+        Terminal.setCommandDeckLatches terminal false false false false
         Terminal.disconnectTerminal terminal
     H.modify_ _
       { attachedSession = ""
@@ -1312,6 +1411,7 @@ handleAction = case _ of
       , terminalSelectionMode = false
       , pasteMenuOpen = false
       , status = "disconnected"
+      , commandDeckLatches = emptyCommandDeckLatches
       }
     syncUi
 
@@ -1357,6 +1457,13 @@ handleAction = case _ of
         H.modify_ _ { status = "link blocked by browser" }
       TerminalScrollGesture lines ->
         scrollAttachedSession lines
+      TerminalCommandDeckConsumed -> do
+        state <- H.get
+        case state.terminal of
+          Nothing -> pure unit
+          Just terminal -> liftEffect $
+            Terminal.setCommandDeckLatches terminal false false false false
+        H.modify_ _ { commandDeckLatches = emptyCommandDeckLatches }
     case event of
       TerminalScrollGesture _ -> pure unit
       _ -> syncUi

--- a/ui/src/bootstrap.js
+++ b/ui/src/bootstrap.js
@@ -4,12 +4,14 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { createElement, icons } from "lucide";
+import * as TerminalInput from "./AgentDaemon/TerminalInput.mjs";
 
 globalThis.AgentTerminal = {
   Terminal,
   FitAddon,
   WebglAddon,
   WebLinksAddon,
-  Unicode11Addon
+  Unicode11Addon,
+  TerminalInput
 };
 globalThis.lucide = { createElement, icons };

--- a/ui/test/CommandDeckLayout.test.mjs
+++ b/ui/test/CommandDeckLayout.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import { readFile } from "node:fs/promises";
+import { mkdirSync } from "node:fs";
+import { basename, extname, join, normalize } from "node:path";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { chromium } = require("playwright");
+const uiBundle = process.env.UI_BUNDLE;
+const screenshotDirectory = process.env.COMMAND_DECK_SCREENSHOT_DIR;
+const viewports = [
+  { width: 390, height: 844 },
+  { width: 768, height: 1024 },
+  { width: 1024, height: 768 }
+];
+
+const contentTypes = {
+  ".css": "text/css",
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".svg": "image/svg+xml",
+  ".woff2": "font/woff2"
+};
+
+const commandDeckMetrics = () =>
+  Array.from(document.querySelectorAll("[data-command-deck-control]")).map((control) => {
+    const rect = control.getBoundingClientRect();
+    const centreX = rect.left + rect.width / 2;
+    const centreY = rect.top + rect.height / 2;
+    const hit = document.elementFromPoint(centreX, centreY);
+    return {
+      label: control.getAttribute("aria-label"),
+      rect: {
+        bottom: rect.bottom,
+        height: rect.height,
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        width: rect.width
+      },
+      intersectsViewport:
+        rect.right > 0 &&
+        rect.bottom > 0 &&
+        rect.left < window.innerWidth &&
+        rect.top < window.innerHeight,
+      centreHit: hit === control || control.contains(hit),
+      hitTag: hit?.tagName ?? null,
+      hitLabel: hit?.closest("[aria-label]")?.getAttribute("aria-label") ?? null
+    };
+  });
+
+const createFixture = async () => {
+  assert.ok(uiBundle, "UI_BUNDLE must name the built static UI directory");
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+    if (url.pathname === "/sessions") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify([{ id: "layout-session", state: "active", tmuxName: "layout" }]));
+      return;
+    }
+    if (url.pathname === "/sessions/layout-session/windows") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify([{ index: 0, name: "layout", active: true }]));
+      return;
+    }
+
+    const requestedPath = url.pathname === "/" ? "index.html" : url.pathname.slice(1);
+    const filePath = normalize(join(uiBundle, requestedPath));
+    if (!filePath.startsWith(`${uiBundle}/`) && filePath !== join(uiBundle, "index.html")) {
+      response.statusCode = 400;
+      response.end("invalid path");
+      return;
+    }
+    try {
+      response.setHeader("content-type", contentTypes[extname(filePath)] ?? "application/octet-stream");
+      response.end(await readFile(filePath));
+    } catch (_) {
+      response.statusCode = 404;
+      response.end(`not found: ${basename(filePath)}`);
+    }
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+  };
+};
+
+const attachSession = async (page, viewport) => {
+  await page.setViewportSize(viewport);
+  await page.addInitScript(() => {
+    class FixtureWebSocket {
+      static OPEN = 1;
+      static CLOSING = 2;
+
+      constructor() {
+        this.readyState = 0;
+        window.setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.onopen?.({});
+        }, 0);
+      }
+
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+
+      send() {}
+    }
+
+    window.WebSocket = FixtureWebSocket;
+  });
+  await page.goto(process.env.COMMAND_DECK_FIXTURE_URL, { waitUntil: "networkidle" });
+  await page.waitForFunction(
+    () => document.querySelectorAll("[data-command-deck-control]").length === 11
+  );
+  await page.waitForTimeout(100);
+};
+
+test("attached command deck controls remain visible and hittable at touch viewports", async (t) => {
+  const fixture = await createFixture();
+  const previousFixtureUrl = process.env.COMMAND_DECK_FIXTURE_URL;
+  process.env.COMMAND_DECK_FIXTURE_URL = fixture.url;
+  // The self-hosted runner's SystemCallFilter denies the zygote capability transition.
+  const browser = await chromium.launch({ headless: true, args: ["--no-zygote"] });
+  t.after(async () => {
+    if (previousFixtureUrl === undefined) delete process.env.COMMAND_DECK_FIXTURE_URL;
+    else process.env.COMMAND_DECK_FIXTURE_URL = previousFixtureUrl;
+    await browser.close();
+    await fixture.close();
+  });
+
+  const failures = [];
+  for (const viewport of viewports) {
+    const page = await browser.newPage({ viewport });
+    await attachSession(page, viewport);
+    const metrics = await page.evaluate(commandDeckMetrics);
+    if (screenshotDirectory) {
+      mkdirSync(screenshotDirectory, { recursive: true });
+      await page.screenshot({
+        path: join(screenshotDirectory, `command-deck-${viewport.width}x${viewport.height}.png`),
+        fullPage: false
+      });
+    }
+    const invalidControls = metrics.filter(
+      (control) =>
+        control.rect.width < 44 ||
+        control.rect.height < 44 ||
+        !control.intersectsViewport ||
+        !control.centreHit
+    );
+    console.log(JSON.stringify({ viewport, controls: metrics.length, metrics, invalidControls }));
+    if (metrics.length !== 11 || invalidControls.length > 0) {
+      failures.push({ viewport, controls: metrics.length, invalidControls });
+    }
+    await page.close();
+  }
+
+  assert.deepEqual(failures, []);
+});

--- a/ui/test/TerminalInput.test.mjs
+++ b/ui/test/TerminalInput.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  advanceArrowRepeat,
+  beginArrowRepeat,
+  createTerminalInput,
+  dispatchKey,
+  stopArrowRepeat,
+  toggleLatch
+} from "../src/AgentDaemon/TerminalInput.mjs";
+
+test("encodes Ctrl-C and consumes Ctrl once", () => {
+  const armed = toggleLatch(createTerminalInput(), "ctrl");
+  const first = dispatchKey(armed, "c");
+
+  assert.equal(first.data, "\x03");
+  assert.deepEqual(first.latches, {
+    alt: false,
+    ctrl: false,
+    shift: false,
+    tmux: false
+  });
+  assert.equal(dispatchKey(first.latches, "c").data, "c");
+});
+
+test("encodes Shift-Tab", () => {
+  const armed = toggleLatch(createTerminalInput(), "shift");
+
+  assert.equal(dispatchKey(armed, "Tab").data, "\x1b[Z");
+});
+
+test("prefixes Alt text with Escape", () => {
+  const armed = toggleLatch(createTerminalInput(), "alt");
+
+  assert.equal(dispatchKey(armed, "x").data, "\x1bx");
+});
+
+test("prefixes a normal-mode arrow with literal Ctrl-B when Tmux is armed", () => {
+  const armed = toggleLatch(createTerminalInput(), "tmux");
+
+  assert.equal(dispatchKey(armed, "ArrowUp").data, "\x02\x1b[A");
+});
+
+test("uses SS3 arrows in application cursor mode", () => {
+  assert.equal(
+    dispatchKey(createTerminalInput(), "ArrowRight", {
+      applicationCursorKeysMode: true
+    }).data,
+    "\x1bOC"
+  );
+});
+
+test("cancelling a latch emits nothing and leaves the next key unmodified", () => {
+  const armed = toggleLatch(createTerminalInput(), "alt");
+  const cancelled = toggleLatch(armed, "alt");
+
+  assert.deepEqual(cancelled, createTerminalInput());
+  assert.equal(dispatchKey(cancelled, "x").data, "x");
+});
+
+test("consumes every armed latch exactly once", () => {
+  const armed = ["ctrl", "alt", "shift", "tmux"].reduce(
+    toggleLatch,
+    createTerminalInput()
+  );
+  const first = dispatchKey(armed, "ArrowLeft");
+
+  assert.equal(first.data, "\x02\x1b[1;8D");
+  assert.deepEqual(first.latches, createTerminalInput());
+  assert.equal(dispatchKey(first.latches, "ArrowLeft").data, "\x1b[D");
+});
+
+test("bounds arrow repeat and stops it on every cancellation path", () => {
+  const initial = beginArrowRepeat("ArrowDown", { limit: 2, delayMs: 100 });
+
+  assert.deepEqual(initial.decision, { type: "schedule", delayMs: 100 });
+
+  const first = advanceArrowRepeat(initial);
+  assert.deepEqual(first.decision, { type: "emit-and-schedule", delayMs: 100 });
+
+  const bounded = advanceArrowRepeat(first.repeat);
+  assert.deepEqual(bounded.decision, { type: "emit-and-stop", reason: "bound" });
+
+  for (const reason of ["pointer-up", "pointer-cancel", "pointer-leave", "blur", "detach"]) {
+    assert.deepEqual(stopArrowRepeat(initial, reason), {
+      decision: { type: "stop", reason },
+      repeat: null
+    });
+  }
+});
+
+test("does not schedule repeat lifecycle decisions for non-arrow keys", () => {
+  assert.deepEqual(beginArrowRepeat("Enter"), {
+    decision: { type: "none" },
+    repeat: null
+  });
+});

--- a/ui/test/TerminalInput.test.mjs
+++ b/ui/test/TerminalInput.test.mjs
@@ -4,8 +4,10 @@ import test from "node:test";
 import {
   advanceArrowRepeat,
   beginArrowRepeat,
+  consumeNativeKey,
   createTerminalInput,
   dispatchKey,
+  suppressNativeKeyPhase,
   stopArrowRepeat,
   toggleLatch
 } from "../src/AgentDaemon/TerminalInput.mjs";
@@ -22,6 +24,37 @@ test("encodes Ctrl-C and consumes Ctrl once", () => {
     tmux: false
   });
   assert.equal(dispatchKey(first.latches, "c").data, "c");
+});
+
+test("consumes an armed native Ctrl-C once and leaves the following native c plain", () => {
+  const armed = toggleLatch(createTerminalInput(), "ctrl");
+  const first = consumeNativeKey(armed, "c");
+
+  assert.deepEqual(first, {
+    consumed: true,
+    data: "\x03",
+    latches: createTerminalInput()
+  });
+  assert.deepEqual(consumeNativeKey(first.latches, "c"), {
+    consumed: false,
+    data: "c",
+    latches: createTerminalInput()
+  });
+});
+
+test("suppresses only the remaining xterm phases of a consumed native key", () => {
+  assert.deepEqual(suppressNativeKeyPhase("c", "c", "keypress"), {
+    suppressed: true,
+    suppressedKey: "c"
+  });
+  assert.deepEqual(suppressNativeKeyPhase("c", "c", "keyup"), {
+    suppressed: true,
+    suppressedKey: null
+  });
+  assert.deepEqual(suppressNativeKeyPhase(null, "c", "keydown"), {
+    suppressed: false,
+    suppressedKey: null
+  });
 });
 
 test("encodes Shift-Tab", () => {


### PR DESCRIPTION
Closes #92

Parent: #80

## Scope

A compact, touch-first terminal command deck for tmux and interactive TUIs,
while retaining native alphanumeric keyboard entry.

## Previously delivered

- Slice 1: a pure, Node-tested input-state and encoding model runs inside the
  authoritative Nix UI check.
- Slice 2: accessible one-shot Ctrl/Alt/Shift/Tmux latches, all eleven deck
  controls, xterm public cursor-mode support, focus-preserving bounded arrow
  repeat, and native-key multi-phase suppression.
- Slice 3: operator documentation plus independently reproduced browser
  evidence at all required viewports.

## Reopened correction set; post-drop CI passed

Review-ready acceptance was revoked after independent screenshots showed that
all eleven deck controls were nested inside the clipped terminal wrapper. The
focused RED/GREEN correction added a real browser-layout regression for viewport
intersection, non-clipping/non-coverage, and hit-testing at 390×844, 768×1024,
and 1024×768, then moved the deck into the direct workspace auto row.

The subsequent exact runner diagnosis is a test-harness concern, not a timeout
or layout regression: the self-hosted runner's `SystemCallFilter` denies
Chromium's zygote capability transition. The correction was independently RED
reproduced under the runner identity/filter (zygote fork failures, GPU crashes,
SIGTRAP, and Playwright closed-target error), then GREEN reproduced with the
single `chromium.launch` argument `--no-zygote`. It makes no application or
runner-hardening change and retains all viewport assertions.

The correction's pre-drop hosted CI run
[29201922280](https://github.com/lambdasistemi/tmux-ws/actions/runs/29201922280)
passed all 9 jobs on `aeb65d615ba9c1ff7e50890027be7b1c0291d75b`. The final
review-ready head `3390fce20697fcdba5983701c1ababd5b553ecc9` drops `gate.sh`
after a fresh finalization audit; its exact post-drop CI run
[29202262067](https://github.com/lambdasistemi/tmux-ws/actions/runs/29202262067)
passed all 9 jobs. PR #93 is ready for review, open, and unmerged.

## Interactive branch preview (tailnet only)

https://development.taildd7d1a.ts.net:8446

This is the real #92 branch preview, served from a separate transient local
service with no-store cache headers. This latest amend is test-harness-only:
the fresh static `index.js`, `index.html`, and `index.css` checksums match the
live service, so no preview restart was needed. The main-branch GitHub Pages
site is not a representation of this branch and cannot control a local daemon.

## Durable evidence

The [corrected browser evidence record](https://github.com/lambdasistemi/tmux-ws/pull/93#issuecomment-4952015180)
covers the rebuilt tailnet preview, exact local/tailnet asset parity, fresh
screenshots, and all-eleven-control viewport and centre-hit results at every
accepted viewport. Hardened-runner RED/GREEN and independent gate evidence is
retained in the ticket runtime protocol.

## Constraints

No backend/API/WebSocket changes, third-party virtual keyboard, configurable
layout/remappable prefix, release/package work, GHC upgrade, application
behavior change, or runner-hardening change.

## Verification status

The prior final-head CI run
[29199727751](https://github.com/lambdasistemi/tmux-ws/actions/runs/29199727751)
passed on `70b996a`, before the reopened correction and is intentionally stale.
The correction head `aeb65d6` had fresh driver, navigator, and ticket-owner
`./gate.sh` passes, plus exact-head hosted CI success. The review-ready
post-drop head `3390fce` has passed a fresh finalization audit and exact-head
hosted CI. This workflow will not merge the PR.
