### PR TITLE
fix(release): bundle the SPA in released artifacts

### DIFF
--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -138,9 +138,12 @@ jobs:
 
           server_log="$RUNNER_TEMP/tmux-ws-server.log"
           server_page="$RUNNER_TEMP/tmux-ws-index.html"
-          mkdir -p "$RUNNER_TEMP/tmux-ws-base"
-          "$binary" --host 127.0.0.1 --port 18081 --base-dir "$RUNNER_TEMP/tmux-ws-base" \
-            >"$server_log" 2>&1 &
+          server_run_dir="$RUNNER_TEMP/tmux-ws-run"
+          mkdir -p "$RUNNER_TEMP/tmux-ws-base" "$server_run_dir"
+          (
+            cd "$server_run_dir"
+            "$binary" --host 127.0.0.1 --port 18081 --base-dir "$RUNNER_TEMP/tmux-ws-base"
+          ) >"$server_log" 2>&1 &
           server_pid="$!"
           served=false
           for _attempt in 1 2 3 4 5; do

--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -64,11 +64,15 @@ jobs:
           bundle="$RUNNER_TEMP/bundle"
           binary="$bundle/bin/tmux-ws"
           libdir="$bundle/libexec/lib"
+          staticdir="$bundle/share/tmux-ws/static"
           queue="$RUNNER_TEMP/dylib-queue"
           origins="$RUNNER_TEMP/dylib-origins"
 
-          mkdir -p "$bundle/bin" "$libdir"
+          mkdir -p "$bundle/bin" "$libdir" "$staticdir"
           cp "$(cat "$RUNNER_TEMP/nix-out")/bin/tmux-ws" "$binary"
+          cp -RL "$(cat "$RUNNER_TEMP/nix-out")/share/tmux-ws/static/." "$staticdir/"
+          test -s "$staticdir/index.html"
+          test -s "$staticdir/index.js"
           chmod u+w "$binary"
           : > "$queue"
           : > "$origins"
@@ -131,6 +135,29 @@ jobs:
             fi
           done < <(find "$bundle" -type f -print)
           "$binary" --help
+
+          server_log="$RUNNER_TEMP/tmux-ws-server.log"
+          server_page="$RUNNER_TEMP/tmux-ws-index.html"
+          mkdir -p "$RUNNER_TEMP/tmux-ws-base"
+          "$binary" --host 127.0.0.1 --port 18081 --base-dir "$RUNNER_TEMP/tmux-ws-base" \
+            >"$server_log" 2>&1 &
+          server_pid="$!"
+          served=false
+          for _attempt in 1 2 3 4 5; do
+            if curl --fail --silent --show-error --output "$server_page" http://127.0.0.1:18081/; then
+              served=true
+              break
+            fi
+            sleep 1
+          done
+          kill "$server_pid" 2>/dev/null || true
+          wait "$server_pid" 2>/dev/null || true
+          if test "$served" != true; then
+            cat "$server_log" >&2
+            exit 1
+          fi
+          grep -Fq '<title>tmux-ws</title>' "$server_page"
+          grep -Fq 'src="index.js' "$server_page"
 
       - name: Create tarball
         id: asset
@@ -217,6 +244,8 @@ jobs:
           brew tap lambdasistemi/tap
           brew trust lambdasistemi/tap
           brew install --formula lambdasistemi/tap/tmux-ws
+          test -s "$(brew --prefix tmux-ws)/share/tmux-ws/static/index.html"
+          test -s "$(brew --prefix tmux-ws)/share/tmux-ws/static/index.js"
           tmux-ws --help
           command -v tmux-ws
           otool -L "$(command -v tmux-ws)"

--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -133,7 +133,7 @@ jobs:
               printf 'unstaged Nix dependency remains in %s\n' "$staged" >&2
               exit 1
             fi
-          done < <(find "$bundle" -type f -print)
+          done < <(find "$bundle/bin" "$libdir" -type f -print)
           "$binary" --help
 
           server_log="$RUNNER_TEMP/tmux-ws-server.log"

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Download published builds from the
 The stable AppImage name tracks the latest release:
 
 ```bash
-curl -LO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/tmux-ws.AppImage
-curl -LO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/SHA256SUMS
+curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/tmux-ws.AppImage
+curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/SHA256SUMS
 sha256sum -c SHA256SUMS --ignore-missing
 chmod +x tmux-ws.AppImage
-./tmux-ws.AppImage --host 127.0.0.1 --port 8080 --base-dir /code
+./tmux-ws.AppImage --host 127.0.0.1 --port 8080 --base-dir "$HOME"
 ```
 
 Open the daemon URL in a browser on the same machine:
@@ -40,9 +40,9 @@ also provides versioned native x86_64 DEB and RPM packages. Download the one
 for your distribution, then install it with the matching package manager:
 
 ```bash
-sudo apt install ./tmux-ws-<version>-x86_64-linux.deb
+sudo apt install ./tmux-ws-*-x86_64-linux.deb
 
-sudo dnf install ./tmux-ws-<version>-x86_64-linux.rpm
+sudo dnf install ./tmux-ws-*-x86_64-linux.rpm
 ```
 
 ### macOS with Homebrew
@@ -57,7 +57,7 @@ The formula is backed by the latest release's versioned
 After installing a native package or the Homebrew formula, launch with:
 
 ```bash
-tmux-ws --host 127.0.0.1 --port 8080 --base-dir /code
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
 ```
 
 Then open `http://127.0.0.1:8080/` on the same machine, or expose that same

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,6 +15,7 @@ import AgentDaemon
     , recoverSessions
     , startServer
     )
+import AgentDaemon.Static (resolveStaticDir)
 import Options.Applicative
     ( Parser
     , auto
@@ -93,9 +94,10 @@ main = do
                 )
     mgr <- newSessionManager
     recoverSessions (configBaseDir config) mgr
+    staticDir <- resolveStaticDir (configStaticDir config)
     startServer
         (configHost config)
         (configPort config)
         (configBaseDir config)
-        (configStaticDir config)
+        staticDir
         mgr

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,10 @@
 # Deployment
 
-## NixOS module
+The daemon must run as the same user who owns the tmux server it controls. Pick
+one of the following persistence routes; all examples keep the browser origin
+on localhost so it can be exposed safely through Tailscale Serve.
+
+## NixOS system module (`configuration.nix`, not `home.nix`)
 
 The flake exposes a NixOS module:
 
@@ -82,7 +86,10 @@ must agree.
 
 ## Systemd (manual)
 
-If you're not on NixOS, create a unit file:
+Use a system service only when a system administrator needs to manage the
+daemon. For a personal tmux server, the [user service](#systemd-user-service-for-released-linux-packages)
+below is usually the better fit because it already runs as the tmux owner.
+If you do need a system service, create this unit file:
 
 ```ini
 # /etc/systemd/system/tmux-ws.service
@@ -95,11 +102,10 @@ Type=simple
 User=<operator>
 Group=<operator-group>
 WorkingDirectory=/path/to/worktrees
-ExecStart=/usr/local/bin/tmux-ws \
+ExecStart=/bin/tmux-ws \
   --host 127.0.0.1 \
   --port 8080 \
-  --base-dir /path/to/worktrees \
-  --static-dir /usr/local/share/tmux-ws/static
+  --base-dir /path/to/worktrees
 Restart=on-failure
 RestartSec=5
 Environment=PATH=/usr/bin:/usr/local/bin
@@ -119,6 +125,80 @@ For a service enabled at boot, ensure `/run/user/<uid>` is created before this
 unit starts (for example, enable lingering and order the unit after
 `user-runtime-dir@<uid>.service`). Then configure a persistent HTTPS route as
 described in [Tailscale HTTPS](tailscale.md).
+
+## Home Manager (`home.nix`) user service
+
+`tmux-ws` exports a NixOS module, not a Home Manager module. Put this user
+service in your own `home.nix` after making the `tmux-ws` flake input available
+to Home Manager through `extraSpecialArgs`:
+
+```nix
+{ inputs, pkgs, ... }:
+
+let
+  tmuxWs = inputs.tmux-ws.packages.${pkgs.stdenv.hostPlatform.system}.default;
+in {
+  home.packages = [ tmuxWs pkgs.tmux pkgs.git pkgs.openssh ];
+
+  systemd.user.services.tmux-ws = {
+    Unit = {
+      Description = "tmux-ws browser and tmux daemon";
+      After = [ "network-online.target" ];
+    };
+    Service = {
+      ExecStart = "${tmuxWs}/bin/tmux-ws --host 127.0.0.1 --port 8080 --base-dir %h";
+      Restart = "on-failure";
+      RestartSec = 5;
+    };
+    Install.WantedBy = [ "default.target" ];
+  };
+}
+```
+
+Enable lingering once so the user service starts after reboot even before a
+desktop or SSH login, then activate the service:
+
+```bash
+loginctl enable-linger "$USER"
+systemctl --user enable --now tmux-ws
+systemctl --user status tmux-ws
+```
+
+This service and the interactive tmux client share the same Unix user and the
+default tmux socket location. Do not set `TMUX_TMPDIR` in only one of them.
+
+## Systemd user service for released Linux packages
+
+For an AppImage, keep the downloaded, verified file at
+`~/.local/bin/tmux-ws.AppImage`, then create this user unit:
+
+```ini
+# ~/.config/systemd/user/tmux-ws.service
+[Unit]
+Description=tmux-ws browser and tmux daemon
+After=network-online.target
+
+[Service]
+ExecStart=%h/.local/bin/tmux-ws.AppImage --host 127.0.0.1 --port 8080 --base-dir %h
+Environment=APPIMAGE_EXTRACT_AND_RUN=1
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+For the released DEB or RPM, use the same unit but replace the `ExecStart`
+executable with `/bin/tmux-ws` and remove the `APPIMAGE_EXTRACT_AND_RUN`
+environment line. Released packages carry their own SPA files, so neither unit
+needs a `--static-dir` argument.
+
+```bash
+loginctl enable-linger "$USER"
+systemctl --user daemon-reload
+systemctl --user enable --now tmux-ws
+journalctl --user -u tmux-ws -f
+```
 
 ## Direct binary
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,13 +112,68 @@ a document reload.
 
 ## Quick start
 
+The supported installation path is the
+[latest GitHub release](https://github.com/lambdasistemi/tmux-ws/releases/latest).
+You do not need Nix or a source checkout to run `tmux-ws`.
+
+### Linux AppImage
+
+The AppImage is the quickest option on x86_64 Linux. Its stable filename always
+points to the latest release:
+
 ```bash
-# Build
+curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/tmux-ws.AppImage
+curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+chmod +x tmux-ws.AppImage
+./tmux-ws.AppImage --host 127.0.0.1 --port 8080 --base-dir "$HOME"
+```
+
+Open `http://127.0.0.1:8080/` on that computer. To use a tablet, keep the
+daemon bound to localhost and follow the [Tailscale HTTPS guide](tailscale.md)
+to expose the same daemon origin safely.
+
+### Debian or Ubuntu
+
+Download the `.deb` file from the
+[latest release](https://github.com/lambdasistemi/tmux-ws/releases/latest), then
+run these commands from your Downloads directory:
+
+```bash
+sudo apt install ./tmux-ws-*-x86_64-linux.deb
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
+```
+
+### Fedora, RHEL, or another RPM-based distribution
+
+Download the `.rpm` file from the
+[latest release](https://github.com/lambdasistemi/tmux-ws/releases/latest), then
+run:
+
+```bash
+sudo dnf install ./tmux-ws-*-x86_64-linux.rpm
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
+```
+
+### macOS on Apple Silicon
+
+```bash
+brew install lambdasistemi/tap/tmux-ws
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
+```
+
+`tmux`, `git`, and `ssh` must be available in `PATH`. See
+[Release and migration](release.md) for package details and upgrades.
+
+## Build from source (developers only)
+
+This is for contributors working on `tmux-ws`, not for normal installation:
+
+```bash
 nix develop
 just build
 
-# Run
-tmux-ws --host 127.0.0.1 --port 8080 --base-dir /code
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
 ```
 
 ## CLI options

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,72 @@ entry point is the SPA served by the daemon itself.
 - Switches tmux windows from touch-first browsers
 - Manages the session lifecycle: attach, detach, stop, refresh
 
+## Quick start
+
+The supported installation path is the
+[latest GitHub release](https://github.com/lambdasistemi/tmux-ws/releases/latest).
+You do not need Nix or a source checkout to run `tmux-ws`.
+
+### Linux AppImage
+
+The AppImage is the quickest option on x86_64 Linux. Its stable filename always
+points to the latest release:
+
+```bash
+curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/tmux-ws.AppImage
+curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+chmod +x tmux-ws.AppImage
+./tmux-ws.AppImage --host 127.0.0.1 --port 8080 --base-dir "$HOME"
+```
+
+Open `http://127.0.0.1:8080/` on that computer. To use a tablet, keep the
+daemon bound to localhost and follow the [Tailscale HTTPS guide](tailscale.md)
+to expose the same daemon origin safely.
+
+### Debian or Ubuntu
+
+Download the `.deb` file from the
+[latest release](https://github.com/lambdasistemi/tmux-ws/releases/latest), then
+run these commands from your Downloads directory:
+
+```bash
+sudo apt install ./tmux-ws-*-x86_64-linux.deb
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
+```
+
+### Fedora, RHEL, or another RPM-based distribution
+
+Download the `.rpm` file from the
+[latest release](https://github.com/lambdasistemi/tmux-ws/releases/latest), then
+run:
+
+```bash
+sudo dnf install ./tmux-ws-*-x86_64-linux.rpm
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
+```
+
+### macOS on Apple Silicon
+
+```bash
+brew install lambdasistemi/tap/tmux-ws
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
+```
+
+`tmux`, `git`, and `ssh` must be available in `PATH`. See
+[Release and migration](release.md) for package details and upgrades.
+
+## Build from source (developers only)
+
+This is for contributors working on `tmux-ws`, not for normal installation:
+
+```bash
+nix develop
+just build
+
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
+```
+
 ## Touch-first operation
 
 The daemon-served SPA is designed to be usable on a tablet with no keyboard or
@@ -109,72 +175,6 @@ need to fetch the SPA itself, such as after upgrading the daemon. Static UI
 responses from the daemon use `Cache-Control: no-store` (with compatible
 no-cache headers), so Chrome is instructed not to keep serving an old UI after
 a document reload.
-
-## Quick start
-
-The supported installation path is the
-[latest GitHub release](https://github.com/lambdasistemi/tmux-ws/releases/latest).
-You do not need Nix or a source checkout to run `tmux-ws`.
-
-### Linux AppImage
-
-The AppImage is the quickest option on x86_64 Linux. Its stable filename always
-points to the latest release:
-
-```bash
-curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/tmux-ws.AppImage
-curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/SHA256SUMS
-sha256sum -c SHA256SUMS --ignore-missing
-chmod +x tmux-ws.AppImage
-./tmux-ws.AppImage --host 127.0.0.1 --port 8080 --base-dir "$HOME"
-```
-
-Open `http://127.0.0.1:8080/` on that computer. To use a tablet, keep the
-daemon bound to localhost and follow the [Tailscale HTTPS guide](tailscale.md)
-to expose the same daemon origin safely.
-
-### Debian or Ubuntu
-
-Download the `.deb` file from the
-[latest release](https://github.com/lambdasistemi/tmux-ws/releases/latest), then
-run these commands from your Downloads directory:
-
-```bash
-sudo apt install ./tmux-ws-*-x86_64-linux.deb
-tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
-```
-
-### Fedora, RHEL, or another RPM-based distribution
-
-Download the `.rpm` file from the
-[latest release](https://github.com/lambdasistemi/tmux-ws/releases/latest), then
-run:
-
-```bash
-sudo dnf install ./tmux-ws-*-x86_64-linux.rpm
-tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
-```
-
-### macOS on Apple Silicon
-
-```bash
-brew install lambdasistemi/tap/tmux-ws
-tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
-```
-
-`tmux`, `git`, and `ssh` must be available in `PATH`. See
-[Release and migration](release.md) for package details and upgrades.
-
-## Build from source (developers only)
-
-This is for contributors working on `tmux-ws`, not for normal installation:
-
-```bash
-nix develop
-just build
-
-tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
-```
 
 ## CLI options
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,22 @@ tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
 `tmux`, `git`, and `ssh` must be available in `PATH`. See
 [Release and migration](release.md) for package details and upgrades.
 
+## Keep it running after reboot
+
+The foreground command above is useful for a first run. For a tablet you will
+normally want a service that starts as the same user who owns the tmux server:
+
+- use the [Home Manager `home.nix` user service](deployment.md#home-manager-homenix-user-service)
+  when your user configuration already uses Home Manager;
+- use the [NixOS system module](deployment.md#nixos-system-module-configurationnix-not-homenix)
+  for a machine-level NixOS configuration; or
+- use the [released-package systemd user service](deployment.md#systemd-user-service-for-released-linux-packages)
+  on another Linux distribution.
+
+Each option keeps the daemon on `127.0.0.1`; publish that same origin to a
+tablet with [Tailscale HTTPS](tailscale.md), not by exposing the daemon directly
+to the network.
+
 ## Build from source (developers only)
 
 This is for contributors working on `tmux-ws`, not for normal installation:

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,16 +2,32 @@
 
 ## New installations
 
-Install the primary product with Homebrew:
+Install a published artifact from the
+[latest release](https://github.com/lambdasistemi/tmux-ws/releases/latest).
+Normal installations do not require Nix or a source checkout.
+
+On x86_64 Linux, the stable AppImage is the shortest path:
+
+```bash
+curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/tmux-ws.AppImage
+curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+chmod +x tmux-ws.AppImage
+./tmux-ws.AppImage --host 127.0.0.1 --port 8080 --base-dir "$HOME"
+```
+
+Debian, Ubuntu, Fedora, and RHEL users can instead download the `.deb` or `.rpm`
+from that release and install it with the platform package manager. Apple
+Silicon macOS users install the released archive through Homebrew:
 
 ```bash
 brew update
 brew install lambdasistemi/tap/tmux-ws
-tmux-ws --help
+tmux-ws --host 127.0.0.1 --port 8080 --base-dir "$HOME"
 ```
 
-NixOS users should configure `services.tmux-ws` and enable the `tmux-ws`
-systemd service.
+NixOS service configuration is an advanced option for reboot-persistent daemon
+operation; it is not the general installation path. See [deployment](deployment.md).
 
 ## Linux release artifacts
 
@@ -23,30 +39,29 @@ Published releases provide
 before using an AppImage:
 
 ```bash
+curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/tmux-ws.AppImage
+curl -fLO https://github.com/lambdasistemi/tmux-ws/releases/latest/download/SHA256SUMS
 sha256sum -c SHA256SUMS --ignore-missing
-chmod +x tmux-ws-<version>-x86_64-linux.AppImage
-./tmux-ws-<version>-x86_64-linux.AppImage --help
-```
-
-The stable path is the same AppImage under an unversioned name:
-
-```bash
 chmod +x tmux-ws.AppImage
 ./tmux-ws.AppImage --help
 ```
+
+The stable path is the same AppImage under an unversioned name. Use the
+versioned AppImage from the release page only when you need to pin a specific
+release.
 
 On Debian or Ubuntu, install the downloaded package and then use the canonical
 `tmux-ws` executable:
 
 ```bash
-sudo apt install ./tmux-ws-<version>-x86_64-linux.deb
+sudo apt install ./tmux-ws-*-x86_64-linux.deb
 tmux-ws --help
 ```
 
 On an RPM-based distribution, use the equivalent RPM package:
 
 ```bash
-sudo dnf install ./tmux-ws-<version>-x86_64-linux.rpm
+sudo dnf install ./tmux-ws-*-x86_64-linux.rpm
 tmux-ws --help
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -45,11 +45,14 @@
             else
               "dirty"
           }";
-        linuxTmuxWs = pkgs.symlinkJoin {
-          name = "tmux-ws-${cabalVersion}";
-          paths = [ project.packages.tmux-ws ];
+        tmuxWs = pkgs.runCommand "tmux-ws-${cabalVersion}" {
           meta.mainProgram = "tmux-ws";
-        };
+        } ''
+          mkdir -p "$out/bin" "$out/share/tmux-ws"
+          cp ${project.packages.tmux-ws}/bin/tmux-ws "$out/bin/tmux-ws"
+          ln -s ${project.packages.static} "$out/share/tmux-ws/static"
+        '';
+        linuxTmuxWs = tmuxWs;
         linuxRelease = import ./nix/linux-release.nix {
           inherit pkgs cabalVersion devVersion linuxTmuxWs;
           bundlers = bundlers.bundlers.${system};
@@ -155,7 +158,8 @@
           '';
       in {
         packages = project.packages // {
-          default = project.packages.tmux-ws;
+          default = tmuxWs;
+          tmux-ws = tmuxWs;
           inherit docs site;
         } // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
           linux-release-artifacts = linuxRelease.release;

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -248,6 +248,8 @@ let
         grep -Fq 'bash scripts/render-homebrew-formulas.sh' "$darwin"
         test "$(yq -r '.jobs."build-and-release"."runs-on"' "$darwin")" = macos-14
         grep -Fq 'cachix/install-nix-action@v30' "$darwin"
+        grep -Fq 'share/tmux-ws/static' "$darwin"
+        grep -Fq 'curl --fail --silent --show-error' "$darwin"
       '';
     };
 
@@ -258,7 +260,7 @@ let
         darwin=.github/workflows/darwin-release.yml
         ci=.github/workflows/ci.yml
         # shellcheck disable=SC2016
-        for literal in 'bin/tmux-ws' 'tmux-ws-''${VERSION}-aarch64-darwin.tar.gz' 'brew install --formula lambdasistemi/tap/tmux-ws' 'tmux-ws --help'; do
+        for literal in 'bin/tmux-ws' 'share/tmux-ws/static' 'tmux-ws-''${VERSION}-aarch64-darwin.tar.gz' 'brew install --formula lambdasistemi/tap/tmux-ws' 'tmux-ws --help'; do
           grep -Fq "$literal" "$darwin"
         done
         if grep -Fq 'class TmuxWs < Formula' "$darwin" \
@@ -282,6 +284,7 @@ let
         bash scripts/render-homebrew-formulas.sh "$formula_dir" "https://example.invalid/tmux-ws-$version-aarch64-darwin.tar.gz" 0000000000000000000000000000000000000000000000000000000000000000 "$version"
         grep -Fqx 'class TmuxWs < Formula' "$formula_dir/tmux-ws.rb"
         grep -Fqx '    bin.install "bin/tmux-ws"' "$formula_dir/tmux-ws.rb"
+        grep -Fqx '    (share/"tmux-ws").install Dir["share/tmux-ws/*"]' "$formula_dir/tmux-ws.rb"
         grep -Fqx 'class AgentDaemon < Formula' "$formula_dir/agent-daemon.rb"
         grep -Fqx '  depends_on "tmux-ws"' "$formula_dir/agent-daemon.rb"
       '';
@@ -318,7 +321,14 @@ let
           echo 'docs/service contract: Quick start must not require the Nix development shell' >&2
           exit 1
         fi
+        require_literal "$docs_index" 'Keep it running after reboot' 'index persistence entry point'
         require_literal "$deployment" 'services.tmux-ws' 'deployment primary service configuration'; reject_literal "$deployment" 'systemctl enable --now agent-daemon' 'deployment legacy service command'; reject_literal "$deployment" '/bin/agent-daemon' 'deployment legacy binary command'
+        # shellcheck disable=SC2016
+        require_literal "$deployment" 'Home Manager (`home.nix`) user service' 'Home Manager user-service guide'
+        require_literal "$deployment" 'systemd.user.services.tmux-ws' 'Home Manager tmux-ws unit'
+        # shellcheck disable=SC2016
+        require_literal "$deployment" 'loginctl enable-linger "$USER"' 'user-service reboot persistence'
+        require_literal "$deployment" 'tmux-ws.AppImage' 'AppImage user-service guide'
         require_literal "$tailscale" 'tmux-ws --host' 'Tailscale primary command'; reject_literal "$tailscale" 'agent-daemon --host' 'Tailscale legacy primary command'
         test -f "$release_guide"
         require_literal "$release_guide" 'brew install lambdasistemi/tap/tmux-ws' 'release Homebrew install command'; require_literal "$release_guide" 'brew update' 'release Homebrew update command'; require_literal "$release_guide" 'brew upgrade tmux-ws' 'release Homebrew upgrade command'; require_literal "$release_guide" 'brew upgrade agent-daemon' 'legacy compatibility-alias upgrade path'; require_literal "$release_guide" 'brew uninstall agent-daemon' 'legacy compatibility-alias removal path'

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -288,7 +288,7 @@ let
     };
 
     docs-service-contract = {
-      runtimeInputs = [ pkgs.coreutils pkgs.gnugrep ];
+      runtimeInputs = [ pkgs.coreutils pkgs.gnugrep pkgs.gnused ];
       text = ''
         set -euo pipefail
         require_literal() { grep -Fq "$2" "$1" || { printf 'docs/service contract: missing %s\n' "$3" >&2; exit 1; }; }
@@ -304,6 +304,14 @@ let
         reject_literal "$module" '/bin/agent-daemon' 'legacy primary service binary'
         require_literal "$readme" 'tmux-ws --host' 'README primary command'; reject_literal "$readme" 'agent-daemon' 'README legacy primary text'
         require_literal "$docs_index" 'tmux-ws --host' 'index primary command'; reject_literal "$docs_index" 'agent-daemon' 'index legacy primary text'
+        quick_start="$(sed -n '/^## Quick start$/,/^## /p' "$docs_index")"
+        grep -Fq 'releases/latest/download/tmux-ws.AppImage' <<<"$quick_start" || { echo 'docs/service contract: Quick start must install the stable release AppImage' >&2; exit 1; }
+        grep -Fq 'sudo apt install' <<<"$quick_start" || { echo 'docs/service contract: Quick start must include the released DEB path' >&2; exit 1; }
+        grep -Fq 'sudo dnf install' <<<"$quick_start" || { echo 'docs/service contract: Quick start must include the released RPM path' >&2; exit 1; }
+        if grep -Fq 'nix develop' <<<"$quick_start"; then
+          echo 'docs/service contract: Quick start must not require the Nix development shell' >&2
+          exit 1
+        fi
         require_literal "$deployment" 'services.tmux-ws' 'deployment primary service configuration'; reject_literal "$deployment" 'systemctl enable --now agent-daemon' 'deployment legacy service command'; reject_literal "$deployment" '/bin/agent-daemon' 'deployment legacy binary command'
         require_literal "$tailscale" 'tmux-ws --host' 'Tailscale primary command'; reject_literal "$tailscale" 'agent-daemon --host' 'Tailscale legacy primary command'
         test -f "$release_guide"

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -250,6 +250,8 @@ let
         grep -Fq 'cachix/install-nix-action@v30' "$darwin"
         grep -Fq 'share/tmux-ws/static' "$darwin"
         grep -Fq 'curl --fail --silent --show-error' "$darwin"
+        # shellcheck disable=SC2016
+        grep -Fq 'find "$bundle/bin" "$libdir" -type f -print' "$darwin"
       '';
     };
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -252,6 +252,8 @@ let
         grep -Fq 'curl --fail --silent --show-error' "$darwin"
         # shellcheck disable=SC2016
         grep -Fq 'find "$bundle/bin" "$libdir" -type f -print' "$darwin"
+        # shellcheck disable=SC2016
+        grep -Fq 'cd "$server_run_dir"' "$darwin"
       '';
     };
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -305,6 +305,12 @@ let
         require_literal "$readme" 'tmux-ws --host' 'README primary command'; reject_literal "$readme" 'agent-daemon' 'README legacy primary text'
         require_literal "$docs_index" 'tmux-ws --host' 'index primary command'; reject_literal "$docs_index" 'agent-daemon' 'index legacy primary text'
         quick_start="$(sed -n '/^## Quick start$/,/^## /p' "$docs_index")"
+        quick_start_line="$(grep -n -m1 '^## Quick start$' "$docs_index" | cut -d: -f1)"
+        touch_first_line="$(grep -n -m1 '^## Touch-first operation$' "$docs_index" | cut -d: -f1)"
+        if ! test "$quick_start_line" -lt "$touch_first_line"; then
+          echo 'docs/service contract: Quick start must precede feature documentation' >&2
+          exit 1
+        fi
         grep -Fq 'releases/latest/download/tmux-ws.AppImage' <<<"$quick_start" || { echo 'docs/service contract: Quick start must install the stable release AppImage' >&2; exit 1; }
         grep -Fq 'sudo apt install' <<<"$quick_start" || { echo 'docs/service contract: Quick start must include the released DEB path' >&2; exit 1; }
         grep -Fq 'sudo dnf install' <<<"$quick_start" || { echo 'docs/service contract: Quick start must include the released RPM path' >&2; exit 1; }

--- a/nix/linux-artifact-smoke.nix
+++ b/nix/linux-artifact-smoke.nix
@@ -73,13 +73,13 @@ pkgs.writeShellApplication {
     }
 
     smokeUi() {
-      appImage="$1"
+      executable="$1"
       destination="$2"
       port="$(shuf -i 20000-40000 -n 1)"
       mkdir -p "$destination/base" "$destination/run"
       (
         cd "$destination/run"
-        APPIMAGE_EXTRACT_AND_RUN=1 "$appImage" \
+        "$executable" \
           --host 127.0.0.1 \
           --port "$port" \
           --base-dir "$destination/base"
@@ -115,8 +115,13 @@ pkgs.writeShellApplication {
         ./tmux-ws.AppImage --appimage-extract >/dev/null
       )
       findUi "$destination/squashfs-root"
-      findTmuxWs "$(find "$destination/squashfs-root" -type f -name tmux-ws -perm -u+x -print -quit)"
-      smokeUi "$destination/tmux-ws.AppImage" "$destination"
+      entrypoint="$(readlink "$destination/squashfs-root/entrypoint")"
+      case "$entrypoint" in
+        /nix/store/*) executable="$destination/squashfs-root$entrypoint" ;;
+        *) executable="$destination/squashfs-root/$entrypoint" ;;
+      esac
+      findTmuxWs "$executable"
+      smokeUi "$executable" "$destination"
     }
 
     versionedPrefix="tmux-ws-$artifactVersion-x86_64-linux"

--- a/nix/linux-artifact-smoke.nix
+++ b/nix/linux-artifact-smoke.nix
@@ -1,8 +1,15 @@
 { pkgs }:
 pkgs.writeShellApplication {
   name = "linux-artifact-smoke";
-  runtimeInputs =
-    [ pkgs.coreutils pkgs.findutils pkgs.dpkg pkgs.rpm pkgs.cpio ];
+  runtimeInputs = [
+    pkgs.coreutils
+    pkgs.cpio
+    pkgs.curl
+    pkgs.dpkg
+    pkgs.findutils
+    pkgs.gnugrep
+    pkgs.rpm
+  ];
   text = ''
     usage() {
       echo "usage: linux-artifact-smoke --artifacts-dir DIR --artifact-version VERSION" >&2
@@ -43,6 +50,61 @@ pkgs.writeShellApplication {
       "$executable" --help >/dev/null
     }
 
+    findUi() {
+      root="$1"
+      staticLink="$(find "$root" -type l -path '*/share/tmux-ws/static' -print -quit)"
+      test -n "$staticLink" || {
+        echo "artifact smoke: missing share/tmux-ws/static link in $root" >&2
+        exit 1
+      }
+      staticTarget="$(readlink "$staticLink")"
+      case "$staticTarget" in
+        /nix/store/*) packagedStatic="$root$staticTarget" ;;
+        *) packagedStatic="$(dirname "$staticLink")/$staticTarget" ;;
+      esac
+      test -s "$packagedStatic/index.html" || {
+        echo "artifact smoke: missing share/tmux-ws/static/index.html in $root" >&2
+        exit 1
+      }
+      test -s "$packagedStatic/index.js" || {
+        echo "artifact smoke: missing share/tmux-ws/static/index.js in $root" >&2
+        exit 1
+      }
+    }
+
+    smokeUi() {
+      appImage="$1"
+      destination="$2"
+      port="$(shuf -i 20000-40000 -n 1)"
+      mkdir -p "$destination/base" "$destination/run"
+      (
+        cd "$destination/run"
+        APPIMAGE_EXTRACT_AND_RUN=1 "$appImage" \
+          --host 127.0.0.1 \
+          --port "$port" \
+          --base-dir "$destination/base"
+      ) >"$destination/server.log" 2>&1 &
+      pid="$!"
+      response="$destination/index.html"
+      status=1
+      for _attempt in 1 2 3 4 5; do
+        if curl --silent --show-error --fail \
+          --output "$response" "http://127.0.0.1:$port/"; then
+          status=0
+          break
+        fi
+        sleep 1
+      done
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      if test "$status" -ne 0; then
+        cat "$destination/server.log" >&2
+        exit 1
+      fi
+      grep -Fq '<title>tmux-ws</title>' "$response"
+      grep -Fq 'src="index.js' "$response"
+    }
+
     smokeAppImage() {
       appImage="$1"
       destination="$2"
@@ -52,7 +114,9 @@ pkgs.writeShellApplication {
         cd "$destination"
         ./tmux-ws.AppImage --appimage-extract >/dev/null
       )
+      findUi "$destination/squashfs-root"
       findTmuxWs "$(find "$destination/squashfs-root" -type f -name tmux-ws -perm -u+x -print -quit)"
+      smokeUi "$destination/tmux-ws.AppImage" "$destination"
     }
 
     versionedPrefix="tmux-ws-$artifactVersion-x86_64-linux"
@@ -71,11 +135,13 @@ pkgs.writeShellApplication {
     smokeAppImage "$versionedAppImage" "$tmpDir/versioned-appimage"
     smokeAppImage "$stableAppImage" "$tmpDir/stable-appimage"
     dpkg-deb -x "$deb" "$tmpDir/deb"
+    findUi "$tmpDir/deb"
     findTmuxWs "$(find "$tmpDir/deb" -type f -name tmux-ws -perm -u+x -print -quit)"
     (
       cd "$tmpDir/rpm"
       rpm2cpio "$rpm" | cpio -idm --quiet
     )
+    findUi "$tmpDir/rpm"
     findTmuxWs "$(find "$tmpDir/rpm" -type f -name tmux-ws -perm -u+x -print -quit)"
   '';
 }

--- a/scripts/render-homebrew-formulas.sh
+++ b/scripts/render-homebrew-formulas.sh
@@ -19,6 +19,7 @@ class TmuxWs < Formula
   def install
     bin.install "bin/tmux-ws"
     (libexec/"lib").install Dir["libexec/lib/*"]
+    (share/"tmux-ws").install Dir["share/tmux-ws/*"]
   end
 
   test do

--- a/src/AgentDaemon/Static.hs
+++ b/src/AgentDaemon/Static.hs
@@ -1,0 +1,36 @@
+module AgentDaemon.Static
+    ( resolveStaticDir
+    , staticDirFor
+    ) where
+
+-- \|
+-- Module      : AgentDaemon.Static
+-- Description : Resolve development and installed SPA directories
+-- Copyright   : (c) Paolo Veronelli, 2026
+-- License     : MIT
+--
+-- Selects an explicit or local development SPA directory when available, then
+-- falls back to the distribution layout beside the installed executable.
+
+import System.Directory (doesDirectoryExist)
+import System.Environment (getExecutablePath)
+import System.FilePath (normalise, takeDirectory, (</>))
+
+-- | Resolve the configured SPA directory for the running executable.
+resolveStaticDir :: FilePath -> IO FilePath
+resolveStaticDir requested = do
+    executable <- getExecutablePath
+    localExists <- doesDirectoryExist requested
+    pure $ staticDirFor executable requested localExists
+
+-- | Choose an explicit, local-development, or installed SPA directory.
+staticDirFor :: FilePath -> FilePath -> Bool -> FilePath
+staticDirFor executable requested localExists
+    | requested /= "static" = requested
+    | localExists = requested
+    | otherwise =
+        normalise $
+            takeDirectory (takeDirectory executable)
+                </> "share"
+                </> "tmux-ws"
+                </> "static"

--- a/test/AgentDaemon/StaticSpec.hs
+++ b/test/AgentDaemon/StaticSpec.hs
@@ -1,0 +1,16 @@
+module AgentDaemon.StaticSpec (spec) where
+
+import AgentDaemon.Static (staticDirFor)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = describe "installed static directory" $ do
+    it "keeps an explicit static directory" $
+        staticDirFor "/opt/tmux-ws/bin/tmux-ws" "/srv/tmux-ws-ui" False
+            `shouldBe` "/srv/tmux-ws-ui"
+    it "keeps a local development static directory when it exists" $
+        staticDirFor "/opt/tmux-ws/bin/tmux-ws" "static" True
+            `shouldBe` "static"
+    it "finds packaged UI files relative to the executable" $
+        staticDirFor "/opt/tmux-ws/bin/tmux-ws" "static" False
+            `shouldBe` "/opt/tmux-ws/share/tmux-ws/static"

--- a/tmux-ws.cabal
+++ b/tmux-ws.cabal
@@ -36,6 +36,7 @@ library
     AgentDaemon.Git
     AgentDaemon.Recovery
     AgentDaemon.Server
+    AgentDaemon.Static
     AgentDaemon.Terminal
     AgentDaemon.Tmux
     AgentDaemon.Types
@@ -47,6 +48,7 @@ library
     , bytestring      >=0.11 && <0.13
     , containers      >=0.6  && <0.8
     , directory       >=1.3  && <1.4
+    , filepath        >=1.4  && <1.6
     , http-types      >=0.12 && <0.13
     , posix-pty       >=0.2  && <0.3
     , process         >=1.6  && <1.7
@@ -132,6 +134,7 @@ test-suite e2e-tests
     AgentDaemon.CloseSpec
     AgentDaemon.GitSpec
     AgentDaemon.RecoverySpec
+    AgentDaemon.StaticSpec
     AgentDaemon.TerminalSpec
     AgentDaemon.TmuxCloseSpec
 


### PR DESCRIPTION
## Summary

This corrective draft makes released `tmux-ws` packages runnable browser daemons, and documents persistent installation without requiring a Nix development checkout.

## Root cause

The v0.5.1 Linux artifacts contained the daemon binary but omitted the SPA files. Starting the released AppImage from an empty directory therefore returned `404 File not found` at `/`; the DEB and RPM layouts likewise had no `index.html` or `index.js`.

## Changes

- stage the executable and SPA together at `share/tmux-ws/static`; when the default `static` directory is absent, the daemon resolves that installed layout next to its executable;
- smoke both versioned and stable AppImage payload entrypoints as live HTTP servers, and inspect the AppImage, DEB, and RPM payloads for the SPA files;
- make the Darwin archive and Homebrew formula carry the same static layout. The Darwin smoke scans only Mach-O files and launches from an empty directory, so it verifies the packaged SPA instead of a checkout-local `static/` directory;
- lead the documentation with verified release artifacts and add Home Manager `home.nix`, NixOS, and released-package systemd user-service persistence routes.

## Evidence

- RED: v0.5.1 AppImage root request returned 404; extracted artifacts lacked `share/tmux-ws/static/index.html`.
- RED: the first hosted Linux smoke invoked an unavailable AppImage namespace launcher; following the first closure binary selected the wrong executable.
- GREEN: the smoke extracts the AppImage, follows its declared `entrypoint`, and serves the real root page from that shipped payload.
- RED: Darwin treated copied SPA files as Mach-O objects, then served the checkout-local legacy SPA during its smoke.
- GREEN: workflow lint locks the Darwin scan to `bin` and `libexec/lib`, and requires a clean smoke working directory.
- GREEN: `nix develop --quiet -c just ci` — all 12 local flake checks pass.

## Release boundary

This is intentionally a draft and is not merged or released. v0.5.1 remains affected until this change is merged and a corrective release is cut; the release notes must call out the fixed Linux package layout and link to the release-first installation and persistence documentation.
