### PR TITLE
fix: ship releases under the tmux-ws product name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
               'let
                 lines = builtins.filter builtins.isString
                   (builtins.split "\n"
-                    (builtins.readFile ./agent-daemon.cabal));
+                    (builtins.readFile ./tmux-ws.cabal));
                 matches = builtins.filter (match: match != null)
                   (map
                     (line: builtins.match
@@ -167,3 +167,38 @@ jobs:
             extra-trusted-public-keys = paolino.cachix.org-1:ecmgO3CXdgSWA2cHlm4srknd/cLFMLmK3i3NrzeDFaE=
       - name: Build
         run: nix build -L
+
+      - name: Verify rendered Homebrew formula compatibility route
+        run: |
+          set -euo pipefail
+          tap=local/tmux-ws-red
+          brew tap-new "$tap"
+          trap 'brew untap --force "$tap"' EXIT
+          formulas="$(brew --repository "$tap")/Formula"
+          bundle="$RUNNER_TEMP/tmux-ws-bundle"
+          archive="$RUNNER_TEMP/tmux-ws-0.3.0-aarch64-darwin.tar.gz"
+          mkdir -p "$bundle/bin" "$bundle/libexec/lib"
+          cp result/bin/tmux-ws "$bundle/bin/tmux-ws"
+          COPYFILE_DISABLE=1 tar -czf "$archive" -C "$bundle" .
+          sha256="$(shasum -a 256 "$archive" | awk '{ print $1 }')"
+          bash scripts/render-homebrew-formulas.sh \
+            "$formulas" \
+            "file://$archive" \
+            "$sha256" \
+            0.3.0
+          brew install --formula "$tap/tmux-ws"
+          brew install --formula "$tap/agent-daemon"
+          tmux-ws --help
+          agent-daemon --help
+          agent_daemon_prefix="$(brew --prefix "$tap/agent-daemon")"
+          agent_daemon_link="$agent_daemon_prefix/bin/agent-daemon"
+          tmux_ws_link="$(brew --prefix tmux-ws)/bin/tmux-ws"
+          test -L "$agent_daemon_link"
+          test ! -e "$agent_daemon_prefix/bin/tmux-ws"
+          agent_daemon_target="$(readlink "$agent_daemon_link")"
+          agent_daemon_identity="$(stat -L -f '%d:%i' "$agent_daemon_link")"
+          tmux_ws_identity="$(stat -L -f '%d:%i' "$tmux_ws_link")"
+          printf 'agent-daemon link: %s -> %s\n' "$agent_daemon_link" "$agent_daemon_target"
+          printf 'agent-daemon resolved identity: %s\n' "$agent_daemon_identity"
+          printf 'tmux-ws resolved identity: %s\n' "$tmux_ws_identity"
+          test "$agent_daemon_identity" = "$tmux_ws_identity"

--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build-and-release:
-    name: Publish agent-daemon for aarch64-darwin
+    name: Publish tmux-ws for aarch64-darwin
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
@@ -56,7 +56,7 @@ jobs:
 
           tag_version="${TAG#v}"
           manifest_version="$(jq -er '."."' .release-please-manifest.json)"
-          cabal_version="$(awk '$1 == "version:" { print $2; exit }' agent-daemon.cabal)"
+          cabal_version="$(awk '$1 == "version:" { print $2; exit }' tmux-ws.cabal)"
 
           test -n "$cabal_version"
           test "$tag_version" = "$manifest_version"
@@ -76,18 +76,18 @@ jobs:
         run: |
           nix build -L --no-link --print-out-paths > "$RUNNER_TEMP/nix-out"
           test "$(wc -l < "$RUNNER_TEMP/nix-out")" -eq 1
-          test -x "$(cat "$RUNNER_TEMP/nix-out")/bin/agent-daemon"
+          test -x "$(cat "$RUNNER_TEMP/nix-out")/bin/tmux-ws"
 
       - name: Bundle and smoke installed layout
         run: |
           bundle="$RUNNER_TEMP/bundle"
-          binary="$bundle/bin/agent-daemon"
+          binary="$bundle/bin/tmux-ws"
           libdir="$bundle/libexec/lib"
           queue="$RUNNER_TEMP/dylib-queue"
           origins="$RUNNER_TEMP/dylib-origins"
 
           mkdir -p "$bundle/bin" "$libdir"
-          cp "$(cat "$RUNNER_TEMP/nix-out")/bin/agent-daemon" "$binary"
+          cp "$(cat "$RUNNER_TEMP/nix-out")/bin/tmux-ws" "$binary"
           chmod u+w "$binary"
           : > "$queue"
           : > "$origins"
@@ -156,7 +156,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          asset="$RUNNER_TEMP/agent-daemon-${VERSION}-aarch64-darwin.tar.gz"
+          asset="$RUNNER_TEMP/tmux-ws-${VERSION}-aarch64-darwin.tar.gz"
           COPYFILE_DISABLE=1 tar -czf "$asset" -C "$RUNNER_TEMP/bundle" .
           sha="$(shasum -a 256 "$asset" | awk '{ print $1 }')"
           printf '%s  %s\n' "$sha" "$(basename "$asset")"
@@ -187,20 +187,21 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           SHA256: ${{ steps.asset.outputs.sha256 }}
         run: |
-          url="https://github.com/lambdasistemi/tmux-ws/releases/download/${TAG}/agent-daemon-${VERSION}-aarch64-darwin.tar.gz"
+          url="https://github.com/lambdasistemi/tmux-ws/releases/download/${TAG}/tmux-ws-${VERSION}-aarch64-darwin.tar.gz"
 
-          printf 'class AgentDaemon < Formula\n  desc "WebSocket daemon for managing tmux workspaces"\n  homepage "https://github.com/lambdasistemi/tmux-ws"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/agent-daemon"\n    (libexec/"lib").install Dir["libexec/lib/*"]\n  end\n\n  test do\n    system "#{bin}/agent-daemon", "--help"\n  end\nend\n' \
-            "$url" "$SHA256" "$VERSION" > "$RUNNER_TEMP/agent-daemon.rb"
+          bash scripts/render-homebrew-formulas.sh \
+            "$RUNNER_TEMP" "$url" "$SHA256" "$VERSION"
 
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/lambdasistemi/homebrew-tap.git" "$RUNNER_TEMP/tap"
           mkdir -p "$RUNNER_TEMP/tap/Formula"
+          cp "$RUNNER_TEMP/tmux-ws.rb" "$RUNNER_TEMP/tap/Formula/tmux-ws.rb"
           cp "$RUNNER_TEMP/agent-daemon.rb" "$RUNNER_TEMP/tap/Formula/agent-daemon.rb"
           cd "$RUNNER_TEMP/tap"
           git config user.name "lambdasistemi-ci[bot]"
           git config user.email "github-actions@github.com"
-          git add Formula/agent-daemon.rb
+          git add Formula/tmux-ws.rb Formula/agent-daemon.rb
           if ! git diff --cached --quiet; then
-            git commit -m "update agent-daemon to ${TAG}"
+            git commit -m "update tmux-ws to ${TAG}"
           fi
           git push
 
@@ -208,7 +209,7 @@ jobs:
         run: |
           brew tap lambdasistemi/tap
           brew trust lambdasistemi/tap
-          brew install --formula lambdasistemi/tap/agent-daemon
-          agent-daemon --help
-          command -v agent-daemon
-          otool -L "$(command -v agent-daemon)"
+          brew install --formula lambdasistemi/tap/tmux-ws
+          tmux-ws --help
+          command -v tmux-ws
+          otool -L "$(command -v tmux-ws)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           matches="$RUNNER_TEMP/recovery-prs.json"
           jq '[.[][] | select(
             .merged_at != null and
-            .user.login == "lambdasistemi-ci[bot]" and
+            (.user.login == "lambdasistemi-ci[bot]" or .user.login == "app/lambdasistemi-ci") and
             .base.ref == "main" and
             .head.ref == "release-please--branches--main"
           )]' "$pull_requests" > "$matches"
@@ -94,7 +94,7 @@ jobs:
             printf 'release metadata mismatch: generated PR title\n' >&2
             exit 1
           fi
-          if test "$(awk '$1 == "version:" { print $2; exit }' agent-daemon.cabal)" != "$version"; then
+          if test "$(awk '$1 == "version:" { print $2; exit }' tmux-ws.cabal)" != "$version"; then
             printf 'release metadata mismatch: Cabal version\n' >&2
             exit 1
           fi
@@ -159,7 +159,7 @@ jobs:
           false_pr_numbers="$RUNNER_TEMP/false-release-pr-numbers"
           if ! jq -r --arg started_at "$RECOVERY_STARTED_AT" '
             .[] | select(
-              .author.login == "lambdasistemi-ci[bot]" and
+              (.author.login == "lambdasistemi-ci[bot]" or .author.login == "app/lambdasistemi-ci") and
               .createdAt >= $started_at
             ) | .number
           ' "$false_prs" > "$false_pr_numbers"; then

--- a/.github/workflows/sync-cabal-version.yml
+++ b/.github/workflows/sync-cabal-version.yml
@@ -37,16 +37,16 @@ jobs:
             *) printf 'invalid manifest version: %s\n' "$version" >&2; exit 1 ;;
           esac
 
-          sed -E -i.bak "s/^(version:[[:space:]]*).*/\\1${version}/" agent-daemon.cabal
-          rm agent-daemon.cabal.bak
+          sed -E -i.bak "s/^(version:[[:space:]]*).*/\\1${version}/" tmux-ws.cabal
+          rm tmux-ws.cabal.bak
 
-          if git diff --quiet -- agent-daemon.cabal; then
+          if git diff --quiet -- tmux-ws.cabal; then
             exit 0
           fi
 
-          test "$(awk '$1 == "version:" { print $2; exit }' agent-daemon.cabal)" = "$version"
+          test "$(awk '$1 == "version:" { print $2; exit }' tmux-ws.cabal)" = "$version"
           git config user.name "lambdasistemi-ci[bot]"
           git config user.email "github-actions@github.com"
-          git add agent-daemon.cabal
+          git add tmux-ws.cabal
           git commit -m "chore: sync Cabal version to ${version}"
           git push origin "HEAD:${GITHUB_HEAD_REF}"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the [full documentation](https://lambdasistemi.github.io/tmux-ws/docs/).
 ```bash
 nix develop
 just build
-agent-daemon --host 127.0.0.1 --port 8080 --base-dir /code
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir /code
 ```
 
 Then open the daemon URL in a browser on the same machine:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,14 +7,14 @@ The flake exposes a NixOS module:
 ```nix
 # flake.nix
 {
-  inputs.agent-daemon.url = "github:lambdasistemi/tmux-ws";
+  inputs.tmux-ws.url = "github:lambdasistemi/tmux-ws";
 
-  outputs = { nixpkgs, agent-daemon, ... }: {
+  outputs = { nixpkgs, tmux-ws, ... }: {
     nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
       modules = [
-        agent-daemon.nixosModules.default
+        tmux-ws.nixosModules.default
         {
-          services.agent-daemon = {
+          services.tmux-ws = {
             enable = true;
             host = "127.0.0.1";
             port = 8080;
@@ -27,13 +27,14 @@ The flake exposes a NixOS module:
 }
 ```
 
-By default the module creates a dedicated `agent-daemon` system user.
+The primary public service is `tmux-ws`; by default it uses the private
+`agent-daemon` system account and state directory for compatibility.
 To control tmux sessions owned by an existing user, run the daemon as that same
 user and point it at the same tmux socket directory. Replace each placeholder
 below with local values; obtain the numeric id with `id -u <operator>`:
 
 ```nix
-services.agent-daemon = {
+services.tmux-ws = {
   enable = true;
   host = "127.0.0.1";
   port = 8080;
@@ -45,7 +46,7 @@ services.agent-daemon = {
 
 # Keep the user's runtime directory available for the boot-started service.
 users.users."<operator>".linger = true;
-systemd.services.agent-daemon = {
+systemd.services.tmux-ws = {
   after = [ "user-runtime-dir@<uid>.service" ];
   requires = [ "user-runtime-dir@<uid>.service" ];
   environment.TMUX_TMPDIR = "/run/user/<uid>";
@@ -75,8 +76,8 @@ must agree.
 | `baseDir` | path | `/var/lib/agent-daemon` | Root for worktrees |
 | `staticDir` | path | (from flake) | Web UI files |
 | `package` | package | (from flake) | The binary to use |
-| `user` | string | `"agent-daemon"` | User to run as |
-| `group` | string | `"agent-daemon"` | Group to run as |
+| `user` | string | `"agent-daemon"` | Private service account |
+| `group` | string | `"agent-daemon"` | Private service group |
 | `createUser` | bool | `true` | Create a dedicated system user |
 
 ## Systemd (manual)
@@ -84,9 +85,9 @@ must agree.
 If you're not on NixOS, create a unit file:
 
 ```ini
-# /etc/systemd/system/agent-daemon.service
+# /etc/systemd/system/tmux-ws.service
 [Unit]
-Description=Agent daemon — Claude Code session manager
+Description=tmux-ws — browser SPA and tmux session daemon
 After=network.target
 
 [Service]
@@ -94,11 +95,11 @@ Type=simple
 User=<operator>
 Group=<operator-group>
 WorkingDirectory=/path/to/worktrees
-ExecStart=/usr/local/bin/agent-daemon \
+ExecStart=/usr/local/bin/tmux-ws \
   --host 127.0.0.1 \
   --port 8080 \
   --base-dir /path/to/worktrees \
-  --static-dir /usr/local/share/agent-daemon/static
+  --static-dir /usr/local/share/tmux-ws/static
 Restart=on-failure
 RestartSec=5
 Environment=PATH=/usr/bin:/usr/local/bin
@@ -110,8 +111,8 @@ WantedBy=multi-user.target
 
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable --now agent-daemon
-journalctl -u agent-daemon -f   # watch logs
+sudo systemctl enable --now tmux-ws
+journalctl -u tmux-ws -f   # watch logs
 ```
 
 For a service enabled at boot, ensure `/run/user/<uid>` is created before this
@@ -125,8 +126,16 @@ Build with nix and copy the binary:
 
 ```bash
 nix build .#default
-# result/bin/agent-daemon
+# result/bin/tmux-ws
 
 # Or run directly:
 nix run .#default -- --host 127.0.0.1 --port 8080 --base-dir /code
 ```
+
+## Legacy configuration migration
+
+`services.agent-daemon` is a compatibility alias for `services.tmux-ws` in
+this corrective release. Rename it in configuration and operate the resulting
+single `tmux-ws` unit; do not enable a second legacy daemon. The alias is
+limited to this corrective release and removal requires a separately reviewed
+migration ticket.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,8 @@
-# Agent Daemon — Design
+# tmux-ws design
+
+> Historical architecture diagrams below retain `agent-daemon` labels for
+> context. They are not current installation, service, or command guidance;
+> operators use `tmux-ws` as documented in the deployment and release guides.
 
 ## Overview
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,7 +118,7 @@ nix develop
 just build
 
 # Run
-agent-daemon --host 127.0.0.1 --port 8080 --base-dir /code
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir /code
 ```
 
 ## CLI options

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,79 @@
+# Release and migration
+
+## New installations
+
+Install the primary product with Homebrew:
+
+```bash
+brew update
+brew install lambdasistemi/tap/tmux-ws
+tmux-ws --help
+```
+
+NixOS users should configure `services.tmux-ws` and enable the `tmux-ws`
+systemd service.
+
+`v0.3.0` is immutable and will not be rewritten or deleted. The corrective
+`v0.3.1` release will publish a new Darwin asset and update the real Homebrew tap;
+this PR itself does neither. After an upgrade, restart the daemon
+(`systemctl restart tmux-ws` on NixOS) and reload the browser document to fetch
+the updated SPA. See [deployment](deployment.md), [Tailscale HTTPS](tailscale.md),
+and the [installation guide](index.md#quick-start) for the linked operator flow.
+
+## Corrective-release compatibility
+
+This corrective release keeps `agent-daemon` only as a bounded compatibility
+route. Existing Homebrew command users can run `agent-daemon --help`; it
+forwards to the installed `tmux-ws` binary without adding a second daemon.
+Existing NixOS configurations using `services.agent-daemon` are accepted as a
+renamed option and configure the single `services.tmux-ws` service.
+
+### Existing Homebrew users
+
+Existing `tmux-ws` users can update and upgrade the installed primary formula:
+
+```bash
+brew update
+brew upgrade tmux-ws
+tmux-ws --help
+```
+
+Existing legacy-only `agent-daemon` users must install the primary formula
+first, migrate scripts, then choose one compatibility path:
+
+```bash
+brew update
+brew install lambdasistemi/tap/tmux-ws
+tmux-ws --help
+# Keep the deprecated command alias temporarily:
+brew upgrade agent-daemon
+agent-daemon --help
+```
+
+Or, after migration, remove the compatibility formula:
+
+```bash
+brew uninstall agent-daemon
+tmux-ws --help
+```
+
+The deprecated `agent-daemon` formula is not the new-install default.
+
+### Existing NixOS users
+
+Rename `services.agent-daemon` to `services.tmux-ws` in your configuration,
+then rebuild and verify the single new unit:
+
+```bash
+sudo nixos-rebuild switch
+sudo systemctl restart tmux-ws
+systemctl status tmux-ws
+systemctl is-active tmux-ws
+```
+
+Do not start `agent-daemon.service`: the renamed option creates only
+`tmux-ws.service`.
+
+Move configurations and scripts to `services.tmux-ws`, `systemctl restart
+tmux-ws`, and `tmux-ws`. The legacy compatibility route is limited to this
+corrective release; its removal requires a separately reviewed migration ticket.

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -16,12 +16,12 @@ One-time step in the admin console:
 Go to [DNS settings](https://login.tailscale.com/admin/dns) and
 enable **HTTPS Certificates**.
 
-### 2. Bind agent-daemon to localhost
+### 2. Bind tmux-ws to localhost
 
 Keep the daemon off the public network:
 
 ```bash
-agent-daemon --host 127.0.0.1 --port 8080 --base-dir /path/to/worktrees
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir /path/to/worktrees
 ```
 
 ### 3. Start Tailscale Serve

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "WebSocket daemon for managing Claude Code agent sessions";
+  description = "tmux-ws browser SPA and tmux session daemon";
   inputs = {
     haskellNix.url = "github:input-output-hk/haskell.nix";
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
@@ -38,25 +38,106 @@
         mkdocsShell = dev-assets-mkdocs.devShells.${system}.default;
         mkdocsPackages = dev-assets-mkdocs.packages.${system};
         docs = pkgs.stdenv.mkDerivation {
-          name = "agent-daemon-docs";
+          name = "tmux-ws-docs";
           src = ./.;
-          buildInputs = [ mkdocsPackages.from-nixpkgs ];
+          buildInputs = [ mkdocsPackages.from-nixpkgs pkgs.python3 ];
           buildPhase = ''
-            mkdocs build -d $out
+            mkdocs build --strict -d $out
+            python3 - "$out" <<'PY'
+            from html.parser import HTMLParser
+            from pathlib import Path
+            from urllib.parse import unquote, urlsplit
+            import sys
+
+            root = Path(sys.argv[1])
+            failures = []
+
+            class Links(HTMLParser):
+                def __init__(self):
+                    super().__init__()
+                    self.hrefs, self.ids = [], set()
+                def handle_starttag(self, tag, attrs):
+                    data = dict(attrs)
+                    if tag == "a" and data.get("href"):
+                        self.hrefs.append(data["href"])
+                    if data.get("id"):
+                        self.ids.add(data["id"])
+
+            for page in root.rglob("*.html"):
+                parser = Links()
+                parser.feed(page.read_text())
+                for href in parser.hrefs:
+                    target = urlsplit(href)
+                    if target.scheme or target.netloc or href.startswith("mailto:"):
+                        continue
+                    path = unquote(target.path)
+                    if path.startswith("/tmux-ws/docs/"):
+                        path = path.removeprefix("/tmux-ws/docs/")
+                    elif path.startswith("/"):
+                        continue
+                    destination = page if not path else (page.parent / path)
+                    if destination.is_dir():
+                        destination /= "index.html"
+                    elif not destination.suffix:
+                        destination = destination / "index.html"
+                    if not destination.exists():
+                        failures.append(f"{page.relative_to(root)}: missing {href}")
+                        continue
+                    if target.fragment:
+                        target_parser = Links()
+                        target_parser.feed(destination.read_text())
+                        if target.fragment not in target_parser.ids:
+                            failures.append(f"{page.relative_to(root)}: missing anchor {href}")
+            if failures:
+                raise SystemExit("\n".join(failures))
+            PY
           '';
           dontInstall = true;
         };
-        site = pkgs.runCommand "agent-daemon-site" { } ''
+        site = pkgs.runCommand "tmux-ws-site" { } ''
           mkdir -p $out/docs
           cp -r ${project.packages.static}/* $out/
           cp -r ${docs}/* $out/docs/
         '';
+        mkModuleCheck = name: serviceConfig:
+          let
+            configuration = nixpkgs.lib.nixosSystem {
+              inherit system;
+              specialArgs = { inherit self; };
+              modules =
+                [ (import ./nix/module.nix { inherit self; }) serviceConfig ];
+            };
+            service = configuration.config.systemd.services."tmux-ws";
+            legacyUnit = if builtins.hasAttr "agent-daemon"
+            configuration.config.systemd.services then
+              "present"
+            else
+              "absent";
+          in pkgs.runCommand name { } ''
+            test '${legacyUnit}' = absent
+            test '${service.serviceConfig.User}' = agent-daemon
+            test '${service.serviceConfig.Group}' = agent-daemon
+            test '${service.serviceConfig.WorkingDirectory}' = /var/lib/agent-daemon
+            case '${service.serviceConfig.ExecStart}' in
+              */bin/tmux-ws\ *) ;;
+              *) echo 'module contract: primary unit must execute bin/tmux-ws' >&2; exit 1 ;;
+            esac
+            touch $out
+          '';
       in {
         packages = project.packages // {
           default = project.packages.tmux-ws;
           inherit docs site;
         };
-        checks = builtins.removeAttrs checksWithApps [ "apps" ];
+        checks = (builtins.removeAttrs checksWithApps [ "apps" ])
+          // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+            module-canonical = mkModuleCheck "module-canonical" {
+              services.tmux-ws.enable = true;
+            };
+            module-legacy = mkModuleCheck "module-legacy" {
+              services.agent-daemon.enable = true;
+            };
+          };
         apps = import ./nix/apps.nix {
           inherit pkgs;
           checks = checksWithApps;

--- a/flake.nix
+++ b/flake.nix
@@ -53,13 +53,14 @@
         '';
       in {
         packages = project.packages // {
-          default = project.packages.main;
+          default = project.packages.tmux-ws;
           inherit docs site;
         };
         checks = builtins.removeAttrs checksWithApps [ "apps" ];
         apps = import ./nix/apps.nix {
           inherit pkgs;
           checks = checksWithApps;
+          packages = project.packages;
         };
         devShells.default = project.devShells.default.overrideAttrs (old: {
           nativeBuildInputs = (old.nativeBuildInputs or [ ])

--- a/gate.sh
+++ b/gate.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix flake check --no-eval-cache
-nix develop --quiet -c cabal build all -O0

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix flake check --no-eval-cache
+nix develop --quiet -c cabal build all -O0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
   - Design: design.md
   - Deployment: deployment.md
   - Tailscale HTTPS: tailscale.md
+  - Release and migration: release.md
 
 markdown_extensions:
   - pymdownx.highlight

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -1,5 +1,18 @@
-{ pkgs, checks }:
-builtins.mapAttrs (_: app: {
+{ pkgs, checks, packages }:
+(builtins.mapAttrs (_: app: {
   type = "app";
   program = pkgs.lib.getExe app;
-}) checks.apps
+}) checks.apps) // {
+  default = {
+    type = "app";
+    program = pkgs.lib.getExe packages.tmux-ws;
+  };
+  tmux-ws = {
+    type = "app";
+    program = pkgs.lib.getExe packages.tmux-ws;
+  };
+  agent-daemon = {
+    type = "app";
+    program = pkgs.lib.getExe packages.agent-daemon;
+  };
+}

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -2,9 +2,11 @@
 let
   scripts = {
     haskell-build = {
-      runtimeInputs = [ components.exes.agent-daemon ];
+      runtimeInputs = [ components.exes.tmux-ws components.exes.agent-daemon ];
       text = ''
         test -e ${components.library}
+        test -x ${components.exes.tmux-ws}/bin/tmux-ws
+        tmux-ws --help >/dev/null
         test -x ${components.exes.agent-daemon}/bin/agent-daemon
         agent-daemon --help >/dev/null
       '';
@@ -40,7 +42,7 @@ let
         pkgs.nixfmt-classic
       ];
       text = ''
-        diff -u agent-daemon.cabal <(cabal-fmt agent-daemon.cabal)
+        diff -u tmux-ws.cabal <(cabal-fmt tmux-ws.cabal)
         find src app -type f -name '*.hs' -exec fourmolu -m check {} +
         nixfmt --check flake.nix nix/*.nix
       '';
@@ -264,7 +266,7 @@ let
           "$version_preflight" \
           'CI manifest drift guard'
 
-        assert_version_contract "$manifest" agent-daemon.cabal current
+        assert_version_contract "$manifest" tmux-ws.cabal current
         future_version_dir="$(mktemp -d)"
         trap 'rm -rf "$future_version_dir"' EXIT
         printf '{".":"0.2.0"}\n' > "$future_version_dir/manifest.json"

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -608,6 +608,93 @@ let
         fi
       '';
     };
+
+    docs-service-contract = {
+      runtimeInputs = [ pkgs.coreutils pkgs.gnugrep ];
+      text = ''
+        set -euo pipefail
+
+        module=nix/module.nix
+        readme=README.md
+        docs_index=docs/index.md
+        deployment=docs/deployment.md
+        tailscale=docs/tailscale.md
+        release_guide=docs/release.md
+        mkdocs=mkdocs.yml
+        failures=0
+
+        require_literal() {
+          local file="$1"
+          local literal="$2"
+          local label="$3"
+
+          if ! grep -Fq "$literal" "$file"; then
+            printf 'docs/service contract: missing %s\n' "$label" >&2
+            failures=1
+          fi
+        }
+
+        require_file() {
+          local file="$1"
+          local label="$2"
+
+          if ! test -f "$file"; then
+            printf 'docs/service contract: missing %s\n' "$label" >&2
+            failures=1
+          fi
+        }
+
+        reject_literal() {
+          local file="$1"
+          local literal="$2"
+          local label="$3"
+
+          if grep -Fq "$literal" "$file"; then
+            printf 'docs/service contract: forbidden %s\n' "$label" >&2
+            failures=1
+          fi
+        }
+
+        require_literal "$module" 'options.services.tmux-ws' 'primary services.tmux-ws module option'
+        require_literal "$module" 'systemd.services.tmux-ws' 'primary tmux-ws systemd unit'
+        require_literal "$module" '/bin/tmux-ws' 'primary tmux-ws service binary'
+        require_literal "$module" 'mkRenamedOptionModule' 'legacy service migration route'
+        require_literal "$module" 'default = "/var/lib/agent-daemon"' 'private legacy state allowance'
+        require_literal "$module" 'default = "agent-daemon"' 'private legacy account allowance'
+        reject_literal "$module" 'systemd.services.agent-daemon' 'legacy primary systemd unit'
+        reject_literal "$module" '/bin/agent-daemon' 'legacy primary service binary'
+        require_literal "$readme" 'tmux-ws --host' 'README primary command'
+        reject_literal "$readme" 'agent-daemon' 'README legacy primary text'
+        require_literal "$docs_index" 'tmux-ws --host' 'index primary command'
+        reject_literal "$docs_index" 'agent-daemon' 'index legacy primary text'
+        require_literal "$deployment" 'services.tmux-ws' 'deployment primary service configuration'
+        reject_literal "$deployment" 'systemctl enable --now agent-daemon' 'deployment legacy service command'
+        reject_literal "$deployment" '/bin/agent-daemon' 'deployment legacy binary command'
+        require_literal "$tailscale" 'tmux-ws --host' 'Tailscale primary command'
+        reject_literal "$tailscale" 'agent-daemon --host' 'Tailscale legacy primary command'
+        require_file "$release_guide" 'release operator guide'
+        if test -f "$release_guide"; then
+        require_literal "$release_guide" 'brew install lambdasistemi/tap/tmux-ws' 'release Homebrew install command'
+          require_literal "$release_guide" 'brew update' 'release Homebrew update command'
+          require_literal "$release_guide" 'brew upgrade tmux-ws' 'release Homebrew upgrade command'
+          require_literal "$release_guide" 'brew upgrade agent-daemon' 'legacy compatibility-alias upgrade path'
+          require_literal "$release_guide" 'brew uninstall agent-daemon' 'legacy compatibility-alias removal path'
+          # Assert the Markdown code span and publication promise independently.
+          # shellcheck disable=SC2016
+          require_literal "$release_guide" '`v0.3.0`' 'immutable publication version code span'
+          require_literal "$release_guide" 'will not be rewritten or deleted' 'immutable no-rewrite/no-delete promise'
+          require_literal "$release_guide" 'v0.3.1' 'corrective publication version'
+          require_literal "$release_guide" 'update the real Homebrew tap' 'corrective tap publication boundary'
+          require_literal "$release_guide" 'corrective release' 'legacy compatibility duration'
+          require_literal "$release_guide" 'separately reviewed migration ticket' 'legacy removal policy'
+        fi
+        require_literal "$mkdocs" 'release.md' 'release guide navigation entry'
+
+        if test "$failures" -ne 0; then
+          exit 1
+        fi
+      '';
+    };
   };
 
   mkApp = name:
@@ -639,5 +726,7 @@ in {
   workflow-lint = mkCheck "workflow-lint" scripts.workflow-lint;
   release-product-name =
     mkCheck "release-product-name" scripts.release-product-name;
+  docs-service-contract =
+    mkCheck "docs-service-contract" scripts.docs-service-contract;
   inherit apps;
 }

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -102,6 +102,7 @@ let
         sync_workflow=.github/workflows/sync-cabal-version.yml
         manifest=.release-please-manifest.json
         release_config=release-please-config.json
+        dollar='$'
 
         assert_eq() {
           local actual="$1"
@@ -418,7 +419,22 @@ let
         # shellcheck disable=SC2016
         grep -Fq '"$binary" --help' "$darwin_workflow"
         grep -Fq 'brew trust lambdasistemi/tap' "$darwin_workflow"
-        grep -Fq 'agent-daemon --help' "$darwin_workflow"
+        grep -Fq 'tmux-ws.cabal' "$darwin_workflow"
+        grep -Fq "tmux-ws-$dollar{VERSION}-aarch64-darwin.tar.gz" "$darwin_workflow"
+        grep -Fq 'bin/tmux-ws' "$darwin_workflow"
+        grep -Fq 'bash scripts/render-homebrew-formulas.sh' "$darwin_workflow"
+        grep -Fq 'Formula/tmux-ws.rb' "$darwin_workflow"
+        grep -Fq 'brew install --formula lambdasistemi/tap/tmux-ws' "$darwin_workflow"
+        grep -Fq 'tmux-ws --help' "$darwin_workflow"
+        if grep -Fq 'class TmuxWs < Formula' "$darwin_workflow" \
+          || grep -Fq 'class AgentDaemon < Formula' "$darwin_workflow"; then
+          echo 'workflow contract: Darwin formula semantics must live in the shared renderer' >&2
+          exit 1
+        fi
+        if grep -Fq 'bin.write_exec_script Formula["tmux-ws"].opt_bin/"tmux-ws"' "$darwin_workflow"; then
+          echo 'workflow contract: legacy formula must not install a conflicting wrapper' >&2
+          exit 1
+        fi
 
         assert_eq \
           "$(yq -r \
@@ -440,6 +456,156 @@ let
         # Assert literal workflow source; expansion would make this weaker.
         # shellcheck disable=SC2016
         grep -Fq 'git push origin "HEAD:''${GITHUB_HEAD_REF}"' "$sync_workflow"
+      '';
+    };
+
+    release-product-name = {
+      runtimeInputs =
+        [ pkgs.bash pkgs.coreutils pkgs.gnugrep pkgs.gnutar pkgs.jq ];
+      text = ''
+        set -euo pipefail
+
+        darwin_workflow=.github/workflows/darwin-release.yml
+        release_workflow=.github/workflows/release.yml
+        sync_workflow=.github/workflows/sync-cabal-version.yml
+        ci_workflow=.github/workflows/ci.yml
+        renderer=scripts/render-homebrew-formulas.sh
+        dollar='$'
+        failures=0
+
+        require_literal() {
+          local file="$1"
+          local literal="$2"
+          local label="$3"
+
+          if ! grep -Fq "$literal" "$file"; then
+            printf 'release product contract: missing %s\n' "$label" >&2
+            failures=1
+          fi
+        }
+
+        reject_literal() {
+          local file="$1"
+          local literal="$2"
+          local label="$3"
+
+          if grep -Fq "$literal" "$file"; then
+            printf 'release product contract: forbidden %s\n' "$label" >&2
+            failures=1
+          fi
+        }
+
+        require_literal "$darwin_workflow" 'tmux-ws.cabal' 'Darwin tmux-ws Cabal manifest'
+        require_literal "$darwin_workflow" 'bin/tmux-ws' 'Darwin primary binary'
+        require_literal "$darwin_workflow" "tmux-ws-$dollar{VERSION}-aarch64-darwin.tar.gz" 'Darwin primary archive'
+        require_literal "$darwin_workflow" 'bash scripts/render-homebrew-formulas.sh' 'Darwin shared Homebrew renderer invocation'
+        require_literal "$darwin_workflow" 'brew install --formula lambdasistemi/tap/tmux-ws' 'primary Homebrew install'
+        require_literal "$darwin_workflow" 'tmux-ws --help' 'primary Homebrew smoke'
+        reject_literal "$darwin_workflow" 'class TmuxWs < Formula' 'inline primary Homebrew formula semantics'
+        reject_literal "$darwin_workflow" 'class AgentDaemon < Formula' 'inline legacy Homebrew formula semantics'
+        reject_literal "$darwin_workflow" 'bin.write_exec_script Formula["tmux-ws"].opt_bin/"tmux-ws"' 'legacy formula conflicting wrapper'
+        require_literal "$release_workflow" '.user.login == "app/lambdasistemi-ci"' 'recovery App author identity'
+        require_literal "$release_workflow" '.author.login == "app/lambdasistemi-ci"' 'cleanup App author identity'
+        require_literal "$release_workflow" 'tmux-ws.cabal' 'release recovery Cabal manifest'
+        require_literal "$sync_workflow" 'tmux-ws.cabal' 'sync Cabal manifest'
+        require_literal "$ci_workflow" './tmux-ws.cabal' 'CI Cabal manifest'
+        # Assert literal workflow source; expansion would make this weaker.
+        # shellcheck disable=SC2016
+        require_literal "$ci_workflow" 'brew tap-new "$tap"' 'temporary local Git tap registration'
+        # Assert literal workflow source; expansion would make this weaker.
+        # shellcheck disable=SC2016
+        require_literal "$ci_workflow" 'brew install --formula "$tap/agent-daemon"' 'temporary local-tap legacy formula install'
+        # Assert literal workflow source; expansion would make this weaker.
+        # shellcheck disable=SC2016
+        require_literal "$ci_workflow" 'brew install --formula "$tap/tmux-ws"' 'temporary local-tap primary formula install'
+        require_literal "$ci_workflow" 'tmux-ws --help' 'temporary local-tap primary formula smoke'
+        require_literal "$ci_workflow" 'agent-daemon --help' 'temporary local-tap legacy formula smoke'
+        # Assert literal workflow source; expansion would make this weaker.
+        # shellcheck disable=SC2016
+        require_literal "$ci_workflow" 'test ! -e "$agent_daemon_prefix/bin/tmux-ws"' 'legacy keg collision absence'
+        require_literal "$ci_workflow" "stat -L -f '%d:%i' \"\$agent_daemon_link\"" 'legacy forwarder resolved identity'
+        require_literal "$ci_workflow" "stat -L -f '%d:%i' \"\$tmux_ws_link\"" 'primary binary resolved identity'
+        require_literal "$ci_workflow" "test \"\$agent_daemon_identity\" = \"\$tmux_ws_identity\"" 'legacy forwarder resolves to primary binary'
+
+        assert_selector() {
+          local selector="$1"
+          local payload="$2"
+          local expected="$3"
+          local label="$4"
+          local actual
+
+          actual="$(printf '%s\n' "$payload" | jq -r "$selector")"
+          if test "$actual" != "$expected"; then
+            printf 'release product contract: %s: expected %s, got %s\n' \
+              "$label" "$expected" "$actual" >&2
+            failures=1
+          fi
+        }
+
+        recovery_selector='if (.user.login == "lambdasistemi-ci[bot]" or .user.login == "app/lambdasistemi-ci") then "accepted" else "rejected" end'
+        cleanup_selector='if (.author.login == "lambdasistemi-ci[bot]" or .author.login == "app/lambdasistemi-ci") then "accepted" else "rejected" end'
+        assert_selector "$recovery_selector" '{"user":{"login":"lambdasistemi-ci[bot]"}}' accepted 'recovery bot author'
+        assert_selector "$recovery_selector" '{"user":{"login":"app/lambdasistemi-ci"}}' accepted 'recovery App author'
+        assert_selector "$recovery_selector" '{"user":{"login":"unrelated-ci[bot]"}}' rejected 'recovery unrelated bot'
+        assert_selector "$cleanup_selector" '{"author":{"login":"lambdasistemi-ci[bot]"}}' accepted 'cleanup bot author'
+        assert_selector "$cleanup_selector" '{"author":{"login":"app/lambdasistemi-ci"}}' accepted 'cleanup App author'
+        assert_selector "$cleanup_selector" '{"author":{"login":"unrelated-ci[bot]"}}' rejected 'cleanup unrelated bot'
+
+        proof_root="$(mktemp -d)"
+        trap 'rm -rf "$proof_root"' EXIT
+        bundle="$proof_root/bundle"
+        mkdir -p "$bundle/bin"
+        cat > "$bundle/bin/tmux-ws" <<'EOF'
+        #!${pkgs.runtimeShell}
+        if test "$1" = --help; then
+          echo 'tmux-ws help'
+        fi
+        EOF
+        chmod +x "$bundle/bin/tmux-ws"
+
+        version=0.3.1
+        archive="$proof_root/tmux-ws-$version-aarch64-darwin.tar.gz"
+        tar -C "$bundle" -czf "$archive" .
+        test -f "$archive"
+        tar -tzf "$archive" | grep -Fx './bin/tmux-ws' >/dev/null
+        mkdir "$proof_root/extract"
+        tar -C "$proof_root/extract" -xzf "$archive"
+        "$proof_root/extract/bin/tmux-ws" --help >/dev/null
+
+        formula_dir="$proof_root/formulas"
+        bash "$renderer" \
+          "$formula_dir" \
+          "https://example.invalid/tmux-ws-$version-aarch64-darwin.tar.gz" \
+          0000000000000000000000000000000000000000000000000000000000000000 \
+          "$version"
+        formula="$formula_dir/tmux-ws.rb"
+        grep -Fqx 'class TmuxWs < Formula' "$formula"
+        grep -Fqx "  url \"https://example.invalid/tmux-ws-$version-aarch64-darwin.tar.gz\"" "$formula"
+        grep -Fqx '  sha256 "0000000000000000000000000000000000000000000000000000000000000000"' "$formula"
+        grep -Fqx "  version \"$version\"" "$formula"
+        grep -Fqx '    bin.install "bin/tmux-ws"' "$formula"
+        grep -Fqx '    system "#{bin}/tmux-ws", "--help"' "$formula"
+
+        legacy_formula="$formula_dir/agent-daemon.rb"
+        grep -Fqx 'class AgentDaemon < Formula' "$legacy_formula"
+        grep -Fqx "  url \"https://example.invalid/tmux-ws-$version-aarch64-darwin.tar.gz\"" "$legacy_formula"
+        grep -Fqx '  sha256 "0000000000000000000000000000000000000000000000000000000000000000"' "$legacy_formula"
+        grep -Fqx "  version \"$version\"" "$legacy_formula"
+        grep -Fqx '  depends_on "tmux-ws"' "$legacy_formula"
+        grep -Fqx '    bin.install_symlink Formula["tmux-ws"].opt_bin/"tmux-ws" => "agent-daemon"' "$legacy_formula"
+        grep -Fqx '      agent-daemon is deprecated; use tmux-ws.' "$legacy_formula"
+        if grep -Fq 'bin.install "bin/tmux-ws"' "$legacy_formula"; then
+          printf 'release product contract: legacy formula installs a conflicting tmux-ws binary\n' >&2
+          failures=1
+        fi
+        if grep -Fq 'bin.write_exec_script Formula["tmux-ws"].opt_bin/"tmux-ws"' "$legacy_formula"; then
+          printf 'release product contract: legacy formula has a conflicting wrapper\n' >&2
+          failures=1
+        fi
+
+        if test "$failures" -ne 0; then
+          exit 1
+        fi
       '';
     };
   };
@@ -471,5 +637,7 @@ in {
   cabal-package = mkCheck "cabal-package" scripts.cabal-package;
   ui = mkCheck "ui" scripts.ui;
   workflow-lint = mkCheck "workflow-lint" scripts.workflow-lint;
+  release-product-name =
+    mkCheck "release-product-name" scripts.release-product-name;
   inherit apps;
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,9 +1,16 @@
 { self }:
 { config, lib, pkgs, ... }:
-let cfg = config.services.agent-daemon;
+let cfg = config.services.tmux-ws;
 in {
-  options.services.agent-daemon = {
-    enable = lib.mkEnableOption "agent-daemon";
+  imports = [
+    (lib.mkRenamedOptionModule [ "services" "agent-daemon" ] [
+      "services"
+      "tmux-ws"
+    ])
+  ];
+
+  options.services.tmux-ws = {
+    enable = lib.mkEnableOption "tmux-ws";
 
     host = lib.mkOption {
       type = lib.types.str;
@@ -32,7 +39,7 @@ in {
     package = lib.mkOption {
       type = lib.types.package;
       default = self.packages.${pkgs.system}.default;
-      description = "The agent-daemon package to use.";
+      description = "The tmux-ws package to use.";
     };
 
     user = lib.mkOption {
@@ -72,8 +79,8 @@ in {
 
     users.groups.${cfg.group} = lib.mkIf cfg.createUser { };
 
-    systemd.services.agent-daemon = {
-      description = "Agent daemon — Claude Code session manager";
+    systemd.services.tmux-ws = {
+      description = "tmux-ws — browser SPA and tmux session daemon";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
@@ -92,7 +99,7 @@ in {
             toString cfg.port
           }/tcp 2>/dev/null) 2>/dev/null || true'";
         ExecStart = lib.concatStringsSep " " [
-          "${cfg.package}/bin/agent-daemon"
+          "${cfg.package}/bin/tmux-ws"
           "--host ${cfg.host}"
           "--port ${toString cfg.port}"
           "--base-dir ${cfg.baseDir}"

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -3,10 +3,10 @@ let
   planProject = pkgs.haskell-nix.cabalProject' {
     src = pkgs.haskell-nix.cleanSourceHaskell {
       src = ./..;
-      name = "agent-daemon";
+      name = "tmux-ws";
     };
     compiler-nix-name = "ghc984";
-    modules = [{ packages.agent-daemon.flags.development-warnings = true; }];
+    modules = [{ packages.tmux-ws.flags.development-warnings = true; }];
     shell = { ... }: {
       tools = {
         cabal = { };
@@ -104,9 +104,11 @@ let
     '';
   };
 in {
-  components = project.hsPkgs.agent-daemon.components;
+  components = project.hsPkgs.tmux-ws.components;
   packages = {
-    main = project.hsPkgs.agent-daemon.components.exes.agent-daemon;
+    main = project.hsPkgs.tmux-ws.components.exes.tmux-ws;
+    tmux-ws = project.hsPkgs.tmux-ws.components.exes.tmux-ws;
+    agent-daemon = project.hsPkgs.tmux-ws.components.exes.agent-daemon;
     inherit static uiBuild uiNodeModules;
   };
   devShells.default = project.shell;

--- a/scripts/render-homebrew-formulas.sh
+++ b/scripts/render-homebrew-formulas.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+out_dir=${1:?usage: render-homebrew-formulas.sh OUT_DIR URL SHA256 VERSION}
+url=${2:?usage: render-homebrew-formulas.sh OUT_DIR URL SHA256 VERSION}
+sha256=${3:?usage: render-homebrew-formulas.sh OUT_DIR URL SHA256 VERSION}
+version=${4:?usage: render-homebrew-formulas.sh OUT_DIR URL SHA256 VERSION}
+
+mkdir -p "$out_dir"
+
+cat > "$out_dir/tmux-ws.rb" <<EOF
+class TmuxWs < Formula
+  desc "WebSocket daemon for managing tmux workspaces"
+  homepage "https://github.com/lambdasistemi/tmux-ws"
+  url "$url"
+  sha256 "$sha256"
+  version "$version"
+
+  def install
+    bin.install "bin/tmux-ws"
+    (libexec/"lib").install Dir["libexec/lib/*"]
+  end
+
+  test do
+    system "#{bin}/tmux-ws", "--help"
+  end
+end
+EOF
+
+cat > "$out_dir/agent-daemon.rb" <<EOF
+class AgentDaemon < Formula
+  desc "Deprecated compatibility route; install tmux-ws instead"
+  homepage "https://github.com/lambdasistemi/tmux-ws"
+  url "$url"
+  sha256 "$sha256"
+  version "$version"
+  depends_on "tmux-ws"
+
+  def install
+    bin.install_symlink Formula["tmux-ws"].opt_bin/"tmux-ws" => "agent-daemon"
+  end
+
+  def caveats
+    <<~EOS
+      agent-daemon is deprecated; use tmux-ws.
+    EOS
+  end
+end
+EOF

--- a/specs/095-release-product-name/checklists/requirements.md
+++ b/specs/095-release-product-name/checklists/requirements.md
@@ -1,0 +1,25 @@
+# Specification Quality Checklist: tmux-ws public release identity
+
+**Purpose**: Validate specification completeness before paired implementation
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] Focuses on observable operator outcomes and bounded compatibility.
+- [X] All mandatory specification sections are complete.
+- [X] Scope distinguishes public release surfaces from private identifiers.
+
+## Requirement Completeness
+
+- [X] No clarification markers remain; issue and parent brief make scope and
+  release boundaries explicit.
+- [X] Each requirement has a named proof or artifact.
+- [X] Scenarios cover installation, compatibility, Darwin/Homebrew, recovery,
+  and service/docs migration.
+
+## Feature Readiness
+
+- [X] Every requirement maps to `tasks.md`.
+- [X] Three serial slices are owned and independently RED→GREEN verifiable.
+- [X] Plan includes full gate, hosted CI, docs, package, formula, and release evidence.

--- a/specs/095-release-product-name/contracts/release-surfaces.md
+++ b/specs/095-release-product-name/contracts/release-surfaces.md
@@ -1,0 +1,13 @@
+# Public release-surface contract
+
+| Surface | Canonical contract | Compatibility contract | Proof |
+|---|---|---|---|
+| Cabal/Nix | Package/default executable `tmux-ws`; `tmux-ws --help` | `agent-daemon --help` reaches the same daemon | Packaged check/app |
+| Darwin | `tmux-ws-<version>-aarch64-darwin.tar.gz`; `bin/tmux-ws` | Legacy binary only as documented compatibility | Non-publishing layout smoke |
+| Homebrew | `brew install lambdasistemi/tap/tmux-ws`; `TmuxWs` | Deprecated `agent-daemon` route | Formula smoke/source guard |
+| NixOS | `services.tmux-ws`; `tmux-ws.service` | Legacy option/service migration | Module evaluation |
+| Docs | New instructions lead with `tmux-ws` | Separate migration section | Strict docs/name guard |
+| Recovery | Exact generated PR with either App identity | No broad bot match | Positive/negative selectors |
+
+`AgentDaemon` source namespaces, browser local-storage keys, and private test
+fixture names are explicitly outside this contract.

--- a/specs/095-release-product-name/plan.md
+++ b/specs/095-release-product-name/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: tmux-ws public release identity
+
+**Branch**: `fix/95-release-product-name` | **Date**: 2026-07-13 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Replace the public package/executable/archive/formula/service identity with
+`tmux-ws`, preserve a bounded `agent-daemon` compatibility path, and make
+flake-owned release/docs checks reject regressions. Work is three serial slices
+because `nix/checks.nix` protects every later release and documentation surface.
+
+## Technical Context
+
+**Language/Version**: Nix, Cabal/Haskell GHC 9.8.4, Bash, Ruby formula text, Markdown/YAML
+**Primary Dependencies**: haskell.nix, release-please, GitHub App tokens, Homebrew, MkDocs
+**Testing**: Flake checks/apps, Cabal build, strict MkDocs, actionlint/shellcheck, Darwin CI package smoke
+**Target Platform**: Linux Nix verification and macOS 14 Darwin/Homebrew verification
+**Constraints**: no merge/publish/tag mutation; preserve v0.3.0 and internal namespaces/keys
+
+## Constitution Check
+
+Pass. No API, WebSocket, terminal, UI, or data-model change is planned. The
+existing quality gate is strengthened through flake-owned checks, strict docs,
+and a separate real development-shell build.
+
+## Compatibility Decision
+
+The primary package, executable, default flake app, Darwin archive, formula,
+and NixOS service are `tmux-ws`. This corrective patch ships a tested
+`agent-daemon` command alias plus deprecated legacy formula/service route.
+Documentation names the replacement and states that removal needs a separately
+reviewed migration ticket. The compatibility path is never a new-install path.
+
+## Source Areas
+
+- Cabal/Nix: `agent-daemon.cabal` → `tmux-ws.cabal`, `nix/project.nix`,
+  `nix/checks.nix`, `nix/apps.nix`, `nix/module.nix`, and `flake.nix` only when
+  output wiring requires it.
+- Release: `.github/workflows/darwin-release.yml`,
+  `.github/workflows/release.yml`, and sync workflow only if manifest rename
+  requires it.
+- Docs: `README.md`, `docs/index.md`, `docs/deployment.md`,
+  `docs/tailscale.md`, new `docs/release.md`, and `mkdocs.yml`.
+
+## Slice 1 — Canonical package and executable
+
+**Commit**: `fix(package): make tmux-ws the canonical executable`
+**Tasks**: T001, T002, T003
+
+1. Driver writes focused RED package assertions that fail because the baseline
+   default output and help command are `agent-daemon`.
+2. Driver changes only public package/executable wiring so default package/app
+   are `tmux-ws`, while `agent-daemon` remains a tested compatibility executable
+   invoking the same daemon entry point. No module or browser-key rename.
+3. Navigator requires captured RED output, Green packaged commands for both
+   names, Cabal validation, focused flake app/check, and `./gate.sh` before one
+   commit.
+
+## Slice 2 — Darwin, Homebrew, and release recovery
+
+**Commit**: `fix(release): publish tmux-ws distribution surfaces`
+**Tasks**: T004, T005, T006
+
+1. Driver adds RED checks for legacy archive/binary/formula names and missing
+   `app/lambdasistemi-ci` author recognition, with positive and negative
+   selector data rather than source grep alone.
+2. Driver makes Darwin generate canonical archive and `TmuxWs` formula, retains
+   a deprecated `agent-daemon` formula route and all dylib/layout hardening,
+   and keeps publication gated to a real immutable tag.
+3. Driver adds/factors a non-publishing macOS-equivalent package/formula smoke
+   for archive contents, canonical help, and primary Homebrew install without
+   upload or tap mutation. Recovery accepts exactly both App forms and retains
+   all other guards.
+
+## Slice 3 — Service migration, docs, and current-surface guard
+
+**Commit**: `docs: lead operators with tmux-ws`
+**Tasks**: T007, T008, T009, T010
+
+1. Driver records a RED current-surface/docs guard that distinguishes allowed
+   migration text from new-install guidance and private identifiers.
+2. Driver exposes `tmux-ws` as primary NixOS option/service while retaining an
+   evaluated legacy route; it documents exact conversion and removal policy.
+3. Driver updates every current operator/install/deployment/Tailscale surface,
+   adds a release guide, leads all new paths with `tmux-ws`, adds migration
+   guidance, and enables strict docs/link/anchor validation.
+4. Navigator requires strict docs proof, module compatibility proof, focused
+   naming/release check, and full `./gate.sh` before one commit.
+
+## Verification Plan
+
+- Every slice captures a real RED failure before the smallest Green change.
+- Focused commands cover packaged `tmux-ws --help`, legacy alias,
+  release-product-name check, workflow lint, and strict docs build.
+- `./gate.sh` is full repository evidence: `git diff --check`,
+  `nix flake check --no-eval-cache`, and
+  `nix develop --quiet -c cabal build all -O0`.
+- The PR remains draft until local gate, exact-head hosted CI, Darwin
+  non-publishing proof, formula smoke, and docs proof are recorded.
+
+## Release Procedure After Merge
+
+1. Confirm v0.3.0 tag, release, and historical asset remain unchanged.
+2. Let release-please open the next patch PR; verify generated version,
+   changelog, and installation/deployment links.
+3. Epic owner merges that generated release PR, creating the new immutable tag.
+4. Invoke Darwin publication only with the new tag; verify archive, primary
+   formula/smoke, and deprecated legacy formula route.
+5. Record release URL, digest, formula commit, and migration evidence on #95/#80.

--- a/specs/095-release-product-name/quickstart.md
+++ b/specs/095-release-product-name/quickstart.md
@@ -1,0 +1,16 @@
+# Verification quickstart
+
+Run these commands after the relevant slice is green:
+
+```bash
+nix build --quiet .#default
+./result/bin/tmux-ws --help
+./result/bin/agent-daemon --help
+nix run --quiet .#workflow-lint
+nix run --quiet .#release-product-name
+nix build --quiet .#docs
+./gate.sh
+```
+
+The Darwin pull-request proof must validate the archive/formula path without
+`gh release upload`, tap push, tag/release creation, or any v0.3.0 mutation.

--- a/specs/095-release-product-name/research.md
+++ b/specs/095-release-product-name/research.md
@@ -1,0 +1,36 @@
+# Research: tmux-ws release product name
+
+## Canonical package with bounded executable compatibility
+
+Use `tmux-ws` for the Cabal package, Nix default, and primary executable.
+Ship `agent-daemon` as a tested compatibility executable that reaches the same
+daemon entry point for this patch only. Silent removal breaks scripts; renaming
+internal modules or browser keys creates unnecessary state risk.
+
+## Primary and deprecated Homebrew formulas
+
+The tap currently contains only `Formula/agent-daemon.rb` for immutable v0.3.0.
+The publisher must generate `Formula/tmux-ws.rb` for the new archive and retain
+`Formula/agent-daemon.rb` as an explicit deprecated route to the canonical
+formula. The primary smoke is always `brew install lambdasistemi/tap/tmux-ws`.
+
+## Flake-owned source guard plus non-publishing package proof
+
+The flake must reject source regressions of name, archive, formula, docs, and
+author selector. A Darwin CI dry-run/equivalent must validate the actual
+archive/formula contract without release upload or tap write. `./gate.sh` runs
+the complete flake check plus a real development-shell build.
+
+## Exact GitHub App author predicate
+
+The existing selector accepts only `lambdasistemi-ci[bot]`. Accept both that
+and `app/lambdasistemi-ci`, retaining merged, main-base, generated-head,
+title/version, time, and one-match constraints. Do not broaden to arbitrary
+bots or branch-only matching.
+
+## Primary NixOS service with legacy route
+
+Use `services.tmux-ws` and `tmux-ws.service` as the current contract. Retain
+the old configuration/service route as an explicitly documented, evaluated
+compatibility migration; do not rename private service account/state merely
+for product-name consistency.

--- a/specs/095-release-product-name/spec.md
+++ b/specs/095-release-product-name/spec.md
@@ -1,0 +1,154 @@
+# Feature Specification: tmux-ws public release identity
+
+**Feature Branch**: `fix/95-release-product-name`
+**Created**: 2026-07-13
+**Status**: Planned
+**Input**: Issue #95 and parent epic #80
+
+## User Scenarios & Testing
+
+### User Story 1 - Install the named product (Priority: P1)
+
+As a new operator, I install and run `tmux-ws` rather than the historical
+implementation name, while an existing script that invokes `agent-daemon`
+continues to work during this corrective patch release.
+
+**Why this priority**: The executable and package identity are the primary
+operator-facing contract.
+
+**Independent Test**: Build the default packaged output, run
+`tmux-ws --help`, run the compatibility `agent-daemon --help`, and prove that
+the package/default app and checks select `tmux-ws` as primary.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new Nix or Cabal installation, **When** the operator follows
+   the primary command, **Then** `tmux-ws --help` succeeds and all public
+   package metadata names `tmux-ws`.
+2. **Given** an existing operator automation that runs `agent-daemon`, **When**
+   it is upgraded to this patch release, **Then** the compatibility command
+   runs the same daemon and its temporary status is explicit in the docs.
+
+---
+
+### User Story 2 - Receive a safe macOS/Homebrew corrective release (Priority: P1)
+
+As a macOS operator, I receive a new immutable patch asset and a `tmux-ws`
+Homebrew formula whose installed command works, without rewriting `v0.3.0` or
+publishing from a pull request.
+
+**Why this priority**: The faulty Darwin asset and tap formula are the direct
+customer impact behind #95.
+
+**Independent Test**: A non-publishing release/package proof validates the
+new archive name and `bin/tmux-ws`, generated `TmuxWs` formula and clean
+`brew install lambdasistemi/tap/tmux-ws` smoke contract. Contract checks also
+exercise both supported GitHub App author shapes in release recovery.
+
+**Acceptance Scenarios**:
+
+1. **Given** a patch tag created after this PR merges, **When** Darwin
+   publication runs, **Then** it uploads
+   `tmux-ws-<version>-aarch64-darwin.tar.gz` containing `bin/tmux-ws` to the
+   already-created release.
+2. **Given** a clean Homebrew environment, **When** the operator installs
+   `lambdasistemi/tap/tmux-ws`, **Then** `tmux-ws --help` succeeds; the old
+   formula is an explicit compatibility/migration route rather than the
+   primary formula.
+3. **Given** release-please recovery sees a merged generated PR authored as
+   either `lambdasistemi-ci[bot]` or `app/lambdasistemi-ci`, **When** the
+   matching release state is recovered, **Then** it recognizes only that
+   exact generated PR and removes no unrelated PR.
+
+---
+
+### User Story 3 - Follow current installation and service documentation (Priority: P2)
+
+As a new or upgrading operator, I find `tmux-ws` first in README, install,
+deployment, Tailscale, release, and NixOS service instructions, with a
+separate migration section for historical names.
+
+**Why this priority**: A corrected package that docs still teach under the old
+name recreates the incident for new operators.
+
+**Independent Test**: Build documentation in strict mode, resolve every
+installation/deployment link and anchor, and run source-level checks that
+reject `agent-daemon` in current-title, primary-command, archive, or formula
+surfaces while permitting the bounded migration section and private keys.
+
+**Acceptance Scenarios**:
+
+1. **Given** a first-time operator, **When** they open README or documentation
+   installation/deployment guidance, **Then** every primary command, package,
+   formula, and service title is `tmux-ws`.
+2. **Given** an existing NixOS service configuration, **When** it follows the
+   documented migration path, **Then** it can move to the new primary service
+   name without a silent outage; the legacy service path remains explicitly
+   documented and tested for this release.
+
+### Edge Cases
+
+- `v0.3.0`, its historical Darwin asset, and its tap formula remain immutable;
+  no task may delete, overwrite, or retag them.
+- Pull-request and dry-run paths must not upload assets or mutate the Homebrew
+  tap.
+- `AgentDaemon` namespaces, browser storage keys, and private test fixture
+  names remain unchanged unless proven to be a public package surface.
+- A generated release PR with a matching branch but an unrecognized author,
+  wrong base, wrong title, or ambiguous match must not be recovered or closed.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The canonical Cabal package, default Nix package/app, and
+  primary executable MUST be named `tmux-ws`; `tmux-ws --help` MUST be proven
+  from the packaged output.
+- **FR-002**: This patch release MUST retain an intentional, tested
+  `agent-daemon` compatibility command. It MUST NOT be the default package,
+  formula, command, or service title.
+- **FR-003**: Darwin publication MUST produce
+  `tmux-ws-<version>-aarch64-darwin.tar.gz` with `bin/tmux-ws`, validate its
+  installed layout, and publish only to an already-created immutable release.
+- **FR-004**: Homebrew publication MUST generate primary formula `tmux-ws`,
+  install and smoke `tmux-ws --help`, and provide an explicit compatibility
+  treatment for the historical `agent-daemon` formula.
+- **FR-005**: Release-please recovery and false-follow-on cleanup MUST accept
+  exactly `lambdasistemi-ci[bot]` and `app/lambdasistemi-ci`, while retaining
+  title, branch, base, time, and ambiguity guards.
+- **FR-006**: Automated checks MUST fail on regression of the primary package,
+  packaged help command, Darwin archive/binary, primary formula/install smoke,
+  current user-facing title/install command, or App-author cleanup selector.
+- **FR-007**: README and current installation, upgrade, deployment,
+  Tailscale, release, and operator documentation MUST lead with `tmux-ws`.
+  Historical text is allowed only in identified migration text or intentionally
+  private identifiers.
+- **FR-008**: The NixOS module MUST expose `tmux-ws` as the primary service
+  configuration and preserve a documented, tested legacy service migration or
+  alias path.
+- **FR-009**: Documentation MUST build strictly and prove current
+  installation/release/deployment links and anchors resolve.
+- **FR-010**: The complete repository gate and focused naming/release proofs
+  MUST run before review. No pull-request execution may publish, merge, change
+  tap state, delete a release, or alter `v0.3.0`.
+
+## Success Criteria
+
+- **SC-001**: The default packaged output exposes `tmux-ws --help` with exit
+  status 0, and the compatibility command also exits 0.
+- **SC-002**: A non-publishing Darwin/Homebrew proof validates exactly one
+  `tmux-ws-<version>-aarch64-darwin.tar.gz`, `bin/tmux-ws`, the
+  `tmux-ws` formula, and `tmux-ws --help` with no tap mutation.
+- **SC-003**: Strict documentation build and link/anchor validation finish
+  with zero errors; every current installation command uses the canonical name.
+- **SC-004**: The full repository gate and all hosted required CI jobs succeed
+  on the final PR head before the PR becomes ready.
+
+## Assumptions
+
+- The bounded compatibility window is this corrective patch release; removal
+  requires a separately reviewed migration ticket.
+- The historical Homebrew formula can remain as a deprecated forwarding formula
+  so old automation has an explicit route to `tmux-ws`.
+- The final patch version and release notes are created only after merge by
+  release-please; this branch must not pre-create a tag or release.

--- a/specs/095-release-product-name/tasks.md
+++ b/specs/095-release-product-name/tasks.md
@@ -15,9 +15,9 @@ non-primary `agent-daemon` command.
 **Independent Test**: Baseline focused check fails for the old default; the
 Green packaged output runs both help commands and selects `tmux-ws` as primary.
 
-- [ ] T001 [US1] Add RED public-package and packaged-help assertions in `nix/checks.nix` that fail against the `agent-daemon` default surface.
-- [ ] T002 [US1] Rename the public Cabal manifest/package and make `tmux-ws` the default executable in `tmux-ws.cabal`, `nix/project.nix`, and `nix/apps.nix`, retaining a documented compatibility `agent-daemon` executable.
-- [ ] T003 [US1] Green the focused package check and update `nix/checks.nix` to prove both commands while selecting `tmux-ws` as primary.
+- [X] T001 [US1] Add RED public-package and packaged-help assertions in `nix/checks.nix` that fail against the `agent-daemon` default surface.
+- [X] T002 [US1] Rename the public Cabal manifest/package and make `tmux-ws` the default executable in `tmux-ws.cabal`, `nix/project.nix`, and `nix/apps.nix`, retaining a documented compatibility `agent-daemon` executable.
+- [X] T003 [US1] Green the focused package check and update `nix/checks.nix` to prove both commands while selecting `tmux-ws` as primary.
 
 ## Phase 2: User Story 2 — Receive a safe macOS/Homebrew corrective release (P1)
 

--- a/specs/095-release-product-name/tasks.md
+++ b/specs/095-release-product-name/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: tmux-ws public release identity
+
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md),
+[research.md](./research.md), and [release-surface contract](./contracts/release-surfaces.md)
+
+**Tests**: Every story requires strict RED → GREEN evidence. Each accepted
+slice is one bisect-safe commit with the listed `Tasks:` trailer; its checked
+tasks are amended into that same commit.
+
+## Phase 1: User Story 1 — Install the named product (P1)
+
+**Goal**: Make `tmux-ws` default while retaining a tested, explicitly
+non-primary `agent-daemon` command.
+
+**Independent Test**: Baseline focused check fails for the old default; the
+Green packaged output runs both help commands and selects `tmux-ws` as primary.
+
+- [ ] T001 [US1] Add RED public-package and packaged-help assertions in `nix/checks.nix` that fail against the `agent-daemon` default surface.
+- [ ] T002 [US1] Rename the public Cabal manifest/package and make `tmux-ws` the default executable in `tmux-ws.cabal`, `nix/project.nix`, and `nix/apps.nix`, retaining a documented compatibility `agent-daemon` executable.
+- [ ] T003 [US1] Green the focused package check and update `nix/checks.nix` to prove both commands while selecting `tmux-ws` as primary.
+
+## Phase 2: User Story 2 — Receive a safe macOS/Homebrew corrective release (P1)
+
+**Goal**: Prepare canonical Darwin archive/formula publication and exact App
+author recovery without PR-side publication.
+
+**Independent Test**: Baseline name/recovery assertions fail; non-publishing
+proof verifies canonical archive/formula/smoke and accepted authors, while
+false authors remain rejected.
+
+- [ ] T004 [US2] Add RED archive/formula/author-selector checks in `nix/checks.nix`, including positive and negative GitHub App author examples.
+- [ ] T005 [US2] Update `.github/workflows/darwin-release.yml` to generate the canonical `tmux-ws` archive and Homebrew formula plus a deprecated legacy formula route, retaining tag-only publication and existing hardening.
+- [ ] T006 [US2] Update `.github/workflows/release.yml`, `.github/workflows/sync-cabal-version.yml` if manifest rename requires it, and `nix/checks.nix` so recovery accepts exactly both App forms and a non-publishing Darwin/Homebrew smoke is required.
+
+## Phase 3: User Story 3 — Follow current installation and service documentation (P2)
+
+**Goal**: Lead current operator material with `tmux-ws` while preserving a
+clear, tested service and command migration path.
+
+**Independent Test**: Current-surface guard is RED on old guidance; Green
+strict docs/link proof and NixOS compatibility evaluation permit historical
+text only in migration material.
+
+- [ ] T007 [US3] Add a RED current-title/install-command and strict documentation/link contract in `nix/checks.nix` and `flake.nix` only if strict docs wiring requires it.
+- [ ] T008 [US3] Make `nix/module.nix` expose `tmux-ws` as primary NixOS service while evaluating and documenting the legacy `agent-daemon` migration/alias without renaming private state.
+- [ ] T009 [US3] Update `README.md`, `docs/index.md`, `docs/deployment.md`, `docs/tailscale.md`, new `docs/release.md`, and `mkdocs.yml` so new installation, upgrade, deployment, Tailscale, release, and operator commands lead with `tmux-ws` and isolate legacy instructions in migration guidance.
+- [ ] T010 [US3] Green the naming guard, strict docs/link proof, NixOS compatibility proof, and focused release/product-name check.
+
+## Dependencies & Execution Order
+
+1. Slice 1 (T001–T003) establishes the canonical package name consumed by all
+   later release and docs work.
+2. Slice 2 (T004–T006) follows because archive/formula generation consumes the
+   canonical package executable.
+3. Slice 3 (T007–T010) follows the stable package/formula/service terms.
+
+No slices run in parallel: all deliberately edit `nix/checks.nix`. A
+driver/navigator pair handles each in order; the navigator vetoes missing RED
+evidence, out-of-scope renames, publish attempts, or missing task trailer.

--- a/specs/095-release-product-name/tasks.md
+++ b/specs/095-release-product-name/tasks.md
@@ -28,9 +28,9 @@ author recovery without PR-side publication.
 proof verifies canonical archive/formula/smoke and accepted authors, while
 false authors remain rejected.
 
-- [ ] T004 [US2] Add RED archive/formula/author-selector checks in `nix/checks.nix`, including positive and negative GitHub App author examples.
-- [ ] T005 [US2] Update `.github/workflows/darwin-release.yml` to generate the canonical `tmux-ws` archive and Homebrew formula plus a deprecated legacy formula route, retaining tag-only publication and existing hardening.
-- [ ] T006 [US2] Update `.github/workflows/release.yml`, `.github/workflows/sync-cabal-version.yml` if manifest rename requires it, and `nix/checks.nix` so recovery accepts exactly both App forms and a non-publishing Darwin/Homebrew smoke is required.
+- [x] T004 [US2] Add RED archive/formula/author-selector checks in `nix/checks.nix`, including positive and negative GitHub App author examples.
+- [x] T005 [US2] Update `.github/workflows/darwin-release.yml` to generate the canonical `tmux-ws` archive and Homebrew formula plus a deprecated legacy formula route, retaining tag-only publication and existing hardening.
+- [x] T006 [US2] Update `.github/workflows/release.yml`, `.github/workflows/sync-cabal-version.yml` if manifest rename requires it, and `nix/checks.nix` so recovery accepts exactly both App forms and a non-publishing Darwin/Homebrew smoke is required.
 
 ## Phase 3: User Story 3 — Follow current installation and service documentation (P2)
 

--- a/specs/095-release-product-name/tasks.md
+++ b/specs/095-release-product-name/tasks.md
@@ -41,10 +41,10 @@ clear, tested service and command migration path.
 strict docs/link proof and NixOS compatibility evaluation permit historical
 text only in migration material.
 
-- [ ] T007 [US3] Add a RED current-title/install-command and strict documentation/link contract in `nix/checks.nix` and `flake.nix` only if strict docs wiring requires it.
-- [ ] T008 [US3] Make `nix/module.nix` expose `tmux-ws` as primary NixOS service while evaluating and documenting the legacy `agent-daemon` migration/alias without renaming private state.
-- [ ] T009 [US3] Update `README.md`, `docs/index.md`, `docs/deployment.md`, `docs/tailscale.md`, new `docs/release.md`, and `mkdocs.yml` so new installation, upgrade, deployment, Tailscale, release, and operator commands lead with `tmux-ws` and isolate legacy instructions in migration guidance.
-- [ ] T010 [US3] Green the naming guard, strict docs/link proof, NixOS compatibility proof, and focused release/product-name check.
+- [x] T007 [US3] Add a RED current-title/install-command and strict documentation/link contract in `nix/checks.nix` and `flake.nix` only if strict docs wiring requires it.
+- [x] T008 [US3] Make `nix/module.nix` expose `tmux-ws` as primary NixOS service while evaluating and documenting the legacy `agent-daemon` migration/alias without renaming private state.
+- [x] T009 [US3] Update `README.md`, `docs/index.md`, `docs/deployment.md`, `docs/tailscale.md`, new `docs/release.md`, and `mkdocs.yml` so new installation, upgrade, deployment, Tailscale, release, and operator commands lead with `tmux-ws` and isolate legacy instructions in migration guidance.
+- [x] T010 [US3] Green the naming guard, strict docs/link proof, NixOS compatibility proof, and focused release/product-name check.
 
 ## Dependencies & Execution Order
 

--- a/tmux-ws.cabal
+++ b/tmux-ws.cabal
@@ -1,5 +1,5 @@
 cabal-version:   3.0
-name:            agent-daemon
+name:            tmux-ws
 version:         0.3.0
 synopsis:
   Same-origin browser SPA and WebSocket daemon for tmux sessions
@@ -81,6 +81,27 @@ library
     RecordWildCards
     StrictData
 
+executable tmux-ws
+  main-is:            Main.hs
+  hs-source-dirs:     app
+  default-language:   GHC2021
+  ghc-options:
+    -Wall -Wunused-imports -Wunused-packages -Wmissing-export-lists
+    -Wname-shadowing -Wredundant-constraints -threaded -rtsopts
+    -with-rtsopts=-N
+
+  if flag(development-warnings)
+    ghc-options: -Werror
+
+  build-depends:
+    , base                  >=4.18 && <5
+    , optparse-applicative  >=0.17 && <0.19
+    , tmux-ws
+
+  default-extensions:
+    ImportQualifiedPost
+    OverloadedStrings
+
 executable agent-daemon
   main-is:            Main.hs
   hs-source-dirs:     app
@@ -94,9 +115,9 @@ executable agent-daemon
     ghc-options: -Werror
 
   build-depends:
-    , agent-daemon
     , base                  >=4.18 && <5
     , optparse-applicative  >=0.17 && <0.19
+    , tmux-ws
 
   default-extensions:
     ImportQualifiedPost
@@ -126,7 +147,6 @@ test-suite e2e-tests
 
   build-depends:
     , aeson           >=2.1  && <2.3
-    , agent-daemon
     , base            >=4.18 && <5
     , bytestring      >=0.11 && <0.13
     , containers      >=0.6  && <0.8
@@ -142,6 +162,7 @@ test-suite e2e-tests
     , temporary       >=1.3  && <1.4
     , text            >=2.0  && <2.2
     , time            >=1.12 && <1.15
+    , tmux-ws
     , warp            >=3.3  && <3.5
     , websockets      >=0.12 && <0.14
 


### PR DESCRIPTION
Closes #95

Parent epic: #80

## Result

`tmux-ws` is now the primary public package, executable, Darwin archive,
Homebrew formula, NixOS service, release metadata, and current operator
documentation. Merging this PR does not itself publish a release or mutate the
real Homebrew tap; those actions remain in the separately reviewed release PR.

## Compatibility and migration

- Canonical surfaces: `tmux-ws`, `TmuxWs`, `bin/tmux-ws`,
  `tmux-ws-<version>-aarch64-darwin.tar.gz`, and `services.tmux-ws` /
  `tmux-ws.service`.
- The `agent-daemon` executable and deprecated formula remain deliberate,
  tested compatibility routes during this corrective release. They are never a
  new-install path; removal requires a separately reviewed migration ticket.
- New Homebrew install: `brew update`,
  `brew install lambdasistemi/tap/tmux-ws`, then `tmux-ws --help`.
- Existing `tmux-ws` operators: `brew update`, `brew upgrade tmux-ws`, then
  `tmux-ws --help`.
- Legacy-only `agent-daemon` operators: install `tmux-ws` first, migrate
  scripts, then either `brew upgrade agent-daemon && agent-daemon --help` to
  keep the alias or `brew uninstall agent-daemon && tmux-ws --help` after
  migration.
- Existing NixOS configurations rename `services.agent-daemon` to
  `services.tmux-ws`, run `sudo nixos-rebuild switch`, then verify the single
  `tmux-ws` unit with `sudo systemctl restart tmux-ws`,
  `systemctl status tmux-ws`, and `systemctl is-active tmux-ws`. Private
  state and account defaults remain `/var/lib/agent-daemon` and
  `agent-daemon`.

## Documentation

- [Installation](https://lambdasistemi.github.io/tmux-ws/docs/#quick-start),
  [deployment](https://lambdasistemi.github.io/tmux-ws/docs/deployment/),
  [Tailscale HTTPS](https://lambdasistemi.github.io/tmux-ws/docs/tailscale/),
  and the new [release and migration guide](https://lambdasistemi.github.io/tmux-ws/docs/release/)
  lead with `tmux-ws` and isolate the legacy path.
- The guide distinguishes new installs from upgrades, documents the NixOS
  service rename/no-second-daemon behavior, requires a daemon restart and
  browser document reload after upgrade, and states the publication boundary:
  `v0.3.0` is immutable and is not rewritten or deleted; the later `v0.3.1`
  release publishes a new asset and updates the real tap. This PR itself does
  neither.

## Implementation and verification

- `68aae6fedb2a8e586486fe60771eac97ef23937e` —
  `fix(package): make tmux-ws the canonical executable` (`Tasks: T001, T002, T003`).
- `31919f28ded652a05d3cb7df02cc0eba93dc434b` —
  `fix(release): publish tmux-ws distribution surfaces` (`Tasks: T004, T005, T006`).
  Exact-head CI [run 29266601214](https://github.com/lambdasistemi/tmux-ws/actions/runs/29266601214)
  was 9/9 successful. Darwin used a registered disposable local tap, installed
  both formulas, ran both help commands, proved no legacy-keg collision, and
  compared the legacy forwarder to the primary binary by BSD device/inode.
- `53c7c75c000612743eb33c9ce0aebb7daa063ae8` —
  `docs: lead operators with tmux-ws` (`Tasks: T007, T008, T009, T010`). The
  task trailer occurs exactly once; this metadata-only replacement preserved
  the prior tree and parent.
- Slice 3 captured RED checks before each Green, then added repository-owned
  Linux canonical and renamed-option NixOS evaluations, executable negative
  current-surface guards, strict MkDocs built-site link/anchor validation,
  Linux-only module check exposure, and release-product/workflow checks.
- Local final verification: `./gate.sh` passed all 11 flake checks plus the
  development-shell Cabal build. Navigator and orchestrator independently
  verified the final diff, scope, private defaults, and task accounting.
- Exact-head CI [run 29269544019](https://github.com/lambdasistemi/tmux-ws/actions/runs/29269544019)
  passed on `53c7c75c000612743eb33c9ce0aebb7daa063ae8` (all required jobs).
- The finalization audit passed every branch commit and found all tasks checked.
  `4459b079009b77227e86711f45d3817c2f159e10` then removes only the
  temporary `gate.sh`; final exact-head CI [run 29270406996](https://github.com/lambdasistemi/tmux-ws/actions/runs/29270406996)
  is 9/9 successful, including the Darwin build and rendered Homebrew
  compatibility route.

## Post-merge release procedure

1. Merge this PR; do not rewrite or delete `v0.3.0`.
2. Let release-please create the patch-release PR and verify its author
   recovery recognizes `app/lambdasistemi-ci`.
3. Merge the release PR to publish immutable `v0.3.1`, its new Darwin asset,
   and the updated real Homebrew tap formula.
4. Smoke the packaged `tmux-ws --help`, Homebrew
   `brew install lambdasistemi/tap/tmux-ws && tmux-ws --help`, and the legacy
   migration alias. Restart the NixOS `tmux-ws` service and reload browser
   documents as described above.
