### PR TITLE
fix: make release-plan validation version-independent

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+git diff --check
+nix run --quiet .#release-plan
+nix run --quiet .#workflow-lint
+nix develop --quiet -c just ci

--- a/gate.sh
+++ b/gate.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-cd "$(git rev-parse --show-toplevel)"
-git diff --check
-nix run --quiet .#release-plan
-nix run --quiet .#workflow-lint
-nix develop --quiet -c just ci

--- a/specs/104-release-proposal-gate/plan.md
+++ b/specs/104-release-proposal-gate/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: Version-independent release-plan validation
+
+## Scope and constraints
+
+This is one behavior-changing, bisect-safe test slice. The only owned code file
+is `test/release-plan.sh`; the ticket owner separately owns this specification,
+`gate.sh`, task accounting, PR metadata, and verification evidence.
+
+The change preserves the Cabal file as the live version source and makes the
+test's synthetic repository independent of that live value. No release script,
+workflow, package output, artifact name, version, changelog, documentation, or
+publication state may change.
+
+## Design
+
+1. Derive an independent expected live version from the single `version:` field
+   in root `tmux-ws.cabal`, then compare `get-cabal-version` with that derived
+   value. The assertion continues testing the helper without encoding the
+   current release number.
+2. Declare a fixed fixture baseline (`0.3.1`) and fixture release (`0.4.0`) near
+   the fixture setup. These are scenario inputs, not repository state.
+3. Normalize each synthetic repository's copied Cabal file to the fixture
+   baseline before its initial commit and annotated baseline tag. Use the named
+   fixture values for tag creation, expected proposal output, publication
+   transition, release assertions, and idempotency counting.
+4. Keep all literals intentional and readable, including clear failure messages
+   that distinguish the live version contract from the synthetic fixture.
+
+## TDD and verification
+
+### RED
+
+Use a detached temporary worktree at exact PR #102 head
+`4b9cc627a9d503a81aa6ea394a393b2a791ce529`. Run its unchanged focused
+release-plan check and record the non-zero exit plus the expected fixed-version
+failure. Do not change or push its branch.
+
+### GREEN
+
+- Run `bash test/release-plan.sh` in the issue worktree.
+- Run `nix run --quiet .#release-plan` in the issue worktree.
+- Overlay only the corrected `test/release-plan.sh` onto the detached PR #102
+  tree and run the focused Bash and Nix-backed checks there.
+- Run `nix run --quiet .#workflow-lint`.
+- Run `./gate.sh`, whose durable route includes
+  `nix develop --quiet -c just ci`.
+
+Record command, exit code, and salient output in `WIP.md` and the worker handoff
+artifacts. Remove the detached worktree after evidence is preserved.
+
+## Commit
+
+Exactly one implementation commit:
+
+```text
+fix: make release-plan test version-independent
+
+Derive the live expectation from the Cabal source of truth and isolate the
+synthetic baseline/release fixture from the checkout version.
+
+Tasks: T104, T105, T106, T107
+```
+
+The navigator must approve RED and GREEN before the driver commits. The ticket
+owner then reviews the full diff, re-runs the gate, checks all task boxes in the
+same amended commit, and pushes it.
+
+## Hosted completion
+
+After the ticket gate passes and `gate.sh` is removed, verify exact-final-head
+Build Gate, every NixOS CI job, Linux artifact build/smoke, and Darwin jobs.
+Do not merge or publish from this ticket.

--- a/specs/104-release-proposal-gate/spec.md
+++ b/specs/104-release-proposal-gate/spec.md
@@ -1,0 +1,70 @@
+# Feature Specification: Version-independent release-plan validation
+
+**Issue**: [#104](https://github.com/lambdasistemi/tmux-ws/issues/104)
+**Parent**: [#80](https://github.com/lambdasistemi/tmux-ws/issues/80)
+**Priority**: P1
+
+## User story
+
+As a maintainer, I can merge a generated Cabal-owned release proposal only
+after the same authoritative gate that protects an ordinary pull request has
+validated its exact head, including when that proposal increments the version
+in `tmux-ws.cabal`.
+
+## Problem
+
+The release-plan check asserts that the live Cabal version is exactly `0.3.1`.
+That assertion passes on current `main` but rejects the valid v0.4.0 proposal at
+`4b9cc627a9d503a81aa6ea394a393b2a791ce529`. Its hosted Build Gate fails with:
+
+```text
+release-plan test: expected Cabal version 0.3.1, got 0.4.0
+```
+
+The test also uses `0.3.1` and `0.4.0` as deliberate fixture versions. Those
+fixture values describe the scenario under test and must remain explicit,
+stable, and independent of the version checked out at the repository root.
+
+## Functional requirements
+
+- **FR-001**: The release-plan test MUST derive the expected live version from
+  `tmux-ws.cabal`; it MUST NOT require a particular current release number.
+- **FR-002**: The Cabal file MUST remain the sole live version source of truth.
+- **FR-003**: The synthetic repository MUST declare readable baseline and
+  release fixture versions and normalize its copied Cabal file to that baseline
+  before creating its baseline tag.
+- **FR-004**: All fixture tag, proposal, publication, and idempotency assertions
+  MUST use the declared fixture versions rather than scattered literals.
+- **FR-005**: The unchanged test from PR #102 MUST be observed failing on the
+  exact proposal head for the expected fixed-version reason before GREEN work.
+- **FR-006**: The corrected test MUST pass both on this branch's current Cabal
+  version and when overlaid onto an otherwise equivalent PR #102 proposal tree.
+- **FR-007**: The behavior-changing diff MUST be confined to
+  `test/release-plan.sh`.
+
+## Success criteria
+
+- **SC-001**: Exact PR #102 head `4b9cc627a9d503a81aa6ea394a393b2a791ce529`
+  supplies recorded RED evidence with the expected `0.3.1` versus `0.4.0`
+  failure.
+- **SC-002**: `bash test/release-plan.sh` and `nix run --quiet .#release-plan`
+  pass on the issue branch.
+- **SC-003**: The corrected `test/release-plan.sh`, overlaid onto a detached
+  copy of PR #102, passes without changing its Cabal version or release notes.
+- **SC-004**: `nix run --quiet .#workflow-lint` and `./gate.sh` pass.
+- **SC-005**: The final PR head is clean, contains no `gate.sh`, and all hosted
+  checks required by the owner brief succeed on that exact SHA.
+
+## Non-goals
+
+- Changing application, API, UI, package, artifact, release workflow, release
+  script, Cabal version, changelog, documentation, or Homebrew behavior.
+- Mutating PR #102, `release/cabal-release`, ticket/PR #79, tags, releases, or
+  previously published assets.
+- Redesigning the Cabal-owned release planner or immutable tag publication.
+
+## Evidence anchors
+
+- Main baseline: `a3edae6a3805c4f998195ecc3f3c2d47cc356f90`.
+- Proposal head: `4b9cc627a9d503a81aa6ea394a393b2a791ce529`.
+- Failed hosted run/job: `29414859720` / `87350346383`.

--- a/specs/104-release-proposal-gate/tasks.md
+++ b/specs/104-release-proposal-gate/tasks.md
@@ -2,7 +2,7 @@
 
 ## Slice 1 — Decouple release-plan validation from the checkout version
 
-- [ ] T104 Capture RED on exact PR #102 head `4b9cc627a9d503a81aa6ea394a393b2a791ce529` with the unchanged test and preserve the expected fixed-version failure evidence.
-- [ ] T105 Derive the live expectation from `tmux-ws.cabal`, declare explicit fixture baseline/release versions, and normalize the synthetic repository in `test/release-plan.sh` only.
-- [ ] T106 Capture GREEN on the issue branch and an equivalent detached proposal-version tree with the focused Bash, Nix release-plan, and workflow-lint checks.
-- [ ] T107 Pass `./gate.sh` and return one reviewed Conventional Commit with a non-empty body and `Tasks: T104, T105, T106, T107` trailer.
+- [X] T104 Capture RED on exact PR #102 head `4b9cc627a9d503a81aa6ea394a393b2a791ce529` with the unchanged test and preserve the expected fixed-version failure evidence.
+- [X] T105 Derive the live expectation from `tmux-ws.cabal`, declare explicit fixture baseline/release versions, and normalize the synthetic repository in `test/release-plan.sh` only.
+- [X] T106 Capture GREEN on the issue branch and an equivalent detached proposal-version tree with the focused Bash, Nix release-plan, and workflow-lint checks.
+- [X] T107 Pass `./gate.sh` and return one reviewed Conventional Commit with a non-empty body and `Tasks: T104, T105, T106, T107` trailer.

--- a/specs/104-release-proposal-gate/tasks.md
+++ b/specs/104-release-proposal-gate/tasks.md
@@ -1,0 +1,8 @@
+# Tasks: Version-independent release-plan validation
+
+## Slice 1 — Decouple release-plan validation from the checkout version
+
+- [ ] T104 Capture RED on exact PR #102 head `4b9cc627a9d503a81aa6ea394a393b2a791ce529` with the unchanged test and preserve the expected fixed-version failure evidence.
+- [ ] T105 Derive the live expectation from `tmux-ws.cabal`, declare explicit fixture baseline/release versions, and normalize the synthetic repository in `test/release-plan.sh` only.
+- [ ] T106 Capture GREEN on the issue branch and an equivalent detached proposal-version tree with the focused Bash, Nix release-plan, and workflow-lint checks.
+- [ ] T107 Pass `./gate.sh` and return one reviewed Conventional Commit with a non-empty body and `Tasks: T104, T105, T106, T107` trailer.

--- a/test/release-plan.sh
+++ b/test/release-plan.sh
@@ -37,8 +37,20 @@ for script in get-cabal-version extract-notes check-version-consistency plan; do
     || fail "missing executable scripts/release/$script"
 done
 
+expected_live_version="$({
+  awk '
+    $1 == "version:" {
+      print $2
+      count += 1
+    }
+    END {
+      if (count != 1) exit 1
+    }
+  ' "$root/tmux-ws.cabal"
+} )" || fail 'tmux-ws.cabal must contain exactly one version field'
 version="$(bash "$root/scripts/release/get-cabal-version")"
-test "$version" = 0.3.1 || fail "expected Cabal version 0.3.1, got $version"
+test "$version" = "$expected_live_version" \
+  || fail "expected Cabal version $expected_live_version, got $version"
 
 notes="$tmp/notes.md"
 bash "$root/scripts/release/extract-notes" "$version" > "$notes"
@@ -46,17 +58,33 @@ test -s "$notes" || fail 'matching changelog notes are empty'
 expect_fail 'missing changelog section' \
   bash "$root/scripts/release/extract-notes" 9.9.9
 
+fixture_baseline_version=0.3.1
+fixture_release_version=0.4.0
+
 make_repo() {
   local repo="$1"
   mkdir -p "$repo/scripts"
   cp "$root/tmux-ws.cabal" "$root/CHANGELOG.md" "$repo/"
   cp -R --no-preserve=mode "$root/scripts/release" "$repo/scripts/"
+  sed -E -i "s/^(version:[[:space:]]*).*/\1${fixture_baseline_version}/" \
+    "$repo/tmux-ws.cabal"
+  {
+    printf '# Changelog\n\n'
+    awk -v heading="## [$fixture_baseline_version]" '
+      index($0, heading) == 1 { found = 1 }
+      found { print }
+      END { if (!found) exit 1 }
+    ' "$repo/CHANGELOG.md"
+  } > "$repo/CHANGELOG.fixture" \
+    || fail "missing fixture baseline changelog $fixture_baseline_version"
+  mv "$repo/CHANGELOG.fixture" "$repo/CHANGELOG.md"
   git -C "$repo" init --quiet --initial-branch main
   git -C "$repo" config user.name test
   git -C "$repo" config user.email test@example.invalid
   git -C "$repo" add .
   git -C "$repo" commit --quiet -m 'chore: baseline release'
-  git -C "$repo" tag -a v0.3.1 -m 'Release v0.3.1'
+  git -C "$repo" tag -a "v$fixture_baseline_version" \
+    -m "Release v$fixture_baseline_version"
 }
 
 bash "$root/scripts/release/check-version-consistency" --mode proposal
@@ -93,7 +121,7 @@ printf 'proposal fixture\n' > "$proposal_repo/feature.txt"
 git -C "$proposal_repo" add feature.txt
 git -C "$proposal_repo" commit --quiet -m 'feat: add release planner fixture'
 bash "$proposal_repo/scripts/release/plan" --dry-run > "$tmp/proposal.out"
-assert_contains 'proposal version=0.4.0' "$tmp/proposal.out"
+assert_contains "proposal version=$fixture_release_version" "$tmp/proposal.out"
 assert_contains 'release/cabal-release' "$tmp/proposal.out"
 test "$(git -C "$proposal_repo" branch --show-current)" = main \
   || fail 'dry-run changed the checked-out branch'
@@ -102,16 +130,17 @@ test "$(git -C "$proposal_repo" status --porcelain)" = '' \
 
 publish_repo="$tmp/publish"
 make_repo "$publish_repo"
-sed -i 's/^version:[[:space:]]*0\.3\.1/version:         0.4.0/' \
+sed -E -i "s/^(version:[[:space:]]*).*/\1${fixture_release_version}/" \
   "$publish_repo/tmux-ws.cabal"
 {
   head -n 1 "$publish_repo/CHANGELOG.md"
-  printf '\n## [0.4.0] (test)\n\n### Features\n\n- planner fixture\n\n'
+  printf '\n## [%s] (test)\n\n### Features\n\n- planner fixture\n\n' \
+    "$fixture_release_version"
   tail -n +2 "$publish_repo/CHANGELOG.md"
 } > "$publish_repo/CHANGELOG.next"
 mv "$publish_repo/CHANGELOG.next" "$publish_repo/CHANGELOG.md"
 git -C "$publish_repo" add tmux-ws.cabal CHANGELOG.md
-git -C "$publish_repo" commit --quiet -m 'chore: release 0.4.0'
+git -C "$publish_repo" commit --quiet -m "chore: release $fixture_release_version"
 git -C "$publish_repo" init --bare --quiet "$tmp/publish-remote.git"
 git -C "$publish_repo" remote add origin "$tmp/publish-remote.git"
 git -C "$publish_repo" push --quiet -u origin main --tags
@@ -132,15 +161,16 @@ EOF
 chmod +x "$mock_bin/gh"
 GH_LOG="$tmp/gh.log" GH_RELEASE_EXISTS="$tmp/release-exists" PATH="$mock_bin:$PATH" \
   bash "$publish_repo/scripts/release/plan" > "$tmp/publish.out"
-git -C "$publish_repo" rev-parse -q --verify refs/tags/v0.4.0 >/dev/null \
+git -C "$publish_repo" rev-parse -q \
+  --verify "refs/tags/v$fixture_release_version" >/dev/null \
   || fail 'planner did not create the annotated release tag'
-assert_contains 'release create v0.4.0' "$tmp/gh.log"
+assert_contains "release create v$fixture_release_version" "$tmp/gh.log"
 assert_not_contains 'release delete' "$tmp/gh.log"
 
-before="$(grep -Fc 'release create v0.4.0' "$tmp/gh.log")"
+before="$(grep -Fc "release create v$fixture_release_version" "$tmp/gh.log")"
 GH_LOG="$tmp/gh.log" GH_RELEASE_EXISTS="$tmp/release-exists" PATH="$mock_bin:$PATH" \
   bash "$publish_repo/scripts/release/plan" > "$tmp/publish-repeat.out"
-after="$(grep -Fc 'release create v0.4.0' "$tmp/gh.log")"
+after="$(grep -Fc "release create v$fixture_release_version" "$tmp/gh.log")"
 test "$before" = "$after" || fail 're-running publication created a release'
 
 for workflow in .github/workflows/release.yml .github/workflows/darwin-release.yml; do


### PR DESCRIPTION
## Summary

- derive the live release-plan expectation from `tmux-ws.cabal` instead of requiring checkout version `0.3.1`
- keep `0.3.1` → `0.4.0` as explicit synthetic fixture inputs and normalize copied Cabal/changelog state to that baseline
- preserve all proposal, immutable publication, and idempotency assertions while making the test pass on both main and a generated proposal tree

## Regression evidence

- RED: exact PR #102 head `4b9cc627a9d503a81aa6ea394a393b2a791ce529` failed `nix run --quiet .#release-plan` with `expected Cabal version 0.3.1, got 0.4.0`
- GREEN: focused Bash and Nix release-plan checks passed on the issue tree and on the same proposal tree with only the corrected test overlaid
- proposal `tmux-ws.cabal` and `CHANGELOG.md` blobs remained unchanged during GREEN verification

## Verification

- `bash test/release-plan.sh`
- `nix run --quiet .#release-plan`
- `nix run --quiet .#workflow-lint`
- `./gate.sh` (`nix develop --quiet -c just ci` included)
- branch-wide commit/task/finalization audit

## Scope

Behavior-changing code is confined to `test/release-plan.sh`. This PR does not change release scripts/workflows, the Cabal version, changelog, packages, artifacts, documentation, tags, releases, PR #102, or ticket #79.

Closes #104.
