### PR TITLE
fix(release): validate API-created tag messages

### DIFF
--- a/scripts/release/check-version-consistency
+++ b/scripts/release/check-version-consistency
@@ -34,7 +34,8 @@ if test "$mode" = publish && git rev-parse -q --verify "refs/tags/$tag" >/dev/nu
 fi
 
 if test "$mode" = publish && git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
-  git show -s --format=%B "$tag" | grep -Fqx "Release $tag" || {
+  test "$(git for-each-ref --format='%(contents)' "refs/tags/$tag")" = \
+    "Release $tag" || {
     printf 'release tag message does not match %s\n' "$tag" >&2
     exit 1
   }

--- a/scripts/release/plan
+++ b/scripts/release/plan
@@ -37,10 +37,11 @@ if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
   if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
     git tag -a "$tag" -m "Release $tag"
     target="$(git rev-parse HEAD)"
+    tag_message="Release $tag"$'\n'
     tag_object="$(
       gh api --method POST "repos/${GITHUB_REPOSITORY:?}/git/tags" \
         --raw-field tag="$tag" \
-        --raw-field message="Release $tag" \
+        --raw-field message="$tag_message" \
         --raw-field object="$target" \
         --raw-field type=commit \
         --jq .sha

--- a/test/release-plan.sh
+++ b/test/release-plan.sh
@@ -202,6 +202,21 @@ assert_contains \
   "api --method POST repos/lambdasistemi/tmux-ws/git/refs" "$tmp/gh.log"
 assert_not_contains 'release delete' "$tmp/gh.log"
 
+# GitHub's tag-object API can preserve an exact message without appending LF.
+# The publish validator must inspect the tag message itself rather than letting
+# git-show concatenate it with the tagged commit message.
+publish_target="$(git -C "$publish_repo" rev-parse HEAD)"
+api_tag_object="$({
+  printf 'object %s\n' "$publish_target"
+  printf 'type commit\n'
+  printf 'tag v%s\n' "$fixture_release_version"
+  printf 'tagger Test <test@example.invalid> 1700000000 +0000\n\n'
+  printf 'Release v%s' "$fixture_release_version"
+} | git -C "$publish_repo" mktag)"
+git -C "$publish_repo" update-ref \
+  "refs/tags/v$fixture_release_version" "$api_tag_object"
+bash "$publish_repo/scripts/release/check-version-consistency" --mode publish
+
 before="$(grep -Fc "release create v$fixture_release_version" "$tmp/gh.log")"
 GITHUB_REPOSITORY=lambdasistemi/tmux-ws GH_LOG="$tmp/gh.log" \
   GH_RELEASE_EXISTS="$tmp/release-exists" PATH="$mock_bin:$PATH" \


### PR DESCRIPTION
## What changed

- validate an annotated release tag from the tag ref's `%(contents)` instead of `git show`
- accept the exact expected message whether or not the stored tag object ends with LF
- append the conventional LF to tag messages created by future planner runs
- add a regression fixture that constructs an API-shaped annotated tag with no terminal LF

## Root cause

The repaired planner successfully created the immutable annotated `v0.5.0` tag and GitHub release. GitHub's tag-object API stored the exact message without a terminal LF. The tag visibly contains `Release v0.5.0`, but `git show -s --format=%B` concatenates a no-LF tag message with the tagged commit subject. Both asset workflows therefore rejected:

```
release tag message does not match v0.5.0
```

Reading `%(contents)` from the tag ref validates the tag object itself and is independent of presentation concatenation.

## Verification

- witnessed RED with a no-LF annotated tag fixture
- `bash test/release-plan.sh`
- `scripts/release/check-version-consistency --mode publish` against the real immutable v0.5.0 tag
- `git diff --check && nix develop --quiet -c just ci` — all 12 Nix checks plus Cabal build
- exact-head hosted CI: 12/12 successful

## Immutable-tag recovery

The v0.5.0 tag is not rewritten. Rerunning its original jobs would check out the tag's old validator, so the Cabal planner correctly proposes v0.5.1 from this post-tag fix. The v0.5.1 release contains the repaired validator and is the installable corrective release.