### PR TITLE
fix(ui): make the touch command deck reliable

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -71,6 +71,7 @@ let
           export UI_BUNDLE=${uiBundle} NODE_PATH=${pkgs.playwright-test}/lib/node_modules
           export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers} PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
           node --test ui/test/CommandDeckLayout.test.mjs
+          node --test ui/test/CommandDeckInteraction.test.mjs
           node --test ui/test/ContextBottomMenus.test.mjs
           node --test ui/test/PreviewFixture.test.mjs
         fi

--- a/ui/src/AgentDaemon/FFI/Terminal.js
+++ b/ui/src/AgentDaemon/FFI/Terminal.js
@@ -160,7 +160,9 @@ const installCommandDeckHandling = (controller) => {
 
   const onClick = (event) => {
     const control = commandDeckControl(event);
-    if (!control || event.detail !== 0) return;
+    // Touch generates a detail=0 click after pointerdown; only keyboard clicks
+    // should take this fallback path because pointerdown already sent the key.
+    if (!control || event.detail !== 0 || event.pointerType) return;
     const key = control.dataset.commandDeckKey;
     if (key) dispatchCommandDeckKey(controller, key);
   };

--- a/ui/src/AgentDaemon/FFI/Terminal.js
+++ b/ui/src/AgentDaemon/FFI/Terminal.js
@@ -144,7 +144,7 @@ const installCommandDeckHandling = (controller) => {
   const stopRepeat = (event) => {
     if (
       controller.commandDeckPointerId != null &&
-      (!event || event.pointerId === controller.commandDeckPointerId)
+      (event?.pointerId == null || event.pointerId === controller.commandDeckPointerId)
     ) {
       clearCommandDeckRepeat(controller);
     }

--- a/ui/test/CommandDeckInteraction.test.mjs
+++ b/ui/test/CommandDeckInteraction.test.mjs
@@ -8,6 +8,45 @@ import test from "node:test";
 const require = createRequire(import.meta.url);
 const { chromium } = require("playwright");
 const uiBundle = process.env.UI_BUNDLE;
+const viewports = [
+  { label: "small touch", width: 390, height: 844 },
+  { label: "portrait tablet", width: 768, height: 1024 },
+  { label: "landscape tablet", width: 1024, height: 768 }
+];
+const latchLabels = ["Ctrl", "Alt", "Shift", "Tmux"];
+const directKeyCases = [
+  ["Esc", [27]],
+  ["Tab", [9]],
+  ["Left", [27, 91, 68]],
+  ["Up", [27, 91, 65]],
+  ["Down", [27, 91, 66]],
+  ["Right", [27, 91, 67]],
+  ["Enter", [13]]
+];
+const modifierCases = [
+  [["Shift"], [27, 91, 49, 59, 50, 65]],
+  [["Alt"], [27, 91, 49, 59, 51, 65]],
+  [["Shift", "Alt"], [27, 91, 49, 59, 52, 65]],
+  [["Ctrl"], [27, 91, 49, 59, 53, 65]],
+  [["Shift", "Ctrl"], [27, 91, 49, 59, 54, 65]],
+  [["Alt", "Ctrl"], [27, 91, 49, 59, 55, 65]],
+  [["Shift", "Alt", "Ctrl"], [27, 91, 49, 59, 56, 65]],
+  [["Tmux"], [2, 27, 91, 65]],
+  [["Tmux", "Shift"], [2, 27, 91, 49, 59, 50, 65]],
+  [["Tmux", "Alt"], [2, 27, 91, 49, 59, 51, 65]],
+  [["Tmux", "Shift", "Alt"], [2, 27, 91, 49, 59, 52, 65]],
+  [["Tmux", "Ctrl"], [2, 27, 91, 49, 59, 53, 65]],
+  [["Tmux", "Shift", "Ctrl"], [2, 27, 91, 49, 59, 54, 65]],
+  [["Tmux", "Alt", "Ctrl"], [2, 27, 91, 49, 59, 55, 65]],
+  [["Tmux", "Shift", "Alt", "Ctrl"], [2, 27, 91, 49, 59, 56, 65]]
+];
+const nativeInputCases = [
+  [["Ctrl"], "c", [3]],
+  [["Alt"], "x", [27, 120]],
+  [["Shift"], "x", [88]],
+  [["Tmux"], "b", [2, 98]],
+  [["Tmux", "Ctrl", "Alt", "Shift"], "z", [2, 27, 26]]
+];
 
 const contentTypes = {
   ".css": "text/css",
@@ -61,12 +100,17 @@ const createFixture = async () => {
   };
 };
 
-const openTouchTerminal = async (browser, fixtureUrl) => {
+const openTouchTerminal = async (browser, fixtureUrl, viewport) => {
   const context = await browser.newContext({
     hasTouch: true,
-    viewport: { width: 390, height: 844 }
+    viewport
   });
   const page = await context.newPage();
+  const browserErrors = [];
+  page.on("pageerror", (error) => browserErrors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(`console.error: ${message.text()}`);
+  });
   await page.addInitScript(() => {
     window.__terminalFrames = [];
 
@@ -104,13 +148,43 @@ const openTouchTerminal = async (browser, fixtureUrl) => {
   await page.evaluate(() => {
     window.__terminalFrames = [];
   });
-  return { context, page };
+  return { browserErrors, context, page };
 };
 
 const terminalDataFrames = (page) =>
   page.evaluate(() => window.__terminalFrames.filter((frame) => frame[0] !== 1));
 
-test("touch command deck sends one terminal command per tap", async (t) => {
+const clearTerminalData = (page) =>
+  page.evaluate(() => {
+    window.__terminalFrames = [];
+  });
+
+const commandButton = (page, label) =>
+  page.getByRole("button", { name: label, exact: true });
+
+const withTouchTerminal = async (browser, fixtureUrl, viewport, scenario) => {
+  const { browserErrors, context, page } = await openTouchTerminal(
+    browser,
+    fixtureUrl,
+    viewport
+  );
+  try {
+    await scenario(page);
+    assert.deepEqual(browserErrors, []);
+  } finally {
+    await context.close();
+  }
+};
+
+const pointerEvent = (pointerId, buttons) => ({
+  button: 0,
+  buttons,
+  isPrimary: true,
+  pointerId,
+  pointerType: "touch"
+});
+
+test("command deck is reliable without a physical keyboard or mouse", async (t) => {
   const fixture = await createFixture();
   // The self-hosted runner's SystemCallFilter denies the zygote capability transition.
   const browser = await chromium.launch({ headless: true, args: ["--no-zygote"] });
@@ -119,82 +193,150 @@ test("touch command deck sends one terminal command per tap", async (t) => {
     await fixture.close();
   });
 
-  await t.test("Tmux plus Up sends one Ctrl-B-prefixed arrow and consumes the latch", async () => {
-    const { context, page } = await openTouchTerminal(browser, fixture.url);
-    const tmux = page.getByRole("button", { name: "Tmux", exact: true });
+  for (const viewport of viewports) {
+    const dimensions = { width: viewport.width, height: viewport.height };
 
-    await tmux.tap();
-    assert.equal(await tmux.getAttribute("aria-pressed"), "true");
-    await page.getByRole("button", { name: "Up", exact: true }).tap();
+    await t.test(`${viewport.label}: every direct key sends exactly once`, async () => {
+      await withTouchTerminal(browser, fixture.url, dimensions, async (page) => {
+        for (const [label] of directKeyCases) {
+          await commandButton(page, label).tap();
+        }
 
-    assert.deepEqual(await terminalDataFrames(page), [[2, 27, 91, 65]]);
-    assert.equal(await tmux.getAttribute("aria-pressed"), "false");
+        assert.deepEqual(
+          await terminalDataFrames(page),
+          directKeyCases.map(([, bytes]) => bytes)
+        );
+      });
+    });
 
-    await page.getByRole("button", { name: "Up", exact: true }).tap();
-    assert.deepEqual(await terminalDataFrames(page), [
-      [2, 27, 91, 65],
-      [27, 91, 65]
-    ]);
-    await context.close();
-  });
+    await t.test(`${viewport.label}: all modifier combinations are one-shot`, async () => {
+      await withTouchTerminal(browser, fixture.url, dimensions, async (page) => {
+        for (const [labels, expected] of modifierCases) {
+          await clearTerminalData(page);
+          for (const label of labels) {
+            const latch = commandButton(page, label);
+            await latch.tap();
+            assert.equal(await latch.getAttribute("aria-pressed"), "true");
+          }
 
-  await t.test("each direct command key emits exactly once", async () => {
-    const { context, page } = await openTouchTerminal(browser, fixture.url);
-    const cases = [
-      ["Esc", [27]],
-      ["Tab", [9]],
-      ["Left", [27, 91, 68]],
-      ["Up", [27, 91, 65]],
-      ["Down", [27, 91, 66]],
-      ["Right", [27, 91, 67]],
-      ["Enter", [13]]
-    ];
+          await commandButton(page, "Up").tap();
+          assert.deepEqual(await terminalDataFrames(page), [expected]);
+          for (const label of latchLabels) {
+            assert.equal(await commandButton(page, label).getAttribute("aria-pressed"), "false");
+          }
 
-    for (const [label] of cases) {
-      await page.getByRole("button", { name: label, exact: true }).tap();
-    }
+          await commandButton(page, "Up").tap();
+          assert.deepEqual(await terminalDataFrames(page), [expected, [27, 91, 65]]);
+        }
+      });
+    });
 
-    assert.deepEqual(
-      await terminalDataFrames(page),
-      cases.map(([, bytes]) => bytes)
+    await t.test(`${viewport.label}: every latch can be cancelled without input`, async () => {
+      await withTouchTerminal(browser, fixture.url, dimensions, async (page) => {
+        for (const label of latchLabels) {
+          await clearTerminalData(page);
+          const latch = commandButton(page, label);
+          await latch.tap();
+          assert.equal(await latch.getAttribute("aria-pressed"), "true");
+          await latch.tap();
+          assert.equal(await latch.getAttribute("aria-pressed"), "false");
+          assert.deepEqual(await terminalDataFrames(page), []);
+        }
+      });
+    });
+
+    await t.test(`${viewport.label}: arrow repeat stops on release, cancel, leave, and blur`, async () => {
+      await withTouchTerminal(browser, fixture.url, dimensions, async (page) => {
+        const up = commandButton(page, "Up");
+        await up.dispatchEvent("pointerdown", pointerEvent(41, 1));
+        await page.waitForTimeout(280);
+        const heldFrames = await terminalDataFrames(page);
+        assert.ok(heldFrames.length >= 2, "held arrow repeats after its initial input");
+        await up.dispatchEvent("pointerup", pointerEvent(41, 0));
+        await page.waitForTimeout(300);
+        assert.deepEqual(await terminalDataFrames(page), heldFrames);
+
+        await clearTerminalData(page);
+        const right = commandButton(page, "Right");
+        await right.dispatchEvent("pointerdown", pointerEvent(42, 1));
+        await page.waitForTimeout(30);
+        await right.dispatchEvent("pointercancel", pointerEvent(42, 0));
+        await page.waitForTimeout(300);
+        assert.deepEqual(await terminalDataFrames(page), [[27, 91, 67]]);
+
+        await clearTerminalData(page);
+        const down = commandButton(page, "Down");
+        await down.dispatchEvent("pointerdown", pointerEvent(43, 1));
+        await page.waitForTimeout(30);
+        await down.dispatchEvent("pointerleave", pointerEvent(43, 0));
+        await page.waitForTimeout(300);
+        assert.deepEqual(await terminalDataFrames(page), [[27, 91, 66]]);
+
+        await clearTerminalData(page);
+        const left = commandButton(page, "Left");
+        await left.dispatchEvent("pointerdown", pointerEvent(44, 1));
+        await page.waitForTimeout(30);
+        await page.evaluate(() => window.dispatchEvent(new Event("blur")));
+        await page.waitForTimeout(300);
+        assert.deepEqual(await terminalDataFrames(page), [[27, 91, 68]]);
+      });
+    });
+  }
+
+  await t.test("keyboard and assistive activation send every direct key once", async () => {
+    const viewport = viewports[1];
+    await withTouchTerminal(
+      browser,
+      fixture.url,
+      { width: viewport.width, height: viewport.height },
+      async (page) => {
+        for (const [label] of directKeyCases) {
+          const control = commandButton(page, label);
+          await control.focus();
+          await control.press("Enter");
+        }
+
+        assert.deepEqual(
+          await terminalDataFrames(page),
+          directKeyCases.map(([, bytes]) => bytes)
+        );
+
+        await clearTerminalData(page);
+        for (const [label] of directKeyCases) {
+          await commandButton(page, label).evaluate((element) => element.click());
+        }
+        assert.deepEqual(
+          await terminalDataFrames(page),
+          directKeyCases.map(([, bytes]) => bytes)
+        );
+      }
     );
-    await context.close();
   });
 
-  await t.test("Ctrl, Alt, and Shift are one-shot touch modifiers", async () => {
-    const { context, page } = await openTouchTerminal(browser, fixture.url);
-    const ctrl = page.getByRole("button", { name: "Ctrl", exact: true });
-    const alt = page.getByRole("button", { name: "Alt", exact: true });
-    const shift = page.getByRole("button", { name: "Shift", exact: true });
+  await t.test("touch latches modify native virtual-keyboard input exactly once", async () => {
+    const viewport = viewports[1];
+    await withTouchTerminal(
+      browser,
+      fixture.url,
+      { width: viewport.width, height: viewport.height },
+      async (page) => {
+        const terminalInput = page.locator(".xterm-helper-textarea");
+        await terminalInput.waitFor({ state: "attached" });
 
-    await shift.tap();
-    await page.getByRole("button", { name: "Tab", exact: true }).tap();
-    assert.equal(await shift.getAttribute("aria-pressed"), "false");
+        for (const [labels, key, expected] of nativeInputCases) {
+          await clearTerminalData(page);
+          for (const label of labels) {
+            await commandButton(page, label).tap();
+          }
+          await terminalInput.focus();
+          await page.keyboard.press(key);
 
-    await ctrl.tap();
-    await page.getByRole("button", { name: "Left", exact: true }).tap();
-    assert.equal(await ctrl.getAttribute("aria-pressed"), "false");
-
-    await alt.tap();
-    await page.getByRole("button", { name: "Right", exact: true }).tap();
-    assert.equal(await alt.getAttribute("aria-pressed"), "false");
-
-    assert.deepEqual(await terminalDataFrames(page), [
-      [27, 91, 90],
-      [27, 91, 49, 59, 53, 68],
-      [27, 91, 49, 59, 51, 67]
-    ]);
-    await context.close();
-  });
-
-  await t.test("keyboard activation remains an accessible single-send fallback", async () => {
-    const { context, page } = await openTouchTerminal(browser, fixture.url);
-    const escape = page.getByRole("button", { name: "Esc", exact: true });
-
-    await escape.focus();
-    await escape.press("Enter");
-
-    assert.deepEqual(await terminalDataFrames(page), [[27]]);
-    await context.close();
+          assert.deepEqual(await terminalDataFrames(page), [expected]);
+          for (const label of latchLabels) {
+            assert.equal(await commandButton(page, label).getAttribute("aria-pressed"), "false");
+          }
+        }
+      }
+    );
   });
 });

--- a/ui/test/CommandDeckInteraction.test.mjs
+++ b/ui/test/CommandDeckInteraction.test.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import { basename, extname, join, normalize } from "node:path";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { chromium } = require("playwright");
+const uiBundle = process.env.UI_BUNDLE;
+
+const contentTypes = {
+  ".css": "text/css",
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".svg": "image/svg+xml",
+  ".woff2": "font/woff2"
+};
+
+const createFixture = async () => {
+  assert.ok(uiBundle, "UI_BUNDLE must name the built static UI directory");
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+    if (url.pathname === "/sessions") {
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify([{ id: "interaction-session", state: "active", tmuxName: "interaction" }])
+      );
+      return;
+    }
+    if (url.pathname === "/sessions/interaction-session/windows") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify([{ index: 0, name: "interaction", active: true }]));
+      return;
+    }
+
+    const requestedPath = url.pathname === "/" ? "index.html" : url.pathname.slice(1);
+    const filePath = normalize(join(uiBundle, requestedPath));
+    if (!filePath.startsWith(`${uiBundle}/`) && filePath !== join(uiBundle, "index.html")) {
+      response.statusCode = 400;
+      response.end("invalid path");
+      return;
+    }
+    try {
+      response.setHeader("content-type", contentTypes[extname(filePath)] ?? "application/octet-stream");
+      response.end(await readFile(filePath));
+    } catch (_) {
+      response.statusCode = 404;
+      response.end(`not found: ${basename(filePath)}`);
+    }
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+  };
+};
+
+const openTouchTerminal = async (browser, fixtureUrl) => {
+  const context = await browser.newContext({
+    hasTouch: true,
+    viewport: { width: 390, height: 844 }
+  });
+  const page = await context.newPage();
+  await page.addInitScript(() => {
+    window.__terminalFrames = [];
+
+    class FixtureWebSocket {
+      static OPEN = 1;
+      static CLOSING = 2;
+
+      constructor() {
+        this.readyState = 0;
+        window.setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.onopen?.({});
+        }, 0);
+      }
+
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+
+      send(payload) {
+        const bytes =
+          payload instanceof Uint8Array
+            ? Array.from(payload)
+            : Array.from(new TextEncoder().encode(String(payload)));
+        window.__terminalFrames.push(bytes);
+      }
+    }
+
+    window.WebSocket = FixtureWebSocket;
+  });
+  await page.goto(fixtureUrl, { waitUntil: "networkidle" });
+  await page.getByRole("button", { name: "Tmux", exact: true }).waitFor();
+  await page.waitForTimeout(100);
+  await page.evaluate(() => {
+    window.__terminalFrames = [];
+  });
+  return { context, page };
+};
+
+const terminalDataFrames = (page) =>
+  page.evaluate(() => window.__terminalFrames.filter((frame) => frame[0] !== 1));
+
+test("touch command deck sends one terminal command per tap", async (t) => {
+  const fixture = await createFixture();
+  // The self-hosted runner's SystemCallFilter denies the zygote capability transition.
+  const browser = await chromium.launch({ headless: true, args: ["--no-zygote"] });
+  t.after(async () => {
+    await browser.close();
+    await fixture.close();
+  });
+
+  await t.test("Tmux plus Up sends one Ctrl-B-prefixed arrow and consumes the latch", async () => {
+    const { context, page } = await openTouchTerminal(browser, fixture.url);
+    const tmux = page.getByRole("button", { name: "Tmux", exact: true });
+
+    await tmux.tap();
+    assert.equal(await tmux.getAttribute("aria-pressed"), "true");
+    await page.getByRole("button", { name: "Up", exact: true }).tap();
+
+    assert.deepEqual(await terminalDataFrames(page), [[2, 27, 91, 65]]);
+    assert.equal(await tmux.getAttribute("aria-pressed"), "false");
+
+    await page.getByRole("button", { name: "Up", exact: true }).tap();
+    assert.deepEqual(await terminalDataFrames(page), [
+      [2, 27, 91, 65],
+      [27, 91, 65]
+    ]);
+    await context.close();
+  });
+
+  await t.test("each direct command key emits exactly once", async () => {
+    const { context, page } = await openTouchTerminal(browser, fixture.url);
+    const cases = [
+      ["Esc", [27]],
+      ["Tab", [9]],
+      ["Left", [27, 91, 68]],
+      ["Up", [27, 91, 65]],
+      ["Down", [27, 91, 66]],
+      ["Right", [27, 91, 67]],
+      ["Enter", [13]]
+    ];
+
+    for (const [label] of cases) {
+      await page.getByRole("button", { name: label, exact: true }).tap();
+    }
+
+    assert.deepEqual(
+      await terminalDataFrames(page),
+      cases.map(([, bytes]) => bytes)
+    );
+    await context.close();
+  });
+
+  await t.test("Ctrl, Alt, and Shift are one-shot touch modifiers", async () => {
+    const { context, page } = await openTouchTerminal(browser, fixture.url);
+    const ctrl = page.getByRole("button", { name: "Ctrl", exact: true });
+    const alt = page.getByRole("button", { name: "Alt", exact: true });
+    const shift = page.getByRole("button", { name: "Shift", exact: true });
+
+    await shift.tap();
+    await page.getByRole("button", { name: "Tab", exact: true }).tap();
+    assert.equal(await shift.getAttribute("aria-pressed"), "false");
+
+    await ctrl.tap();
+    await page.getByRole("button", { name: "Left", exact: true }).tap();
+    assert.equal(await ctrl.getAttribute("aria-pressed"), "false");
+
+    await alt.tap();
+    await page.getByRole("button", { name: "Right", exact: true }).tap();
+    assert.equal(await alt.getAttribute("aria-pressed"), "false");
+
+    assert.deepEqual(await terminalDataFrames(page), [
+      [27, 91, 90],
+      [27, 91, 49, 59, 53, 68],
+      [27, 91, 49, 59, 51, 67]
+    ]);
+    await context.close();
+  });
+
+  await t.test("keyboard activation remains an accessible single-send fallback", async () => {
+    const { context, page } = await openTouchTerminal(browser, fixture.url);
+    const escape = page.getByRole("button", { name: "Esc", exact: true });
+
+    await escape.focus();
+    await escape.press("Enter");
+
+    assert.deepEqual(await terminalDataFrames(page), [[27]]);
+    await context.close();
+  });
+});


### PR DESCRIPTION
## What changed

- send each touch command-deck key exactly once instead of dispatching both `pointerdown` and the synthesized touch `click`
- stop held-arrow repeat when Chrome blurs, as well as on pointer release, cancellation, and leave
- expand the Playwright interaction suite across 390x844, 768x1024, and 1024x768 touch viewports
- assert the exact terminal WebSocket bytes for every direct key and all 15 Ctrl/Alt/Shift/Tmux combinations
- cover latch cancellation, one-shot clearing, held-arrow repeat lifecycle, keyboard/assistive button activation, and native virtual-keyboard input through xterm
- keep the Playwright interaction suite in the Nix-owned UI gate

## Root cause

Chrome touch activation produced a `pointerdown` followed by a synthesized `click` whose `detail` was zero. The handler sent on `pointerdown` and mistook that click for the non-pointer accessibility fallback, so every key was sent twice. With `Tmux + Up`, the first send consumed the Tmux latch and the second leaked a plain Up.

The repeat cancellation helper also required a matching `pointerId` for every event. Browser `blur` has no pointer ID, so the repeat timer survived focus loss and emitted another arrow.

## User impact

Tablet users can rely on Tmux, arrows, Esc, Tab, Enter, and modifier latches without a physical keyboard or mouse. Taps send once, modifiers clear after one use, and held arrows stop when the page loses focus.

## Playwright coverage

The command-deck interaction file now reports 15 passing results and exercises:

- every direct command button at all three touch viewports
- all 15 non-empty modifier combinations, including every Tmux combination
- cancellation of each latch without terminal input
- repeat start and stop on release, pointer cancel, pointer leave, and browser blur
- keyboard and programmatic assistive activation
- native virtual-keyboard sequences including Ctrl-C, Alt-x, Shift-x, Tmux-b, and the four-latch combination

## Verification

- witnessed RED: `Tmux + Up` produced `[2,27,91,65]` followed by stray `[27,91,65]`
- witnessed RED: blur produced one extra repeated Left arrow at all three viewports
- `nix run --quiet .#ui`
- `nix develop --quiet -c just ci` — 12 Nix checks plus Cabal build