### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.5.0] (2026-07-17)
+
+### Release
+
+- fix(ui): stop arrow repeat on browser blur (d84867e)
+- fix(ui): send touch command deck keys once (5826d78)
+- ci: publish PR-only UI preview (d97f2f9)
+- feat(ui): add touch context bottom sheets (b98e5ba)
+- docs: lead README with release installs (453a5b3)
+
+
 ## [0.4.0] (2026-07-15)
 
 tmux-ws now ships reproducible x86_64 Linux packages alongside the existing Apple Silicon/Homebrew distribution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,57 @@
 
 ## [0.5.0] (2026-07-17)
 
-### Release
+tmux-ws 0.5.0 makes its tablet command deck dependable and adds browser-level
+regression coverage for the no-keyboard workflow.
+
+### Tablet controls
+
+- Sessions and Windows open touch-friendly bottom menus, keeping their actions
+  reachable on small screens.
+- Esc, Tab, Enter, arrows, and Ctrl/Alt/Shift/Tmux combinations now send exactly
+  one terminal sequence per tap. In particular, `Tmux` + `Up` no longer leaks a
+  second plain `Up` after Chrome synthesizes a click.
+- Held arrows stop on release, pointer cancellation, pointer leave, or browser
+  focus loss, so a tablet cannot keep scrolling after Chrome is backgrounded.
+- Modifier latches remain one-shot and can be cancelled without sending terminal
+  input.
+
+### Browser regression suite
+
+The Playwright interaction suite runs at 390x844, 768x1024, and 1024x768. It
+checks every direct command button, all 15 non-empty Ctrl/Alt/Shift/Tmux
+combinations, latch cancellation and clearing, arrow-repeat lifecycle,
+keyboard/assistive activation, native xterm virtual-keyboard input, exact
+WebSocket bytes, and browser errors. Pull requests also publish an isolated UI
+preview for real-device review.
+
+### Install or upgrade
+
+Download Linux builds from the
+[v0.5.0 release](https://github.com/lambdasistemi/tmux-ws/releases/tag/v0.5.0):
+
+- `tmux-ws-0.5.0-x86_64-linux.AppImage`
+- `tmux-ws-0.5.0-x86_64-linux.deb`
+- `tmux-ws-0.5.0-x86_64-linux.rpm`
+- stable `tmux-ws.AppImage`
+- `SHA256SUMS`
+
+Verify downloaded assets with `sha256sum -c SHA256SUMS --ignore-missing` before
+running or installing them. On Apple Silicon macOS:
+
+```bash
+brew update
+brew upgrade tmux-ws || brew install lambdasistemi/tap/tmux-ws
+```
+
+### Documentation
+
+- [Quick start and installation](https://lambdasistemi.github.io/tmux-ws/docs/#quick-start)
+- [Release packages and migration](https://lambdasistemi.github.io/tmux-ws/docs/release/)
+- [NixOS deployment and service operation](https://lambdasistemi.github.io/tmux-ws/docs/deployment/)
+- [Persistent Tailscale HTTPS for tablets](https://lambdasistemi.github.io/tmux-ws/docs/tailscale/)
+
+### Included changes
 
 - fix(ui): stop arrow repeat on browser blur (d84867e)
 - fix(ui): send touch command deck keys once (5826d78)

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ serves the SPA and API together.
 
 ### Native Linux packages
 
-Release v0.4.0 also provides native x86_64 DEB and RPM packages:
+The [latest release](https://github.com/lambdasistemi/tmux-ws/releases/latest)
+also provides versioned native x86_64 DEB and RPM packages. Download the one
+for your distribution, then install it with the matching package manager:
 
 ```bash
-curl -LO https://github.com/lambdasistemi/tmux-ws/releases/download/v0.4.0/tmux-ws-0.4.0-x86_64-linux.deb
-sudo apt install ./tmux-ws-0.4.0-x86_64-linux.deb
+sudo apt install ./tmux-ws-<version>-x86_64-linux.deb
 
-curl -LO https://github.com/lambdasistemi/tmux-ws/releases/download/v0.4.0/tmux-ws-0.4.0-x86_64-linux.rpm
-sudo dnf install ./tmux-ws-0.4.0-x86_64-linux.rpm
+sudo dnf install ./tmux-ws-<version>-x86_64-linux.rpm
 ```
 
 ### macOS with Homebrew
@@ -51,8 +51,8 @@ sudo dnf install ./tmux-ws-0.4.0-x86_64-linux.rpm
 brew install lambdasistemi/tap/tmux-ws
 ```
 
-The formula is backed by the v0.4.0 release artifact
-`tmux-ws-0.4.0-aarch64-darwin.tar.gz`.
+The formula is backed by the latest release's versioned
+`tmux-ws-<version>-aarch64-darwin.tar.gz` artifact.
 
 After installing a native package or the Homebrew formula, launch with:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -13,9 +13,9 @@ tmux-ws --help
 NixOS users should configure `services.tmux-ws` and enable the `tmux-ws`
 systemd service.
 
-## Future Linux release artifacts
+## Linux release artifacts
 
-Future Linux releases provide
+Published releases provide
 `tmux-ws-<version>-x86_64-linux.AppImage`,
 `tmux-ws-<version>-x86_64-linux.deb`,
 `tmux-ws-<version>-x86_64-linux.rpm`, `SHA256SUMS`, and the stable
@@ -50,15 +50,17 @@ sudo dnf install ./tmux-ws-<version>-x86_64-linux.rpm
 tmux-ws --help
 ```
 
-Pull requests and default manual runs build and smoke artifacts only. They do
-not publish production assets. A future immutable `v*` tag attaches production assets only to the planner-created release.
-The attachment is idempotent and does not delete or recreate that release.
-This PR does not publish, dispatch, retag, rewrite releases, or mutate a tap.
+Pull requests and manual workflow runs build and smoke artifacts only; they do
+not publish production assets. An immutable `v*` tag attaches production assets
+only to the planner-created release. Attachment is idempotent and does not
+delete or recreate that release.
 
-`v0.3.0` is immutable and remains unchanged, and will not be rewritten or deleted.
-`v0.3.1` is published with the canonical `tmux-ws-0.3.1-aarch64-darwin.tar.gz` Darwin asset and an
-updated Homebrew tap formula. The release workflow used that formula to
-update the real Homebrew tap. After an upgrade, restart the daemon
+`v0.3.0` is immutable and remains unchanged; it will not be rewritten or deleted.
+`v0.3.1` is the corrective publication that introduced the canonical
+Darwin archive and used the release workflow to update the real Homebrew tap.
+Current releases likewise include a versioned Apple Silicon Darwin archive and
+update the Homebrew formula without changing historical releases. After an
+upgrade, restart the daemon
 (`systemctl restart tmux-ws` on NixOS) and
 reload the browser document on Chrome tablets to fetch the updated SPA. See
 [deployment](deployment.md), [Tailscale HTTPS](tailscale.md), and the

--- a/scripts/release/plan
+++ b/scripts/release/plan
@@ -85,8 +85,12 @@ if ! git diff --cached --quiet; then
   git commit -m "chore(release): prepare v${next}"
 fi
 git push --force-with-lease origin "HEAD:refs/heads/$branch"
-if gh pr view "$branch" --repo "${GITHUB_REPOSITORY:-}" >/dev/null 2>&1; then
-  gh pr edit "$branch" --title "chore(release): prepare v${next}" \
+open_pr="$(
+  gh pr list --state open --head "$branch" --base main \
+    --repo "${GITHUB_REPOSITORY:-}" --json number --jq '.[0].number // empty'
+)"
+if test -n "$open_pr"; then
+  gh pr edit "$open_pr" --title "chore(release): prepare v${next}" \
     --body "Cabal-owned release proposal for v${next}."
 else
   gh pr create --head "$branch" --base main --title "chore(release): prepare v${next}" \

--- a/test/release-plan.sh
+++ b/test/release-plan.sh
@@ -128,6 +128,29 @@ test "$(git -C "$proposal_repo" branch --show-current)" = main \
 test "$(git -C "$proposal_repo" status --porcelain)" = '' \
   || fail 'dry-run changed the proposal fixture'
 
+git -C "$proposal_repo" init --bare --quiet "$tmp/proposal-remote.git"
+git -C "$proposal_repo" remote add origin "$tmp/proposal-remote.git"
+git -C "$proposal_repo" push --quiet -u origin main --tags
+proposal_mock_bin="$tmp/proposal-mock-bin"
+mkdir "$proposal_mock_bin"
+printf '#!%s\n' "$(command -v bash)" > "$proposal_mock_bin/gh"
+cat >> "$proposal_mock_bin/gh" <<'EOF'
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_LOG"
+case "$1 $2" in
+  'pr view') exit 0 ;; # A prior release PR for the reused branch was merged.
+  'pr list') : ;;
+  'pr create') exit 0 ;;
+  *) printf 'unexpected gh command: %s\n' "$*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "$proposal_mock_bin/gh"
+GH_LOG="$tmp/proposal-gh.log" PATH="$proposal_mock_bin:$PATH" \
+  bash "$proposal_repo/scripts/release/plan" > "$tmp/proposal-create.out"
+assert_contains 'pr create --head release/cabal-release --base main' \
+  "$tmp/proposal-gh.log"
+assert_not_contains 'pr edit' "$tmp/proposal-gh.log"
+
 publish_repo="$tmp/publish"
 make_repo "$publish_repo"
 sed -E -i "s/^(version:[[:space:]]*).*/\1${fixture_release_version}/" \

--- a/tmux-ws.cabal
+++ b/tmux-ws.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            tmux-ws
-version:         0.4.0
+version:         0.5.0
 synopsis:
   Same-origin browser SPA and WebSocket daemon for tmux sessions
 


### PR DESCRIPTION
## Release

Prepare tmux-ws v0.5.0 from the Cabal-owned release planner.

## Included user changes

- touch-friendly Sessions and Windows bottom menus
- reliable Esc, Tab, Enter, arrows, and Ctrl/Alt/Shift/Tmux command-deck input
- exact one-shot touch activation in Chrome
- arrow repeat cancellation on release, pointer cancellation/leave, and browser blur
- an extensive Playwright interaction matrix at 390x844, 768x1024, and 1024x768

## Release quality

- bump the Cabal package version to 0.5.0
- replace raw generated notes with operator-facing tablet, testing, installation, and upgrade guidance
- link the published notes directly to quick start, package/migration, NixOS deployment, and persistent Tailscale HTTPS documentation
- make README package examples track the latest release instead of hard-coding v0.4.0
- correct stale release-guide wording about Linux packages
- fix the Cabal planner so a previously merged PR on the reused release branch cannot prevent a new release PR from opening
- add a regression test for that reused-branch lifecycle

## Verification

- witnessed RED: the planner selected a previously merged release PR and called `pr edit`
- `bash test/release-plan.sh`
- `nix build --no-link .#checks.x86_64-linux.docs-service-contract`
- `git diff --check && nix develop --quiet -c just ci` — all 12 Nix checks plus Cabal build

After this PR merges, the repository planner creates the immutable `v0.5.0` tag and GitHub release. Tag workflows then build, smoke-test, and attach Linux and Apple Silicon artifacts and update the Homebrew tap.