### PR TITLE
feat(ui): add touch context bottom sheets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,39 @@ jobs:
       - name: Lint workflows
         run: nix run --quiet .#workflow-lint
 
+  pr-preview:
+    name: PR UI preview
+    if: github.event_name == 'pull_request'
+    needs: build-gate
+    runs-on: nixos
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v17
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build static site
+        run: nix build --quiet .#site
+      - name: Prepare illustrative preview
+        run: |
+          set -euo pipefail
+          preview_dir="$RUNNER_TEMP/tmux-ws-pr-preview"
+          rm -rf "$preview_dir"
+          mkdir -p "$preview_dir"
+          cp -RL result/. "$preview_dir/"
+          chmod -R u+w "$preview_dir"
+          cp ui/preview/fixture.js "$preview_dir/fixture.js"
+          sed -i 's#  <script src="index.js#  <script src="fixture.js"></script>\n  <script src="index.js#' "$preview_dir/index.html"
+          grep -Fq '<script src="fixture.js"></script>' "$preview_dir/index.html"
+      - uses: paolino/dev-assets/static-preview@main
+        with:
+          path: ${{ runner.temp }}/tmux-ws-pr-preview
+          comment: true
+
   dev-shell:
     name: Dev shell build
     needs: build-gate

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -71,6 +71,7 @@ let
           export UI_BUNDLE=${uiBundle} NODE_PATH=${pkgs.playwright-test}/lib/node_modules
           export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers} PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
           node --test ui/test/CommandDeckLayout.test.mjs
+          node --test ui/test/ContextBottomMenus.test.mjs
         fi
       '';
     };

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -72,6 +72,7 @@ let
           export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers} PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
           node --test ui/test/CommandDeckLayout.test.mjs
           node --test ui/test/ContextBottomMenus.test.mjs
+          node --test ui/test/PreviewFixture.test.mjs
         fi
       '';
     };
@@ -127,6 +128,58 @@ let
         plan=.github/workflows/release-plan.yml
         linux=.github/workflows/release.yml
         darwin=.github/workflows/darwin-release.yml
+
+        require_value() {
+          actual="$(yq -r "$2" "$1")"
+          test "$actual" = "$3" || {
+            printf 'workflow contract: %s (expected %s, got %s)\n' "$4" "$3" "$actual" >&2
+            exit 1
+          }
+        }
+        require_query() {
+          yq -e "$2" "$1" >/dev/null || {
+            printf 'workflow contract: missing %s\n' "$3" >&2
+            exit 1
+          }
+        }
+        require_job_literal() {
+          grep -Fq "$1" <<<"$preview_runs" || {
+            printf 'workflow contract: PR preview job missing %s\n' "$2" >&2
+            exit 1
+          }
+        }
+
+        require_value "$ci" '.jobs."pr-preview".if' "github.event_name == 'pull_request'" 'PR-only preview condition'
+        require_value "$ci" '.jobs."pr-preview"."runs-on"' nixos 'PR preview nixos runner'
+        require_value "$ci" '.jobs."pr-preview".needs' build-gate 'PR preview build-gate dependency'
+        require_value "$ci" '.jobs."pr-preview".permissions.contents' read 'PR preview contents permission'
+        require_value "$ci" '.jobs."pr-preview".permissions.issues' write 'PR preview issues permission'
+        require_value "$ci" '.jobs."pr-preview".permissions."pull-requests"' write 'PR preview pull-request permission'
+        require_value "$ci" '.jobs."pr-preview".permissions | keys | sort | join(",")' 'contents,issues,pull-requests' 'PR preview minimal permissions'
+        require_query "$ci" '.jobs."pr-preview".steps[] | select(.uses == "actions/checkout@v6")' 'PR preview checkout step'
+        require_query "$ci" '.jobs."pr-preview".steps[] | select(.uses == "cachix/cachix-action@v17" and .with.name == "paolino")' 'PR preview Cachix step'
+        require_query "$ci" '.jobs."pr-preview".steps[] | select(.uses == "paolino/dev-assets/static-preview@main" and .with.comment == true)' 'shared static-preview publication step with comment'
+        preview_path="$(yq -r '.jobs."pr-preview".steps[] | select(.uses == "paolino/dev-assets/static-preview@main") | .with.path' "$ci")"
+        if test "''${preview_path##*/}" != tmux-ws-pr-preview || ! grep -Fq runner.temp <<<"$preview_path"; then
+          echo 'workflow contract: static-preview must publish the writable runner-temp directory' >&2
+          exit 1
+        fi
+        preview_runs="$(yq -r '.jobs."pr-preview".steps[] | select(has("run")) | .run' "$ci")"
+        require_job_literal 'nix build --quiet .#site' 'site build'
+        require_job_literal "cp -RL result/. \"\$preview_dir/\"" 'dereferenced result copy'
+        require_job_literal "chmod -R u+w \"\$preview_dir\"" 'writable preview copy'
+        require_job_literal "cp ui/preview/fixture.js \"\$preview_dir/fixture.js\"" 'fixture copy'
+        require_job_literal '<script src="fixture.js"></script>' 'fixture script injection'
+        require_job_literal 'index.js' 'production script injection anchor'
+        preview_job="$(yq -o=json -I=0 '.jobs."pr-preview"' "$ci")"
+        if grep -Eiq 'actions/(upload|deploy)-pages|github-pages|mkdocs[^";]*deploy|deploy-docs|gh release|git tag|scripts/release|systemctl|/opt/services' <<<"$preview_job"; then
+          echo 'workflow contract: deployment or release mutation in PR preview job' >&2
+          exit 1
+        fi
+        if grep -Fq 'fixture.js' ui/dist/index.html; then
+          echo 'workflow contract: production UI must not load the illustrative fixture' >&2
+          exit 1
+        fi
 
         for obsolete in .github/workflows/sync-cabal-version.yml release-please-config.json .release-please-manifest.json; do
           test ! -e "$obsolete" || { echo "workflow contract: obsolete artifact $obsolete" >&2; exit 1; }

--- a/ui/dist/index.css
+++ b/ui/dist/index.css
@@ -181,6 +181,25 @@ h1 {
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.32);
 }
 
+.context-menu-layer {
+  display: contents;
+}
+
+.context-menu-layer.hidden {
+  display: none;
+}
+
+.context-menu-backdrop,
+.context-menu-header {
+  display: none;
+}
+
+.context-menu-choices {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+}
+
 .session-menu {
   right: 0;
 }
@@ -1082,6 +1101,88 @@ button:active:not(:disabled),
     border-radius: 14px;
     padding: 10px;
     transform: none;
+  }
+
+  .context-menu-layer {
+    position: fixed;
+    inset: 0;
+    z-index: 36;
+    display: block;
+  }
+
+  .context-menu-layer.hidden {
+    display: none;
+  }
+
+  .context-menu-backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    border: 0;
+    border-radius: 0;
+    background: rgba(0, 0, 0, 0.56);
+    padding: 0;
+  }
+
+  .context-menu-backdrop:active:not(:disabled) {
+    transform: none;
+    filter: none;
+  }
+
+  .session-menu.context-menu-sheet,
+  .window-menu.context-menu-sheet {
+    position: absolute;
+    inset: auto 0 var(--safe-bottom);
+    z-index: 1;
+    width: 100%;
+    height: min(72dvh, calc(100dvh - var(--safe-top) - var(--safe-bottom)));
+    max-height: calc(100dvh - var(--safe-top) - var(--safe-bottom));
+    overflow: hidden;
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: 0;
+    border-radius: 18px 18px 0 0;
+    padding: 0;
+  }
+
+  .context-menu-header {
+    min-width: 0;
+    min-height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    padding: 8px 10px 8px 16px;
+  }
+
+  .context-menu-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 23px;
+    margin: 0;
+    color: var(--text-strong);
+    font-size: 18px;
+    line-height: 1.25;
+  }
+
+  .context-menu-close {
+    width: 44px;
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .context-menu-choices {
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    padding: 10px;
   }
 
   .terminal-menu {

--- a/ui/preview/fixture.js
+++ b/ui/preview/fixture.js
@@ -1,0 +1,200 @@
+(() => {
+  "use strict";
+
+  const sessions = [
+    {
+      id: "preview-roadmap",
+      state: "active",
+      tmuxName: "Roadmap review",
+      currentPath: "/workspace/tmux-ws"
+    },
+    {
+      id: "preview-release",
+      state: "detached",
+      tmuxName: "Release rehearsal",
+      currentPath: "/workspace/release"
+    },
+    {
+      id: "preview-incident",
+      state: "detached",
+      tmuxName: "Payments incident",
+      currentPath: "/workspace/incident-response"
+    },
+    {
+      id: "preview-documentation",
+      state: "detached",
+      tmuxName: "Documentation pass",
+      currentPath: "/workspace/docs"
+    },
+    {
+      id: "preview-experiments",
+      state: "detached",
+      tmuxName: "UI experiments",
+      currentPath: "/workspace/ui-lab"
+    }
+  ];
+
+  const windowNames = [
+    "editor",
+    "tests",
+    "daemon-logs",
+    "ui-preview",
+    "release-notes",
+    "nix-shell",
+    "api-client",
+    "metrics",
+    "documentation",
+    "review",
+    "scratch",
+    "monitor"
+  ];
+  const windowsBySession = new Map(
+    sessions.map((session) => [
+      session.id,
+      windowNames.map((name, index) => ({ index, name, active: index === 0 }))
+    ])
+  );
+
+  const jsonResponse = (value) =>
+    new Response(JSON.stringify(value), {
+      headers: { "content-type": "application/json" },
+      status: 200
+    });
+
+  const requestDetails = (input, init) => {
+    const request = input instanceof Request ? input : null;
+    return {
+      body: init?.body ?? request?.body,
+      method: String(init?.method ?? request?.method ?? "GET").toUpperCase(),
+      url: new URL(request?.url ?? String(input), window.location.href)
+    };
+  };
+
+  const sessionWindowsMatch = (pathname) =>
+    pathname.match(/^\/sessions\/([^/]+)\/windows$/);
+  const newWindowMatch = (pathname) =>
+    pathname.match(/^\/sessions\/([^/]+)\/windows\/new$/);
+  const liveOrScrollMatch = (pathname) =>
+    pathname.match(/^\/sessions\/([^/]+)\/(live|scroll)$/);
+
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = async (input, init) => {
+    const request = requestDetails(input, init);
+    if (request.url.origin !== window.location.origin) return originalFetch(input, init);
+
+    if (request.method === "GET" && request.url.pathname === "/sessions") {
+      return jsonResponse(sessions);
+    }
+
+    const windowsMatch = sessionWindowsMatch(request.url.pathname);
+    if (request.method === "GET" && windowsMatch) {
+      return jsonResponse(windowsBySession.get(decodeURIComponent(windowsMatch[1])) ?? []);
+    }
+    if (request.method === "POST" && windowsMatch) {
+      const sessionId = decodeURIComponent(windowsMatch[1]);
+      const windows = windowsBySession.get(sessionId) ?? [];
+      const payload = typeof request.body === "string" ? JSON.parse(request.body) : {};
+      for (const windowInfo of windows) windowInfo.active = windowInfo.index === payload.index;
+      return jsonResponse({});
+    }
+
+    const createMatch = newWindowMatch(request.url.pathname);
+    if (request.method === "POST" && createMatch) {
+      const sessionId = decodeURIComponent(createMatch[1]);
+      const windows = windowsBySession.get(sessionId) ?? [];
+      const index = windows.reduce((maximum, windowInfo) =>
+        Math.max(maximum, windowInfo.index), -1) + 1;
+      for (const windowInfo of windows) windowInfo.active = false;
+      const created = { index, name: `new-window-${index}`, active: true };
+      windows.push(created);
+      windowsBySession.set(sessionId, windows);
+      return jsonResponse(created);
+    }
+
+    if (request.method === "POST" && liveOrScrollMatch(request.url.pathname)) {
+      return jsonResponse({});
+    }
+
+    return originalFetch(input, init);
+  };
+
+  const NativeWebSocket = window.WebSocket;
+  const isPreviewTerminal = (url) => {
+    const target = new URL(String(url), window.location.href.replace(/^http/, "ws"));
+    return (
+      target.host === window.location.host &&
+      /^\/sessions\/[^/]+\/terminal$/.test(target.pathname)
+    );
+  };
+
+  class PreviewWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+
+    constructor(url, protocols) {
+      if (!isPreviewTerminal(url)) return new NativeWebSocket(url, protocols);
+      this.binaryType = "blob";
+      this.bufferedAmount = 0;
+      this.extensions = "";
+      this.protocol = "";
+      this.readyState = PreviewWebSocket.CONNECTING;
+      this.url = String(url);
+      this.listeners = new Map();
+      window.setTimeout(() => {
+        if (this.readyState !== PreviewWebSocket.CONNECTING) return;
+        this.readyState = PreviewWebSocket.OPEN;
+        this.dispatch("open", new Event("open"));
+        this.dispatch(
+          "message",
+          new MessageEvent("message", {
+            data: "\u001b[36mIllustrative terminal\u001b[0m\r\n$ nix develop\r\n"
+          })
+        );
+      }, 0);
+    }
+
+    addEventListener(type, listener) {
+      const listeners = this.listeners.get(type) ?? new Set();
+      listeners.add(listener);
+      this.listeners.set(type, listeners);
+    }
+
+    removeEventListener(type, listener) {
+      this.listeners.get(type)?.delete(listener);
+    }
+
+    dispatch(type, event) {
+      this[`on${type}`]?.call(this, event);
+      for (const listener of this.listeners.get(type) ?? []) listener.call(this, event);
+    }
+
+    send() {}
+
+    close() {
+      if (this.readyState >= PreviewWebSocket.CLOSING) return;
+      this.readyState = PreviewWebSocket.CLOSING;
+      window.setTimeout(() => {
+        this.readyState = PreviewWebSocket.CLOSED;
+        this.dispatch("close", new Event("close"));
+      }, 0);
+    }
+  }
+
+  window.WebSocket = PreviewWebSocket;
+
+  const notice = document.createElement("div");
+  notice.dataset.previewFixtureNotice = "";
+  notice.setAttribute("role", "status");
+  notice.textContent = "Illustrative preview data — not connected to a daemon.";
+  notice.style.cssText = [
+    "background:#fef3c7",
+    "border-bottom:1px solid #d97706",
+    "color:#78350f",
+    "font:600 14px/1.4 system-ui,sans-serif",
+    "padding:8px 16px",
+    "text-align:center"
+  ].join(";");
+  document.body.prepend(notice);
+})();

--- a/ui/src/Main.purs
+++ b/ui/src/Main.purs
@@ -300,11 +300,28 @@ renderSessionSwitcher state =
         ]
     , HH.div
         [ cls
-            ( "session-menu"
+            ( "context-menu-layer"
                 <> if state.sessionMenuOpen then "" else " hidden"
             )
         ]
-        (renderSessionItems state)
+        [ HH.button
+            [ cls "context-menu-backdrop"
+            , HP.attr (HH.AttrName "aria-label") "Close Sessions menu"
+            , HE.onClick \_ -> ToggleSessionMenu
+            ]
+            []
+        , HH.section
+            [ cls "session-menu context-menu-sheet"
+            , HP.attr (HH.AttrName "role") "dialog"
+            , HP.attr (HH.AttrName "aria-modal") "true"
+            , HP.attr (HH.AttrName "aria-labelledby") "sessions-menu-title"
+            ]
+            [ renderContextMenuHeader "sessions-menu-title" "Sessions" ToggleSessionMenu
+            , HH.div
+                [ cls "context-menu-choices" ]
+                (renderSessionItems state)
+            ]
+        ]
     ]
 
 renderSessionItems
@@ -326,6 +343,8 @@ renderSessionItem state session =
         ( "session-menu-item"
             <> if session.id == state.attachedSession then " active" else ""
         )
+    , HP.attr (HH.AttrName "aria-current")
+        (if session.id == state.attachedSession then "true" else "false")
     , HE.onClick \_ -> ChooseSession session.id
     ]
     [ HH.span
@@ -369,11 +388,49 @@ renderWindowSwitcher state =
         ]
     , HH.div
         [ cls
-            ( "window-menu"
+            ( "context-menu-layer"
                 <> if state.windowMenuOpen then "" else " hidden"
             )
         ]
-        (renderWindowItems state.windows)
+        [ HH.button
+            [ cls "context-menu-backdrop"
+            , HP.attr (HH.AttrName "aria-label") "Close Windows menu"
+            , HE.onClick \_ -> ToggleWindowMenu
+            ]
+            []
+        , HH.section
+            [ cls "window-menu context-menu-sheet"
+            , HP.attr (HH.AttrName "role") "dialog"
+            , HP.attr (HH.AttrName "aria-modal") "true"
+            , HP.attr (HH.AttrName "aria-labelledby") "windows-menu-title"
+            ]
+            [ renderContextMenuHeader "windows-menu-title" "Windows" ToggleWindowMenu
+            , HH.div
+                [ cls "context-menu-choices" ]
+                (renderWindowItems state.windows)
+            ]
+        ]
+    ]
+
+renderContextMenuHeader
+  :: String
+  -> String
+  -> Action
+  -> H.ComponentHTML Action Slots Aff
+renderContextMenuHeader titleId title closeAction =
+  HH.div
+    [ cls "context-menu-header" ]
+    [ HH.h2
+        [ HP.id titleId
+        , cls "context-menu-title"
+        ]
+        [ HH.text title ]
+    , HH.button
+        [ cls "context-menu-close icon-button"
+        , HP.attr (HH.AttrName "aria-label") ("Close " <> title <> " menu")
+        , HE.onClick \_ -> closeAction
+        ]
+        [ icon "x" ]
     ]
 
 renderWindowItems
@@ -603,6 +660,8 @@ renderWindowItem windowInfo =
         ( "window-menu-item"
             <> if windowInfo.active then " active" else ""
         )
+    , HP.attr (HH.AttrName "aria-current")
+        (if windowInfo.active then "true" else "false")
     , HE.onClick \_ -> SelectWindow windowInfo.index
     ]
     [ HH.span

--- a/ui/test/ContextBottomMenus.test.mjs
+++ b/ui/test/ContextBottomMenus.test.mjs
@@ -1,0 +1,334 @@
+import assert from "node:assert/strict";
+import { mkdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import { basename, extname, join, normalize } from "node:path";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { chromium } = require("playwright");
+const uiBundle = process.env.UI_BUNDLE;
+const screenshotDirectory = process.env.CONTEXT_MENU_SCREENSHOT_DIR;
+const viewports = [
+  { width: 390, height: 844 },
+  { width: 768, height: 1024 },
+  { width: 1024, height: 768 }
+];
+
+const sessions = Array.from({ length: 20 }, (_, index) => ({
+  id: `context-session-${index + 1}`,
+  state: index === 0 ? "active" : "detached",
+  tmuxName: `context-${index + 1}`,
+  currentPath: `/workspace/context-${index + 1}`
+}));
+
+const windows = Array.from({ length: 18 }, (_, index) => ({
+  index,
+  name: `window-${String(index + 1).padStart(2, "0")}`,
+  active: index === 0
+}));
+
+const contentTypes = {
+  ".css": "text/css",
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".svg": "image/svg+xml",
+  ".woff2": "font/woff2"
+};
+
+const createFixture = async () => {
+  assert.ok(uiBundle, "UI_BUNDLE must name the built static UI directory");
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+    if (request.method === "GET" && url.pathname === "/sessions") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify(sessions));
+      return;
+    }
+    if (
+      request.method === "GET" &&
+      /^\/sessions\/[^/]+\/windows$/.test(url.pathname)
+    ) {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify(windows));
+      return;
+    }
+    if (
+      request.method === "POST" &&
+      /^\/sessions\/[^/]+\/windows$/.test(url.pathname)
+    ) {
+      response.setHeader("content-type", "application/json");
+      response.end("{}");
+      return;
+    }
+
+    const requestedPath = url.pathname === "/" ? "index.html" : url.pathname.slice(1);
+    const filePath = normalize(join(uiBundle, requestedPath));
+    if (!filePath.startsWith(`${uiBundle}/`) && filePath !== join(uiBundle, "index.html")) {
+      response.statusCode = 400;
+      response.end("invalid path");
+      return;
+    }
+    try {
+      response.setHeader("content-type", contentTypes[extname(filePath)] ?? "application/octet-stream");
+      response.end(await readFile(filePath));
+    } catch (_) {
+      response.statusCode = 404;
+      response.end(`not found: ${basename(filePath)}`);
+    }
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+  };
+};
+
+const installWebSocketFixture = async (page) => {
+  await page.addInitScript(() => {
+    class FixtureWebSocket {
+      static OPEN = 1;
+      static CLOSING = 2;
+
+      constructor() {
+        this.readyState = 0;
+        window.setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.onopen?.({});
+        }, 0);
+      }
+
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+
+      send() {}
+    }
+
+    window.WebSocket = FixtureWebSocket;
+  });
+};
+
+const menuContract = async (page, viewport, kind) => {
+  const title = kind === "session" ? "Sessions" : "Windows";
+  const titleId = kind === "session" ? "sessions-menu-title" : "windows-menu-title";
+  const switchLabel = kind === "session" ? "Switch session" : "Switch tmux window";
+  const otherSwitchLabel = kind === "session" ? "Switch tmux window" : "Switch session";
+  const sheetSelector = `.${kind}-menu`;
+  const rowSelector = `.${kind}-menu-item`;
+  const switcher = page.getByRole("button", { name: switchLabel, exact: true });
+  const openMenu = async () => {
+    await switcher.tap();
+    await page.waitForFunction(
+      (label) =>
+        document.querySelector(`button[aria-label="${label}"]`)?.getAttribute("aria-expanded") ===
+        "true",
+      switchLabel,
+      { timeout: 10000 }
+    );
+  };
+
+  await openMenu();
+  const sheet = page.locator(`${sheetSelector}:visible`);
+  const layer = page.locator(`.context-menu-layer:visible`);
+  const backdrop = layer.locator(".context-menu-backdrop");
+  const header = sheet.locator(".context-menu-header");
+  const close = sheet.locator(`.context-menu-close[aria-label="Close ${title} menu"]`);
+  const choices = sheet.locator(".context-menu-choices");
+
+  await assert.doesNotReject(
+    sheet.locator(`h2#${titleId}`).waitFor({ state: "visible", timeout: 10000 }),
+    `${title} menu exposes a visible title`
+  );
+  assert.equal((await sheet.locator(`h2#${titleId}`).textContent()).trim(), title);
+  assert.equal(await sheet.getAttribute("aria-labelledby"), titleId);
+  await assert.doesNotReject(
+    backdrop.waitFor({ state: "visible", timeout: 10000 }),
+    `${title} menu exposes a visible backdrop`
+  );
+
+  if (screenshotDirectory) {
+    mkdirSync(screenshotDirectory, { recursive: true });
+    await page.screenshot({
+      path: join(
+        screenshotDirectory,
+        `${kind}-menu-${viewport.width}x${viewport.height}.png`
+      ),
+      fullPage: false
+    });
+  }
+
+  const geometry = await page.evaluate(
+    ({ sheetSelector: currentSheetSelector }) => {
+      const currentSheet = document.querySelector(`${currentSheetSelector}:not(.hidden)`);
+      const currentBackdrop = document.querySelector(
+        ".context-menu-layer:not(.hidden) .context-menu-backdrop"
+      );
+      const dock = document.querySelector(".action-dock");
+      assertElement(currentSheet, "open context menu sheet");
+      assertElement(currentBackdrop, "open context menu backdrop");
+      assertElement(dock, "action dock");
+
+      const sheetRect = currentSheet.getBoundingClientRect();
+      const backdropRect = currentBackdrop.getBoundingClientRect();
+      const dockRect = dock.getBoundingClientRect();
+      const overlapY = Math.min(sheetRect.bottom - 4, dockRect.top + 4);
+      const overlapX = sheetRect.left + sheetRect.width / 2;
+      const hit = document.elementFromPoint(overlapX, overlapY);
+      const safeProbe = document.createElement("div");
+      safeProbe.style.position = "fixed";
+      safeProbe.style.bottom = "var(--safe-bottom)";
+      document.body.append(safeProbe);
+      const safeBottom = Number.parseFloat(getComputedStyle(safeProbe).bottom) || 0;
+      safeProbe.remove();
+
+      return {
+        backdrop: {
+          bottom: backdropRect.bottom,
+          left: backdropRect.left,
+          right: backdropRect.right,
+          top: backdropRect.top
+        },
+        dockTop: dockRect.top,
+        hitInsideSheet: hit === currentSheet || currentSheet.contains(hit),
+        safeBottom,
+        sheetBottom: sheetRect.bottom,
+        viewport: { height: innerHeight, width: innerWidth }
+      };
+
+      function assertElement(element, description) {
+        if (!element) throw new Error(`missing ${description}`);
+      }
+    },
+    { sheetSelector }
+  );
+
+  assert.ok(Math.abs(geometry.backdrop.left) <= 1, `${title} backdrop starts at viewport left`);
+  assert.ok(Math.abs(geometry.backdrop.top) <= 1, `${title} backdrop starts at viewport top`);
+  assert.ok(
+    Math.abs(geometry.backdrop.right - geometry.viewport.width) <= 1,
+    `${title} backdrop reaches viewport right`
+  );
+  assert.ok(
+    Math.abs(geometry.backdrop.bottom - geometry.viewport.height) <= 1,
+    `${title} backdrop reaches viewport bottom`
+  );
+  assert.ok(
+    Math.abs(geometry.sheetBottom - (geometry.viewport.height - geometry.safeBottom)) <= 1,
+    `${title} sheet is anchored to the viewport bottom above the safe area`
+  );
+  assert.ok(geometry.sheetBottom > geometry.dockTop, `${title} sheet visually overlays the dock`);
+  assert.ok(geometry.hitInsideSheet, `${title} sheet owns the hit layer over the dock`);
+
+  const headerBefore = await header.boundingBox();
+  await choices.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await page.waitForTimeout(50);
+  const scrollTop = await choices.evaluate((element) => element.scrollTop);
+  const headerAfter = await header.boundingBox();
+  assert.ok(scrollTop > 0, `${title} choices scroll independently`);
+  assert.ok(headerBefore && headerAfter, `${title} header stays visible while choices scroll`);
+  assert.ok(
+    Math.abs(headerBefore.y - headerAfter.y) <= 1,
+    `${title} header remains fixed while choices scroll`
+  );
+  await assert.doesNotReject(close.waitFor({ state: "visible" }), `${title} close stays visible`);
+
+  const controls = sheet.locator(`${rowSelector}, .context-menu-close`);
+  const controlCount = await controls.count();
+  assert.ok(controlCount > 1, `${title} exposes close and choice controls`);
+  for (let index = 0; index < controlCount; index += 1) {
+    const control = controls.nth(index);
+    await control.scrollIntoViewIfNeeded();
+    const metrics = await control.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+      return {
+        centreHit: hit === element || element.contains(hit),
+        height: rect.height,
+        label: element.getAttribute("aria-label") ?? element.textContent.trim(),
+        width: rect.width
+      };
+    });
+    assert.ok(metrics.width >= 44, `${title} ${metrics.label} is at least 44px wide`);
+    assert.ok(metrics.height >= 44, `${title} ${metrics.label} is at least 44px high`);
+    assert.ok(metrics.centreHit, `${title} ${metrics.label} owns its centre hit point`);
+  }
+
+  const activeRows = sheet.locator(
+    `${rowSelector}[aria-current="true"], ${rowSelector}[aria-selected="true"]`
+  );
+  assert.equal(await activeRows.count(), 1, `${title} exposes exactly one accessible active row`);
+
+  if (kind === "window") {
+    const firstChoice = choices.locator("button").first();
+    assert.equal((await firstChoice.textContent()).trim(), "New window", "New window stays first");
+    assert.ok(
+      await firstChoice.evaluate((element) => element.classList.contains("window-menu-action")),
+      "New window remains a separated action"
+    );
+  }
+
+  await close.tap();
+  await assert.doesNotReject(sheet.waitFor({ state: "hidden" }), `${title} close dismisses`);
+
+  await openMenu();
+  await backdrop.tap({ position: { x: 2, y: 2 } });
+  await assert.doesNotReject(sheet.waitFor({ state: "hidden" }), `${title} backdrop dismisses`);
+
+  await openMenu();
+  await page
+    .getByRole("button", { name: otherSwitchLabel, exact: true })
+    .evaluate((element) => element.click());
+  await assert.doesNotReject(sheet.waitFor({ state: "hidden" }), `opening the other menu closes ${title}`);
+  const otherKind = kind === "session" ? "window" : "session";
+  const otherSheet = page.locator(`.${otherKind}-menu:visible`);
+  await assert.doesNotReject(otherSheet.waitFor({ state: "visible" }), "the other menu opens");
+  await otherSheet.locator(".context-menu-close").tap();
+
+  await openMenu();
+  await sheet
+    .locator(`${rowSelector}[aria-current="true"], ${rowSelector}[aria-selected="true"]`)
+    .tap();
+  await assert.doesNotReject(sheet.waitFor({ state: "hidden" }), `${title} selection keeps close behavior`);
+};
+
+test("touch Session and Window selectors are viewport-bottom context menus", async (t) => {
+  const fixture = await createFixture();
+  const browser = await chromium.launch({ headless: true, args: ["--no-zygote"] });
+  t.after(async () => {
+    await browser.close();
+    await fixture.close();
+  });
+
+  for (const viewport of viewports) {
+    for (const kind of ["session", "window"]) {
+      await t.test(`${kind} menu at ${viewport.width}x${viewport.height}`, async (subtest) => {
+        const context = await browser.newContext({ viewport, hasTouch: true, isMobile: false });
+        const page = await context.newPage();
+        subtest.after(() => context.close());
+        await installWebSocketFixture(page);
+        await page.goto(fixture.url, { waitUntil: "networkidle" });
+        await page.waitForFunction(
+          () =>
+            document.querySelectorAll(".session-menu-item").length >= 2 &&
+            document.querySelectorAll(".window-menu-item").length >= 12
+        );
+        const coarsePointer = await page.evaluate(() => matchMedia("(pointer: coarse)").matches);
+        if (viewport.width === 1024 && !coarsePointer) {
+          subtest.skip("Chromium context does not expose coarse pointer emulation");
+          return;
+        }
+        await menuContract(page, viewport, kind);
+      });
+    }
+  }
+});

--- a/ui/test/PreviewFixture.test.mjs
+++ b/ui/test/PreviewFixture.test.mjs
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import { basename, extname, join, normalize } from "node:path";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { chromium } = require("playwright");
+const uiBundle = process.env.UI_BUNDLE;
+const fixtureUrl = new URL("../preview/fixture.js", import.meta.url);
+
+const contentTypes = {
+  ".css": "text/css",
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".svg": "image/svg+xml",
+  ".woff2": "font/woff2"
+};
+
+const createPreview = async () => {
+  assert.ok(uiBundle, "UI_BUNDLE must name the built static UI directory");
+  const [fixture, productionIndex] = await Promise.all([
+    readFile(fixtureUrl),
+    readFile(join(uiBundle, "index.html"), "utf8")
+  ]);
+  const previewIndex = productionIndex.replace(
+    /(\s*<script\s+src=["']index\.js[^>]*><\/script>)/,
+    '\n  <script src="fixture.js"></script>$1'
+  );
+  assert.notEqual(previewIndex, productionIndex, "fixture is injected before index.js");
+  assert.ok(
+    previewIndex.indexOf('src="fixture.js"') < previewIndex.indexOf('src="index.js'),
+    "fixture runs before the production application bundle"
+  );
+
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+    if (url.pathname === "/fixture.js") {
+      response.setHeader("content-type", "text/javascript");
+      response.end(fixture);
+      return;
+    }
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      response.setHeader("content-type", "text/html");
+      response.end(previewIndex);
+      return;
+    }
+
+    const filePath = normalize(join(uiBundle, url.pathname.slice(1)));
+    if (!filePath.startsWith(`${uiBundle}/`)) {
+      response.statusCode = 400;
+      response.end("invalid path");
+      return;
+    }
+    try {
+      response.setHeader(
+        "content-type",
+        contentTypes[extname(filePath)] ?? "application/octet-stream"
+      );
+      response.end(await readFile(filePath));
+    } catch (_) {
+      response.statusCode = 404;
+      response.end(`not found: ${basename(filePath)}`);
+    }
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    close: () =>
+      new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      ),
+    url: `http://127.0.0.1:${port}`
+  };
+};
+
+const openMenu = async (page, buttonName, menuSelector) => {
+  await page.getByRole("button", { name: buttonName, exact: true }).tap();
+  const menu = page.locator(`${menuSelector}:visible`);
+  await menu.waitFor({ state: "visible" });
+  return menu;
+};
+
+test("PR preview fixture illustrates the complete session and window flow", async (t) => {
+  const preview = await createPreview();
+  const browser = await chromium.launch({ headless: true, args: ["--no-zygote"] });
+  const context = await browser.newContext({
+    viewport: { width: 768, height: 1024 },
+    hasTouch: true,
+    isMobile: false
+  });
+  const page = await context.newPage();
+  const browserErrors = [];
+  page.on("pageerror", (error) => browserErrors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(`console.error: ${message.text()}`);
+  });
+  t.after(async () => {
+    await context.close();
+    await browser.close();
+    await preview.close();
+  });
+
+  await page.goto(preview.url, { waitUntil: "networkidle" });
+  await page
+    .getByText("Illustrative preview data — not connected to a daemon.", { exact: true })
+    .waitFor({ state: "visible" });
+  await page.waitForFunction(
+    () =>
+      document.querySelectorAll(".session-menu-item").length >= 4 &&
+      document.querySelectorAll(".window-menu-item").length >= 10
+  );
+
+  let menu = await openMenu(page, "Switch session", ".session-menu");
+  assert.ok(await menu.locator(".session-menu-item").count() >= 4, "multiple sessions load");
+  await menu.locator(".context-menu-close").tap();
+  await menu.waitFor({ state: "hidden" });
+
+  menu = await openMenu(page, "Switch session", ".session-menu");
+  const nextSession = menu.locator(".session-menu-item").nth(2);
+  const nextSessionName = (await nextSession.locator(".session-name").textContent()).trim();
+  await nextSession.tap();
+  await menu.waitFor({ state: "hidden" });
+  await page.waitForFunction(
+    (name) => document.querySelector(".session-label")?.textContent?.trim() === name,
+    nextSessionName
+  );
+
+  menu = await openMenu(page, "Switch tmux window", ".window-menu");
+  assert.ok(await menu.locator(".window-menu-item").count() >= 10, "many windows load");
+  const nextWindow = menu.locator(".window-menu-item").nth(2);
+  const nextWindowName = (await nextWindow.textContent()).trim();
+  await nextWindow.tap();
+  await menu.waitFor({ state: "hidden" });
+  await page.waitForFunction(
+    (name) => document.querySelector(".window-label")?.textContent?.trim() === name,
+    nextWindowName
+  );
+
+  menu = await openMenu(page, "Switch tmux window", ".window-menu");
+  await page
+    .locator(".context-menu-layer:not(.hidden) .context-menu-backdrop")
+    .tap({ position: { x: 2, y: 2 } });
+  await menu.waitFor({ state: "hidden" });
+
+  menu = await openMenu(page, "Switch tmux window", ".window-menu");
+  const countBeforeCreate = await menu.locator(".window-menu-item").count();
+  await menu.getByRole("button", { name: "New window", exact: true }).tap();
+  await menu.waitFor({ state: "hidden" });
+  menu = await openMenu(page, "Switch tmux window", ".window-menu");
+  await page.waitForFunction(
+    (expected) => document.querySelectorAll(".window-menu-item").length === expected,
+    countBeforeCreate + 1
+  );
+  assert.equal(
+    await menu.locator('.window-menu-item[aria-current="true"]').count(),
+    1,
+    "new window becomes the active window"
+  );
+  await menu.locator(".context-menu-close").tap();
+
+  await page.waitForTimeout(100);
+  assert.deepEqual(browserErrors, []);
+});


### PR DESCRIPTION
## Summary

- Presents Session and Window selectors as titled, safe-area-aware bottom sheets on screens up to 900px or with a coarse pointer.
- Adds a dimmed full-viewport backdrop, fixed header and 44px close control, independently scrollable choices, accessible current states, and clear active-row styling.
- Keeps `New window` as the separated first Window action while preserving desktop dropdown behavior.

## Preview and verification

- [Shared browser preview](https://preview.dev.plutimus.com/lambdasistemi/tmux-ws/pr-107/)
- `nix run --quiet .#ui` — 20/20 pass, including all Session/Window viewport cases and preview interactions; 0 skipped.
- `nix run --quiet .#workflow-lint` — pass.
- `nix develop --quiet -c just ci` — pass.
- Exact-head hosted CI — 12/12 pass.

## Production safety

The representative preview fixture is injected only by the PR preview job. Production `ui/dist/index.html`, packaged `.#site`, and the daemon do not load or contain it.

No issue is linked because this was a bounded, issue-less UI lane.