### PR TITLE
fix(release): create tags through GitHub API

### DIFF
--- a/scripts/release/plan
+++ b/scripts/release/plan
@@ -36,7 +36,18 @@ if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
 
   if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
     git tag -a "$tag" -m "Release $tag"
-    git push origin "$tag"
+    target="$(git rev-parse HEAD)"
+    tag_object="$(
+      gh api --method POST "repos/${GITHUB_REPOSITORY:?}/git/tags" \
+        --raw-field tag="$tag" \
+        --raw-field message="Release $tag" \
+        --raw-field object="$target" \
+        --raw-field type=commit \
+        --jq .sha
+    )"
+    gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+      --raw-field ref="refs/tags/$tag" \
+      --raw-field sha="$tag_object" >/dev/null
   fi
   if ! gh release view "$tag" --repo "${GITHUB_REPOSITORY:-}" >/dev/null 2>&1; then
     notes="$(mktemp)"

--- a/test/release-plan.sh
+++ b/test/release-plan.sh
@@ -176,22 +176,35 @@ set -euo pipefail
 printf '%s\n' "$*" >> "$GH_LOG"
 case "$1 $2" in
   'pr list') printf '[{"mergedAt":"2026-07-14T00:00:00Z"}]\n' ;;
+  'api --method')
+    case "$*" in
+      *'/git/tags'*) printf '1111111111111111111111111111111111111111\n' ;;
+      *'/git/refs'*) : ;;
+      *) printf 'unexpected gh api command: %s\n' "$*" >&2; exit 1 ;;
+    esac
+    ;;
   'release view') test -e "$GH_RELEASE_EXISTS" ;;
   'release create') touch "$GH_RELEASE_EXISTS" ;;
   *) printf 'unexpected gh command: %s\n' "$*" >&2; exit 1 ;;
 esac
 EOF
 chmod +x "$mock_bin/gh"
-GH_LOG="$tmp/gh.log" GH_RELEASE_EXISTS="$tmp/release-exists" PATH="$mock_bin:$PATH" \
+GITHUB_REPOSITORY=lambdasistemi/tmux-ws GH_LOG="$tmp/gh.log" \
+  GH_RELEASE_EXISTS="$tmp/release-exists" PATH="$mock_bin:$PATH" \
   bash "$publish_repo/scripts/release/plan" > "$tmp/publish.out"
 git -C "$publish_repo" rev-parse -q \
   --verify "refs/tags/v$fixture_release_version" >/dev/null \
   || fail 'planner did not create the annotated release tag'
 assert_contains "release create v$fixture_release_version" "$tmp/gh.log"
+assert_contains \
+  "api --method POST repos/lambdasistemi/tmux-ws/git/tags" "$tmp/gh.log"
+assert_contains \
+  "api --method POST repos/lambdasistemi/tmux-ws/git/refs" "$tmp/gh.log"
 assert_not_contains 'release delete' "$tmp/gh.log"
 
 before="$(grep -Fc "release create v$fixture_release_version" "$tmp/gh.log")"
-GH_LOG="$tmp/gh.log" GH_RELEASE_EXISTS="$tmp/release-exists" PATH="$mock_bin:$PATH" \
+GITHUB_REPOSITORY=lambdasistemi/tmux-ws GH_LOG="$tmp/gh.log" \
+  GH_RELEASE_EXISTS="$tmp/release-exists" PATH="$mock_bin:$PATH" \
   bash "$publish_repo/scripts/release/plan" > "$tmp/publish-repeat.out"
 after="$(grep -Fc "release create v$fixture_release_version" "$tmp/gh.log")"
 test "$before" = "$after" || fail 're-running publication created a release'


### PR DESCRIPTION
## What changed

- create the annotated release tag object through the GitHub Git database API
- create `refs/tags/<version>` from that annotated tag object
- keep the existing App-minted `contents: write` token so the tag still triggers downstream release workflows
- retain local annotated-tag validation and idempotent release creation
- add release-planner coverage for both Git API calls

## Root cause

The v0.5.0 post-merge planner failed with:

```
remote: Permission to lambdasistemi/tmux-ws.git denied to lambdasistemi-ci[bot].
fatal: unable to access 'https://github.com/lambdasistemi/tmux-ws/': 403
```

v0.4.0 had published successfully with the same App and token permissions. The relevant change since that tag was a commit under `.github/workflows`. GitHub requires the separate Workflows permission when Git transport accesses or edits workflow files; the least-privilege org App intentionally has Contents but not Workflows.

The Git database endpoints accept `contents: write` for creating annotated tag objects and references. Creating a ref to the already-merged commit avoids transporting workflow-file changes and does not broaden the org-wide App.

## Verification

- witnessed RED: `release-plan test: missing api --method POST .../git/tags`
- `bash test/release-plan.sh`
- `git diff --check && nix develop --quiet -c just ci` — all 12 Nix checks plus Cabal build

After this PR merges, the main-branch planner will retry the still-unpublished Cabal v0.5.0 proposal and create the tag and GitHub release.